### PR TITLE
feat: `switch_notice` for yapi export

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/AbstractYapiApiExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/AbstractYapiApiExporter.kt
@@ -95,6 +95,7 @@ open class AbstractYapiApiExporter {
         apiInfos.forEach { apiInfo ->
             apiInfo["token"] = privateToken
             apiInfo["catid"] = cartId
+            apiInfo["switch_notice"] = true
             ret = ret or yapiApiHelper!!.saveApiInfo(apiInfo)
         }
         return ret


### PR DESCRIPTION
`switch_notice` are supported after yapi v1.9.1 :https://github.com/YMFE/yapi/issues/1729
PR: https://github.com/YMFE/yapi/pull/1646