### PR TITLE
release v1.9.5.0.183.0

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -135,3 +135,8 @@
     * opti: support new rule `postman.prerequest`&`postman.test` [(#283)](https://github.com/tangcent/easy-api/pull/283)
     
     * opti: support new rule tool `config` [(#284)](https://github.com/tangcent/easy-api/pull/284)
+    
+    * fix: preserving the order of field in `YapiFormatter` [(#189)](https://github.com/tangcent/easy-yapi/pull/189)
+    
+    * opti: input new token if the old one be deleted. [(#192)](https://github.com/tangcent/easy-yapi/pull/192)
+                                                          

--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -132,3 +132,6 @@
     
     * feat: support switch notice at `Setting` [(#180)](https://github.com/tangcent/easy-yapi/pull/180)
                                                     
+    * opti: support new rule `postman.prerequest`&`postman.test` [(#283)](https://github.com/tangcent/easy-api/pull/283)
+    
+    * opti: support new rule tool `config` [(#284)](https://github.com/tangcent/easy-api/pull/284)

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '1.9.4.0.183.0'
+version '1.9.5.0.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=1.9.4.0.183.0
+plugin_version=1.9.5.0.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v1.9.4.0">v1.9.4.0.183.0(2020-05-06)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v1.9.5.0">v1.9.5.0.183.0(2020-05-13)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
@@ -8,4 +8,10 @@
     <li>opti: support new rule tool `config`<a
             href="https://github.com/tangcent/easy-api/pull/284">(#284)</a>
     </li>
+</ul>
+<ul>fix
+    <li>fix: preserving the order of field in `YapiFormatter` <a
+            href="https://github.com/tangcent/easy-yapi/pull/189">(#189)</a></li>
+    <li>opti: input new token if the old one be deleted. <a
+            href="https://github.com/tangcent/easy-yapi/pull/192">(#192)</a></li>
 </ul>

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,11 @@
 <a href="https://github.com/tangcent/easy-yapi/releases/tag/v1.9.4.0">v1.9.4.0.183.0(2020-05-06)</a>
 <br/>
-<a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
-<ul>bug-fix:
-    <li>fix: request body preview-language in postman example<a
-            href="https://github.com/tangcent/easy-api/pull/281">(#281)</a>
-    </li>
-</ul>
+<a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li>feat: support new rule `api.open` <a
-            href="https://github.com/tangcent/easy-yapi/pull/179">(#179)</a>
+    <li>opti: support new rule `postman.prerequest`&`postman.test`<a
+            href="https://github.com/tangcent/easy-api/pull/283">(#283)</a>
     </li>
-    <li>feat: support switch notice at `Setting` <a
-            href="https://github.com/tangcent/easy-yapi/pull/180">(#180)</a>
+    <li>opti: support new rule tool `config`<a
+            href="https://github.com/tangcent/easy-api/pull/284">(#284)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/EasyApiConfigReader.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/EasyApiConfigReader.kt
@@ -1,11 +1,12 @@
 package com.itangcent.idea.plugin.api.export
 
 import com.itangcent.intellij.config.AutoSearchConfigReader
+import com.itangcent.utils.Initializable
 
-class EasyApiConfigReader : AutoSearchConfigReader() {
+class EasyApiConfigReader : AutoSearchConfigReader(), Initializable {
 
     //    @PostConstruct
-    fun init() {
+    override fun init() {
         loadConfigInfo()
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanConfigReader.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanConfigReader.kt
@@ -1,11 +1,12 @@
 package com.itangcent.idea.plugin.api.export.postman
 
 import com.itangcent.intellij.config.AutoSearchConfigReader
+import com.itangcent.utils.Initializable
 
-class PostmanConfigReader : AutoSearchConfigReader() {
+class PostmanConfigReader : AutoSearchConfigReader(), Initializable {
 
     //    @PostConstruct
-    fun init() {
+    override fun init() {
         loadConfigInfo()
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/config/RecommendConfigReader.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/config/RecommendConfigReader.kt
@@ -11,13 +11,14 @@ import com.itangcent.intellij.config.MutableConfigReader
 import com.itangcent.intellij.extend.guice.PostConstruct
 import com.itangcent.intellij.logger.Logger
 import com.itangcent.intellij.psi.ContextSwitchListener
+import com.itangcent.utils.Initializable
 import org.apache.commons.io.IOUtils
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
 
 
-class RecommendConfigReader : ConfigReader {
+class RecommendConfigReader : ConfigReader, Initializable {
 
     @Inject
     @Named("delegate_config_reader")
@@ -67,7 +68,7 @@ class RecommendConfigReader : ConfigReader {
     }
 
     @PostConstruct
-    fun init() {
+    override fun init() {
 
         if (configReader is MutableConfigReader) {
             contextSwitchListener!!.clear()
@@ -94,7 +95,11 @@ class RecommendConfigReader : ConfigReader {
 
     private fun initDelegateAndRecommend() {
         try {
-            configReader?.invokeMethod("init")
+            if (configReader is Initializable) {
+                configReader.init()
+            } else {
+                configReader?.invokeMethod("init")
+            }
         } catch (e: Throwable) {
         }
         if (settingBinder?.read()?.useRecommendConfig == true) {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/DebugDialog.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/DebugDialog.kt
@@ -18,6 +18,7 @@ import com.itangcent.common.logger.traceError
 import com.itangcent.common.logger.traceWarn
 import com.itangcent.common.utils.notNullOrEmpty
 import com.itangcent.idea.plugin.rule.contextOf
+import com.itangcent.intellij.config.ConfigReader
 import com.itangcent.intellij.config.rule.RuleParser
 import com.itangcent.intellij.config.rule.StringRule
 import com.itangcent.intellij.context.ActionContext
@@ -25,6 +26,7 @@ import com.itangcent.intellij.extend.guice.PostConstruct
 import com.itangcent.intellij.extend.rx.AutoComputer
 import com.itangcent.intellij.jvm.DuckTypeHelper
 import com.itangcent.intellij.logger.Logger
+import com.itangcent.intellij.psi.ContextSwitchListener
 import com.itangcent.intellij.psi.PsiClassUtils
 import com.itangcent.intellij.util.ToolUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -70,6 +72,12 @@ class DebugDialog : JDialog() {
 
     @Inject
     val logger: Logger? = null
+
+    @Inject
+    val configReader: ConfigReader? = null
+
+    @Inject
+    val contextSwitchListener: ContextSwitchListener? = null
 
     private var evalTimer: Timer = Timer()
     private var lastEvalTime: AtomicLong = AtomicLong(0)
@@ -128,9 +136,13 @@ class DebugDialog : JDialog() {
             doCopy()
         }
 
-//        autoComputer.bind<Any>(this, "context")
-//                .with(this.contextTextField!!)
-//                .eval { contextStr -> }
+        autoComputer.listen(this::context)
+                .action { ele ->
+                    ele?.let {
+                        contextSwitchListener?.switchTo(it)
+                    }
+                }
+
         autoComputer.bind(this.contextTextField!!)
                 .with(this::context)
                 .eval { context ->
@@ -410,7 +422,7 @@ class DebugDialog : JDialog() {
         }
 
         override fun demoCode(): String {
-            return "var separator = tool.repeat(\"-\", 35) + \"\\n\\n\"\nvar sb = \"\"\nsb += \"debug `tool`:\\n\"\nsb += tool.debug(tool)\nsb += separator\nsb += \"debug `it`:\\n\"\nsb += tool.debug(it)\nsb += separator\nsb += \"debug `regex`:\\n\"\nsb += tool.debug(regex)\nsb += separator\nsb += \"debug `logger`:\\n\"\nsb += tool.debug(logger)\nsb += separator\nsb += \"debug `helper`:\\n\"\nsb += tool.debug(helper)\nsb += separator\nsb += \"debug `httpClient`:\\n\"\nsb += tool.debug(httpClient)\nsb += separator\nsb += \"debug `localStorage`:\\n\"\nsb += tool.debug(localStorage)\nsb += separator\nsb"
+            return "var separator = tool.repeat(\"-\", 35) + \"\\n\\n\"\nvar sb = \"\"\nsb += \"debug `tool`:\\n\"\nsb += tool.debug(tool)\nsb += separator\nsb += \"debug `it`:\\n\"\nsb += tool.debug(it)\nsb += separator\nsb += \"debug `regex`:\\n\"\nsb += tool.debug(regex)\nsb += separator\nsb += \"debug `logger`:\\n\"\nsb += tool.debug(logger)\nsb += separator\nsb += \"debug `helper`:\\n\"\nsb += tool.debug(helper)\nsb += separator\nsb += \"debug `httpClient`:\\n\"\nsb += tool.debug(httpClient)\nsb += separator\nsb += \"debug `localStorage`:\\n\"\nsb += tool.debug(localStorage)\nsb += separator\nsb += \"debug `config`:\\n\"\nsb += tool.debug(config)\nsb += separator\nsb"
         }
     }
 
@@ -433,7 +445,7 @@ class DebugDialog : JDialog() {
         }
 
         override fun demoCode(): String {
-            return "def separator = tool.repeat(\"-\", 35) + \"\\n\\n\"\ndef sb = \"\"\nsb += \"debug `tool`:\\n\"\nsb += tool.debug(tool)\nsb += separator\nsb += \"debug `it`:\\n\"\nsb += tool.debug(it)\nsb += separator\nsb += \"debug `regex`:\\n\"\nsb += tool.debug(regex)\nsb += separator\nsb += \"debug `logger`:\\n\"\nsb += tool.debug(logger)\nsb += separator\nsb += \"debug `helper`:\\n\"\nsb += tool.debug(helper)\nsb += separator\nsb += \"debug `httpClient`:\\n\"\nsb += tool.debug(httpClient)\nsb += separator\nsb += \"debug `localStorage`:\\n\"\nsb += tool.debug(localStorage)\nsb += separator\nreturn sb"
+            return "def separator = tool.repeat(\"-\", 35) + \"\\n\\n\"\ndef sb = \"\"\nsb += \"debug `tool`:\\n\"\nsb += tool.debug(tool)\nsb += separator\nsb += \"debug `it`:\\n\"\nsb += tool.debug(it)\nsb += separator\nsb += \"debug `regex`:\\n\"\nsb += tool.debug(regex)\nsb += separator\nsb += \"debug `logger`:\\n\"\nsb += tool.debug(logger)\nsb += separator\nsb += \"debug `helper`:\\n\"\nsb += tool.debug(helper)\nsb += separator\nsb += \"debug `httpClient`:\\n\"\nsb += tool.debug(httpClient)\nsb += separator\nsb += \"debug `localStorage`:\\n\"\nsb += tool.debug(localStorage)\nsb += separator\nsb += \"debug `config`:\\n\"\nsb += tool.debug(config)\nsb += separator\nreturn sb"
         }
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/utils/Initializable.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/utils/Initializable.kt
@@ -1,0 +1,13 @@
+package com.itangcent.utils
+
+import com.itangcent.intellij.context.ActionContext
+
+/**
+ * Interface to be implemented by beans that need to react once all their properties
+ * have been inject by [ActionContext]: e.g. to perform custom initialization,
+ * or merely to check that all mandatory properties have been set.
+ */
+interface Initializable {
+
+    fun init()
+}

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>1.9.4.0.183.0</version>
+    <version>1.9.5.0.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
- opti: support new rule `postman.prerequest`&`postman.test` [(#283)](https://github.com/tangcent/easy-api/pull/283)

- opti: support new rule tool `config` [(#284)](https://github.com/tangcent/easy-api/pull/284)

- fix: preserving the order of field in `YapiFormatter` [(#189)](https://github.com/tangcent/easy-yapi/pull/189)

- opti: input new token if the old one be deleted. [(#192)](https://github.com/tangcent/easy-yapi/pull/192)