### PR TITLE
release v1.9.7.0.183.0

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -146,3 +146,9 @@
     * feat: new tool `files` [(#289)](https://github.com/tangcent/easy-api/pull/289)
     
     * feat: `Debug` enhancement [(#290)](https://github.com/tangcent/easy-api/pull/290)
+    
+    * feat: support new rule `method.content.type` [(#292)](https://github.com/tangcent/easy-api/pull/292)
+   
+    * feat: support rule `param.http.type` for `RequestParam ` [(#298)](https://github.com/tangcent/easy-api/pull/298)
+    
+    * feat: handle annotation `CookieValue` [(#300)](https://github.com/tangcent/easy-api/pull/300)

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '1.9.6.183.0'
+version '1.9.7.183.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '1.9.7.183.0'
+version '1.9.7.0.183.0'

--- a/common-api/build.gradle
+++ b/common-api/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
-    compile('com.itangcent:commons:0.7.1') {
+    compile('com.itangcent:commons:0.7.3-SNAPSHOT') {
         exclude group: 'com.google.inject'
         exclude group: 'com.google.code.gson'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=1.9.6.0.183.0
+plugin_version=1.9.7.0.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -100,17 +100,17 @@ dependencies {
 //    compile fileTree(dir: 'libs', include: ['*.jar'])
 
 
-    compile('com.itangcent:intellij-idea:0.7.1') {
+    compile('com.itangcent:intellij-idea:0.7.3-SNAPSHOT') {
         exclude group: 'com.google.inject'
         exclude group: 'com.google.code.gson'
     }
 
-    compile('com.itangcent:intellij-kotlin-support:0.7.1') {
+    compile('com.itangcent:intellij-kotlin-support:0.7.3-SNAPSHOT') {
         exclude group: 'com.google.inject'
         exclude group: 'com.google.code.gson'
     }
 
-    compile('com.itangcent:intellij-scala-support:0.7.1') {
+    compile('com.itangcent:intellij-scala-support:0.7.3-SNAPSHOT') {
         exclude group: 'com.google.inject'
         exclude group: 'com.google.code.gson'
     }

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -2,14 +2,14 @@
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li>feat: support new rule `export.after`<a
-            href="https://github.com/tangcent/easy-api/pull/287">(#287)</a>
+    <li> feat: support new rule `method.content.type`<a
+            href="https://github.com/tangcent/easy-api/pull/292">(#292)</a>
     </li>
-    <li>feat: new tool `files`<a
-            href="https://github.com/tangcent/easy-api/pull/289">(#289)</a>
+    <li> feat: support rule `param.http.type` for `RequestParam `<a
+            href="https://github.com/tangcent/easy-api/pull/298">(#298)</a>
     </li>
-    <li> feat: `Debug` enhancement<a
-            href="https://github.com/tangcent/easy-api/pull/290">(#290)</a>
+    <li> feat: handle annotation `CookieValue`<a
+            href="https://github.com/tangcent/easy-api/pull/300">(#300)</a>
     </li>
 </ul>
 <ul>fix

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v1.9.6.0">v1.9.6.0.183.0(2020-05-13)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v1.9.7.0">v1.9.7.0.183.0(2020-07-12)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-api/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
@@ -11,10 +11,4 @@
     <li> feat: handle annotation `CookieValue`<a
             href="https://github.com/tangcent/easy-api/pull/300">(#300)</a>
     </li>
-</ul>
-<ul>fix
-    <li>fix: preserving the order of field in `YapiFormatter` <a
-            href="https://github.com/tangcent/easy-yapi/pull/189">(#189)</a></li>
-    <li>opti: input new token if the old one be deleted. <a
-            href="https://github.com/tangcent/easy-yapi/pull/192">(#192)</a></li>
 </ul>

--- a/idea-plugin/parts/pluginDescription.html
+++ b/idea-plugin/parts/pluginDescription.html
@@ -14,6 +14,11 @@
     <li>与之相对的是, 你可以灵活的运用配置规则来适应你的项目特性以减少代码侵入.</li>
 </ul>
 <br/>
+<p>
+    如果快捷键无效, 请检查快捷键冲突.
+    可以在 <kbd>Preferences(Settings)</kbd> > <kbd>KeyMap</kbd>修改快捷键.
+</p>
+<br/>
 
 <b>详细信息参考:<a href="https://easyyapi.com">Guide</a></b>
 <ul>导出API到Yapi,有四种方法:

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>1.9.6.0.183.0</version>
+    <version>1.9.7.0.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: support new rule `export.after`   [(#198)](https://github.com/tangcent/easy-yapi/pull/198)

* fix: yapi formatPath allow `?`&`=`  [(#200)](https://github.com/tangcent/easy-yapi/pull/200)

* feat: support new rule `method.content.type` [(#292)](https://github.com/tangcent/easy-api/pull/292)
   
* feat: support rule `param.http.type` for `RequestParam ` [(#298)](https://github.com/tangcent/easy-api/pull/298)
    
* feat: handle annotation `CookieValue` [(#300)](https://github.com/tangcent/easy-api/pull/300)