### PR TITLE
feat: support property `api.tag.delimiter`

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiMethodDocClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiMethodDocClassExporter.kt
@@ -1,17 +1,23 @@
 package com.itangcent.idea.plugin.api.export.yapi
 
+import com.google.inject.Inject
 import com.intellij.psi.PsiMethod
 import com.itangcent.common.model.MethodDoc
 import com.itangcent.idea.plugin.api.export.DefaultMethodDocClassExporter
+import com.itangcent.intellij.config.ConfigReader
+import org.apache.commons.lang3.StringUtils
 
 class YapiMethodDocClassExporter : DefaultMethodDocClassExporter() {
+
+    @Inject
+    private val configReader: ConfigReader? = null
 
     override fun processCompleted(method: PsiMethod, methodDoc: MethodDoc) {
         super.processCompleted(method, methodDoc)
 
         val tags = ruleComputer!!.computer(YapiClassExportRuleKeys.TAG, method)
         if (!tags.isNullOrBlank()) {
-            methodDoc.setTags(tags.split("\n")
+            methodDoc.setTags(StringUtils.split(tags, configReader!!.first("api.tag.delimiter") ?: ",\n")
                     .map { it.trim() }
                     .filter { it.isNotBlank() })
         }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiSpringRequestClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiSpringRequestClassExporter.kt
@@ -1,5 +1,6 @@
 package com.itangcent.idea.plugin.api.export.yapi
 
+import com.google.inject.Inject
 import com.itangcent.common.constant.Attrs
 import com.itangcent.common.constant.HttpMethod
 import com.itangcent.common.kit.KVUtils
@@ -10,18 +11,23 @@ import com.itangcent.common.logger.traceError
 import com.itangcent.common.model.*
 import com.itangcent.common.utils.*
 import com.itangcent.idea.plugin.api.export.*
+import com.itangcent.intellij.config.ConfigReader
 import com.itangcent.intellij.config.rule.computer
 import com.itangcent.intellij.jvm.element.ExplicitMethod
 import com.itangcent.intellij.util.*
+import org.apache.commons.lang3.StringUtils
 
 open class YapiSpringRequestClassExporter : SpringRequestClassExporter() {
+
+    @Inject
+    private val configReader: ConfigReader? = null
 
     override fun processCompleted(method: ExplicitMethod, kv: KV<String, Any?>, request: Request) {
         super.processCompleted(method, kv, request)
 
         val tags = ruleComputer!!.computer(YapiClassExportRuleKeys.TAG, method)
         if (tags.notNullOrEmpty()) {
-            request.setTags(tags!!.split("\n")
+            request.setTags(StringUtils.split(tags, configReader!!.first("api.tag.delimiter") ?: ",\n")
                     .map { it.trim() }
                     .filter { it.isNotBlank() })
         }


### PR DESCRIPTION
- By default, split tags by `,\n` .
- Support property `api.tag.delimiter`