### PR TITLE
release v2.0.1.0.183.0

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -172,3 +172,9 @@
     
     * feat: new Setting [postman] wrapCollection & autoMergeScript [(#317)](https://github.com/tangcent/easy-api/pull/317)
     
+    * opti: parse param as query by default [(#229)](https://github.com/tangcent/easy-yapi/pull/229)
+    
+    * feat: [ScriptExecutor] support select field or method in the class. [(#231)](https://github.com/tangcent/easy-yapi/pull/231)
+    
+    * feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#232)](https://github.com/tangcent/easy-yapi/pull/232)
+    

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.0.0.0.183.0'
+version '2.0.1.0.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.0.0.0.183.0
+plugin_version=2.0.1.0.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,14 +1,14 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.0.0">v2.0.0.0.183.0(2020-08-02)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.1.0">v2.0.1.0.183.0(2020-08-09)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> feat: support new rules `class.postman.prerequest`&`class.postman.test` <a
-            href="https://github.com/tangcent/easy-api/pull/312">(#312)</a>
+    <li> opti: parse param as query by default <a
+            href="https://github.com/tangcent/easy-yapi/pull/229">(#229)</a>
     </li>
-    <li> feat: new rule `collection.postman.prerequest`&`collection.postman.test` <a
-            href="https://github.com/tangcent/easy-api/pull/314">(#314)</a>
+    <li> feat: [ScriptExecutor] support select field or method in the class. <a
+            href="https://github.com/tangcent/easy-yapi/pull/231">(#231)</a>
     </li>
-    <li> feat: new Setting [postman] wrapCollection & autoMergeScript <a
-            href="https://github.com/tangcent/easy-api/pull/317">(#317)</a>
+    <li> feat: add rule alias `param.doc`/`method.doc`/`class.doc` <a
+            href="https://github.com/tangcent/easy-yapi/pull/232">(#232)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.0.0.0.183.0</version>
+    <version>2.0.1.0.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* opti: parse param as query by default [(#229)](https://github.com/tangcent/easy-yapi/pull/229)
    
* feat: [ScriptExecutor] support select field or method in the class. [(#231)](https://github.com/tangcent/easy-yapi/pull/231)
    
* feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#232)](https://github.com/tangcent/easy-yapi/pull/232)
    