### PR TITLE
release v2.0.4

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -190,3 +190,12 @@
     
     * fix: fix class/type #isExtend [(#253)](https://github.com/tangcent/easy-yapi/pull/253)
     
+    * fix: always use json settings. [(#261)](https://github.com/tangcent/easy-yapi/pull/261)
+    
+    * opti: new func: tool.traversal [(#265)](https://github.com/tangcent/easy-yapi/pull/265)
+    
+    * opti: support rule `field.default.value` [(#266)](https://github.com/tangcent/easy-yapi/pull/266)
+    
+    * fix: remove usage of Module.getModuleFilePath [(#267)](https://github.com/tangcent/easy-yapi/pull/267)
+    
+    

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.0.3.0.183.0'
+version '2.0.4.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.0.3.0.183.0
+plugin_version=2.0.4.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.3.0">v2.0.3.0.183.0(2020-09-22)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.4">v2.0.4.183.0(2020-10-18)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> feat: support DeferredResult by recommend <a
-            href="https://github.com/tangcent/easy-yapi/pull/250">(#250)</a>
+    <li> opti: new func: tool.traversal <a
+            href="https://github.com/tangcent/easy-yapi/pull/265">(#265)</a>
     </li>
-    <li> feat: new recommend config [support_enum_common] <a
-            href="https://github.com/tangcent/easy-yapi/pull/251">(#251)</a>
+    <li> opti: support rule `field.default.value` <a
+            href="https://github.com/tangcent/easy-yapi/pull/266">(#266)</a>
     </li>
 </ul>
 <ul>fix:
-    <li> fix: fix class/type #isExtend <a
-            href="https://github.com/tangcent/easy-yapi/pull/253">(#253)</a>
+    <li> fix: always use json settings. <a
+            href="https://github.com/tangcent/easy-yapi/pull/261">(#261)</a>
+    </li>
+    <li> fix: remove usage of Module.getModuleFilePath. <a
+            href="https://github.com/tangcent/easy-yapi/pull/267">(#267)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.0.3.0.183.0</version>
+    <version>2.0.4.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* fix: always use json settings. [(#261)](https://github.com/tangcent/easy-yapi/pull/261)

* opti: new func: tool.traversal [(#265)](https://github.com/tangcent/easy-yapi/pull/265)

* opti: support rule `field.default.value` [(#266)](https://github.com/tangcent/easy-yapi/pull/266)

* fix: remove usage of Module.getModuleFilePath [(#267)](https://github.com/tangcent/easy-yapi/pull/267)

