### PR TITLE
release v2.0.6

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,121 +1,50 @@
-*   0.2.0
-    *  enhance:support export api to postman`[Code -> ExportPostman]`
-*   0.3.0
-    *  enhance:cache api export result
-*   0.4.0 ~
-    *  enhance:quick API requests from code`[Alt + Insert -> Call]`
-    *  enhance:support request&response header
-    *  enhance:support download response
-    *  enhance:support host history
-    *  enhance:support response auto format
-    *  (beta)enhance:Export Api As Markdown\[Code -> ExportMarkdown]
-    *  fix:support Post File In `[Call Api Action]`
-*   0.5.0 ~
-    *  fix:auto format xml/html response
-    *  fix:set prompt for json response
-    *  fix:optimized the cache
-*   0.6.0 ~
-    *  enhance:support ApiDashboard
-    *  enhance:optimized ui
-    *  enhance:auto fix postman collection info
-    *  enhance:support PopupMenu for Postman Tree [(#42)](https://github.com/tangcent/easy-api/issues/42)
-    *  enhance:support clear cache in Setting [(#46)](https://github.com/tangcent/easy-api/issues/46)
-    *  enhance:support generic type of api method[(#48)](https://github.com/tangcent/easy-api/issues/48)
-    *  enhance:optional form parameters[(#53)](https://github.com/tangcent/easy-api/issues/53)
-    *  fix:deserialize int numbers correctly [(#49)](https://github.com/tangcent/easy-api/issues/49)
-    *  fix:fix custom module rule in config [(#54)](https://github.com/tangcent/easy-api/issues/54)
-    * fix:support org.springframework.web.bind.annotation.RequestHeader [(#57)](https://github.com/tangcent/easy-api/issues/57)
-    * enhance:optimize the inference of the return type of the method [(#60)](https://github.com/tangcent/easy-api/issues/60)
-    * enhance:provide http properties settings [(#61)](https://github.com/tangcent/easy-api/issues/61)
-    * enhance:set toolTip for postman tree node [(#64)](https://github.com/tangcent/easy-api/pull/64)
-    * enhance:support recommend config [(#66)](https://github.com/tangcent/easy-api/pull/66)
-    * enhance:support class rule:ignoreField\[json.rule.field.ignore] [(#67)](https://github.com/tangcent/easy-api/pull/67)
-    * enhance:support YapiDashBoard [(#66)](https://github.com/tangcent/easy-yapi/issues/5)
-    *  enhance:try resolve link to yapi [#2](https://github.com/tangcent/easy-yapi/issues/2)
-*   0.7.0 ~
-    * enhance:provide logging level Settings  [(#68)](https://github.com/tangcent/easy-api/issues/68)
-    * enhance:optimized action interrupt  [(#72)](https://github.com/tangcent/easy-api/pull/72)
-    * fix:support org.springframework.http.HttpEntity/org.springframework.http.ResponseEntity  [(#71)](https://github.com/tangcent/easy-api/issues/71)
-*   0.8.0 ~
-    * enhance:process key 'Tab' in request params  [(#85)](https://github.com/tangcent/easy-api/pull/85)
-    * enhance:process Deprecated info on class in RecommendConfig  [(#86)](https://github.com/tangcent/easy-api/pull/86)
-    * enhance:try parse linked option info for form params  [(#87)](https://github.com/tangcent/easy-api/pull/87)
-*   0.9.0 ~
-    * enhance:support groovy extension  [(#98)](https://github.com/tangcent/easy-api/pull/98)
-    * enhance:update toolTip of ApiProjectNode in ApiDashBoard  [(#102)](https://github.com/tangcent/easy-api/pull/102)
-    * fix:opti method Infer  [(#103)](https://github.com/tangcent/easy-api/pull/103)
-    * enhance:support export method doc(rpc)  [(#107)](https://github.com/tangcent/easy-api/pull/107)
-    * fix config search[(#113)](https://github.com/tangcent/easy-api/pull/113)
-    * resolve `{@link ...}` in param desc doc[(#117)](https://github.com/tangcent/easy-api/pull/117)
-    * Output path params in 'Export Markdown'[(#118)](https://github.com/tangcent/easy-api/pull/118)
-    * fix:use json instead of form for add cart of yapi [(#44)](https://github.com/tangcent/easy-yapi/pull/44)
-*   1.0.0 ~
-    * enhance:support kotlin  [(#125)](https://github.com/tangcent/easy-api/pull/125)
-*   1.1.0 ~
-    * enhance:support rule: `name[filter]=value`  [(#138)](https://github.com/tangcent/easy-api/pull/138)
-    * enhance:parse kotlin files in ApiDashboard  [(#141)](https://github.com/tangcent/easy-api/pull/141)
-    * fix: support Serializer for Enum  [(#134)](https://github.com/tangcent/easy-api/issues/134)
-    * fix: fix error base path for APIs in super class  [(#137)](https://github.com/tangcent/easy-api/issues/137)
-    * fix: ApiDashboard not show kotlin module&apis [(#140)](https://github.com/tangcent/easy-api/issues/140)
-*   1.2.0 ~
-    * enhance:provide more recommended configurations  [(#153)](https://github.com/tangcent/easy-api/issues/153)
-    * enhance:support for export&import settings [(#167)](https://github.com/tangcent/easy-api/issues/167)
-    * fix: Some icon maybe missing in Windows  [(#164)](https://github.com/tangcent/easy-api/issues/164)
-       
-*   1.3.0 ~
-    * enhance:new rule:`[class.prefix.path]`  [(#181)](https://github.com/tangcent/easy-api/pull/181)
-    * enhance:new rule:`[doc.class]`  [(#178)](https://github.com/tangcent/easy-api/pull/178)
-    * enhance:new rule:`[param.ignore]`  [(#176)](https://github.com/tangcent/easy-api/pull/176)
-    * enhance:import spring properties by recommend [(#181)](https://github.com/tangcent/easy-api/pull/181)
-    * enhance:Auto reload the configuration while context switch [(#185)](https://github.com/tangcent/easy-api/pull/185)
-   
-*   1.4.0 ~
-    * enhance:support new rule: `api.name`  [(#200)](https://github.com/tangcent/easy-api/pull/200)
-    * enhance:new method `contextType` for rule  [(#201)](https://github.com/tangcent/easy-api/pull/201)
-    * enhance:cache parsed additional `Header`/`Param`  [(#205)](https://github.com/tangcent/easy-api/pull/205)
-    * enhance:ignore param extend HttpServletRequest/HttpServletResponse  [(#206)](https://github.com/tangcent/easy-api/pull/206)
-    * enhance:new rule: `method.default.http.method`   [(#207)](https://github.com/tangcent/easy-api/pull/207)
-    * enhance:provide recommend config for yapi mock [(#116)](https://github.com/tangcent/easy-yapi/pull/116)
-    * enhance:new rule `field.mock` [(#113)](https://github.com/tangcent/easy-yapi/pull/113)
-   
-*   1.5.0 ~
-    * enhance:support setting charset for export markdown  [(#211)](https://github.com/tangcent/easy-api/pull/211)
-    * enhance:add new method `jsonType` for `method`&`field`  [(#213)](https://github.com/tangcent/easy-api/pull/213)
-    * enhance:support scala project   [(#214)](https://github.com/tangcent/easy-api/pull/214)
-    * bug-fix: preserving the order of field in infer   [(#216)](https://github.com/tangcent/easy-api/pull/216)
 
+* 2.0.0~
 
-*   1.7.0 ~
-    * enhance:new rule tool: helper  [(#242)](https://github.com/tangcent/easy-api/pull/242)
-    * enhance:support rule: method.return  [(#240)](https://github.com/tangcent/easy-api/pull/240)
-   
-*   1.8.0 ~
-
-    * enhance:support render yapi desc: [yapi render](http://easyyapi.com/documents/yapi_render.html)  [(#138)](https://github.com/tangcent/easy-api/pull/138)
-
-    * fix type parse for markdown formatter [(#255)](https://github.com/tangcent/easy-api/pull/255)
+    * feat: support rule util `session` [(#273)](https://github.com/tangcent/easy-yapi/pull/273)
     
-    * addHeaderIfMissed only if the request hasBody  [(#258)](https://github.com/tangcent/easy-api/pull/258)
-   
-    * fix name of api without any comment  [(#263)](https://github.com/tangcent/easy-api/pull/263)
-   
-    * recommend config: private_protected_field_only  [(#256)](https://github.com/tangcent/easy-api/pull/256)
-   
-    * refactor http client [(#257)](https://github.com/tangcent/easy-api/pull/257)
-   
-    * resolve RequestMapping#params [(#259)](https://github.com/tangcent/easy-api/pull/259)
-   
-    * resolve RequestMapping#headers [(#260)](https://github.com/tangcent/easy-api/pull/260)
+    * feat: support new method `annValue` for rule elements [(#274)](https://github.com/tangcent/easy-yapi/pull/274)
     
-    * log saved file path [(#264)](https://github.com/tangcent/easy-api/pull/264)
+    * opti: support rule `param.before`&`param.after` [(#275)](https://github.com/tangcent/easy-yapi/pull/275)
     
-    * opti: [DEBUG ACTION] [(#265)](https://github.com/tangcent/easy-api/pull/265)
+    * opti: several recommended configs is not selected by default any longer [(#276)](https://github.com/tangcent/easy-yapi/pull/276)
     
-    * fix HttpRequest querys [(#267)](https://github.com/tangcent/easy-api/pull/267)
+    * feat: new recommend configs [(#277)](https://github.com/tangcent/easy-yapi/pull/277)
     
-    * new rule tool: localStorage [(#268)](https://github.com/tangcent/easy-api/pull/268)
+    * opti: support repeat validation annotation [(#278)](https://github.com/tangcent/easy-yapi/pull/278)
 
-
+    * feat: new rules `class.postman.prerequest`&`class.postman.test` [(#312)](https://github.com/tangcent/easy-api/pull/312)
+    
+    * feat: new rule `collection.postman.prerequest`&`collection.postman.test` [(#314)](https://github.com/tangcent/easy-api/pull/314)
+    
+    * feat: new Setting [postman] wrapCollection & autoMergeScript [(#317)](https://github.com/tangcent/easy-api/pull/317)
+    
+    * opti: parse param as query by default [(#229)](https://github.com/tangcent/easy-yapi/pull/229)
+    
+    * feat: [ScriptExecutor] support select field or method in the class. [(#231)](https://github.com/tangcent/easy-yapi/pull/231)
+    
+    * feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#232)](https://github.com/tangcent/easy-yapi/pull/232)
+    
+    * chore: fix recommend config for ignore serialVersionUID [(#237)](https://github.com/tangcent/easy-yapi/pull/237)
+    
+    * chore: remove cache of recommend config [(#238)](https://github.com/tangcent/easy-yapi/pull/238)
+    
+    * chore: update recommend config [(#239)](https://github.com/tangcent/easy-yapi/pull/239)
+    
+    * feat: support DeferredResult by recommend [(#250)](https://github.com/tangcent/easy-yapi/pull/250)
+    
+    * feat: new recommend config \[support_enum_common] [(#251)](https://github.com/tangcent/easy-yapi/pull/251)
+    
+    * fix: fix class/type #isExtend [(#253)](https://github.com/tangcent/easy-yapi/pull/253)
+    
+    * fix: always use json settings. [(#261)](https://github.com/tangcent/easy-yapi/pull/261)
+    
+    * opti: new func: tool.traversal [(#265)](https://github.com/tangcent/easy-yapi/pull/265)
+    
+    * opti: support rule `field.default.value` [(#266)](https://github.com/tangcent/easy-yapi/pull/266)
+    
+    * fix: remove usage of Module.getModuleFilePath [(#267)](https://github.com/tangcent/easy-yapi/pull/267)
+    
 * 1.9.0 ~
 
     * fix: support `java`/`kt`/`scala` in all action. [(#271)](https://github.com/tangcent/easy-api/pull/271
@@ -164,38 +93,132 @@
     
     * feat: support property `api.tag.delimiter` [(#223)](https://github.com/tangcent/easy-yapi/pull/223)
     
-* 2.0.0~
+    
+*   1.8.0 ~
 
-    * feat: new rules `class.postman.prerequest`&`class.postman.test` [(#312)](https://github.com/tangcent/easy-api/pull/312)
+    * enhance:support render yapi desc: [yapi render](http://easyyapi.com/documents/yapi_render.html)  [(#138)](https://github.com/tangcent/easy-api/pull/138)
+
+    * fix type parse for markdown formatter [(#255)](https://github.com/tangcent/easy-api/pull/255)
     
-    * feat: new rule `collection.postman.prerequest`&`collection.postman.test` [(#314)](https://github.com/tangcent/easy-api/pull/314)
+    * addHeaderIfMissed only if the request hasBody  [(#258)](https://github.com/tangcent/easy-api/pull/258)
+   
+    * fix name of api without any comment  [(#263)](https://github.com/tangcent/easy-api/pull/263)
+   
+    * recommend config: private_protected_field_only  [(#256)](https://github.com/tangcent/easy-api/pull/256)
+   
+    * refactor http client [(#257)](https://github.com/tangcent/easy-api/pull/257)
+   
+    * resolve RequestMapping#params [(#259)](https://github.com/tangcent/easy-api/pull/259)
+   
+    * resolve RequestMapping#headers [(#260)](https://github.com/tangcent/easy-api/pull/260)
     
-    * feat: new Setting [postman] wrapCollection & autoMergeScript [(#317)](https://github.com/tangcent/easy-api/pull/317)
+    * log saved file path [(#264)](https://github.com/tangcent/easy-api/pull/264)
     
-    * opti: parse param as query by default [(#229)](https://github.com/tangcent/easy-yapi/pull/229)
+    * opti: [DEBUG ACTION] [(#265)](https://github.com/tangcent/easy-api/pull/265)
     
-    * feat: [ScriptExecutor] support select field or method in the class. [(#231)](https://github.com/tangcent/easy-yapi/pull/231)
+    * fix HttpRequest querys [(#267)](https://github.com/tangcent/easy-api/pull/267)
     
-    * feat: add rule alias `param.doc`/`method.doc`/`class.doc` [(#232)](https://github.com/tangcent/easy-yapi/pull/232)
+    * new rule tool: localStorage [(#268)](https://github.com/tangcent/easy-api/pull/268)
+
+*   1.7.0 ~
+
+    * enhance:new rule tool: helper  [(#242)](https://github.com/tangcent/easy-api/pull/242)
     
-    * chore: fix recommend config for ignore serialVersionUID [(#237)](https://github.com/tangcent/easy-yapi/pull/237)
+    * enhance:support rule: method.return  [(#240)](https://github.com/tangcent/easy-api/pull/240)
+   
+
+*   1.5.0 ~
+    * enhance:support setting charset for export markdown  [(#211)](https://github.com/tangcent/easy-api/pull/211)
+    * enhance:add new method `jsonType` for `method`&`field`  [(#213)](https://github.com/tangcent/easy-api/pull/213)
+    * enhance:support scala project   [(#214)](https://github.com/tangcent/easy-api/pull/214)
+    * bug-fix: preserving the order of field in infer   [(#216)](https://github.com/tangcent/easy-api/pull/216)
+
+*   1.4.0 ~
+    * enhance:support new rule: `api.name`  [(#200)](https://github.com/tangcent/easy-api/pull/200)
+    * enhance:new method `contextType` for rule  [(#201)](https://github.com/tangcent/easy-api/pull/201)
+    * enhance:cache parsed additional `Header`/`Param`  [(#205)](https://github.com/tangcent/easy-api/pull/205)
+    * enhance:ignore param extend HttpServletRequest/HttpServletResponse  [(#206)](https://github.com/tangcent/easy-api/pull/206)
+    * enhance:new rule: `method.default.http.method`   [(#207)](https://github.com/tangcent/easy-api/pull/207)
+    * enhance:provide recommend config for yapi mock [(#116)](https://github.com/tangcent/easy-yapi/pull/116)
+    * enhance:new rule `field.mock` [(#113)](https://github.com/tangcent/easy-yapi/pull/113)
+       
+*   1.3.0 ~
+    * enhance:new rule:`[class.prefix.path]`  [(#181)](https://github.com/tangcent/easy-api/pull/181)
+    * enhance:new rule:`[doc.class]`  [(#178)](https://github.com/tangcent/easy-api/pull/178)
+    * enhance:new rule:`[param.ignore]`  [(#176)](https://github.com/tangcent/easy-api/pull/176)
+    * enhance:import spring properties by recommend [(#181)](https://github.com/tangcent/easy-api/pull/181)
+    * enhance:Auto reload the configuration while context switch [(#185)](https://github.com/tangcent/easy-api/pull/185)
+   
+*   1.2.0 ~
+    * enhance:provide more recommended configurations  [(#153)](https://github.com/tangcent/easy-api/issues/153)
+    * enhance:support for export&import settings [(#167)](https://github.com/tangcent/easy-api/issues/167)
+    * fix: Some icon maybe missing in Windows  [(#164)](https://github.com/tangcent/easy-api/issues/164)
+  
+*   1.1.0 ~
+    * enhance:support rule: `name[filter]=value`  [(#138)](https://github.com/tangcent/easy-api/pull/138)
+    * enhance:parse kotlin files in ApiDashboard  [(#141)](https://github.com/tangcent/easy-api/pull/141)
+    * fix: support Serializer for Enum  [(#134)](https://github.com/tangcent/easy-api/issues/134)
+    * fix: fix error base path for APIs in super class  [(#137)](https://github.com/tangcent/easy-api/issues/137)
+    * fix: ApiDashboard not show kotlin module&apis [(#140)](https://github.com/tangcent/easy-api/issues/140)
+     
+*   1.0.0 ~
+    * enhance:support kotlin  [(#125)](https://github.com/tangcent/easy-api/pull/125)
+
+*   0.9.0 ~
+    * enhance:support groovy extension  [(#98)](https://github.com/tangcent/easy-api/pull/98)
+    * enhance:update toolTip of ApiProjectNode in ApiDashBoard  [(#102)](https://github.com/tangcent/easy-api/pull/102)
+    * fix:opti method Infer  [(#103)](https://github.com/tangcent/easy-api/pull/103)
+    * enhance:support export method doc(rpc)  [(#107)](https://github.com/tangcent/easy-api/pull/107)
+    * fix config search[(#113)](https://github.com/tangcent/easy-api/pull/113)
+    * resolve `{@link ...}` in param desc doc[(#117)](https://github.com/tangcent/easy-api/pull/117)
+    * Output path params in 'Export Markdown'[(#118)](https://github.com/tangcent/easy-api/pull/118)
+    * fix:use json instead of form for add cart of yapi [(#44)](https://github.com/tangcent/easy-yapi/pull/44)
+
+*   0.8.0 ~
+    * enhance:process key 'Tab' in request params  [(#85)](https://github.com/tangcent/easy-api/pull/85)
+    * enhance:process Deprecated info on class in RecommendConfig  [(#86)](https://github.com/tangcent/easy-api/pull/86)
+    * enhance:try parse linked option info for form params  [(#87)](https://github.com/tangcent/easy-api/pull/87)
+
+*   0.7.0 ~
+    * enhance:provide logging level Settings  [(#68)](https://github.com/tangcent/easy-api/issues/68)
+    * enhance:optimized action interrupt  [(#72)](https://github.com/tangcent/easy-api/pull/72)
+    * fix:support org.springframework.http.HttpEntity/org.springframework.http.ResponseEntity  [(#71)](https://github.com/tangcent/easy-api/issues/71)
+          
+*   0.6.0 ~
+    * enhance:support ApiDashboard
+    * enhance:optimized ui
+    * enhance:auto fix postman collection info
+    * enhance:support PopupMenu for Postman Tree [(#42)](https://github.com/tangcent/easy-api/issues/42)
+    * enhance:support clear cache in Setting [(#46)](https://github.com/tangcent/easy-api/issues/46)
+    * enhance:support generic type of api method[(#48)](https://github.com/tangcent/easy-api/issues/48)
+    * enhance:optional form parameters[(#53)](https://github.com/tangcent/easy-api/issues/53)
+    * fix:deserialize int numbers correctly [(#49)](https://github.com/tangcent/easy-api/issues/49)
+    * fix:fix custom module rule in config [(#54)](https://github.com/tangcent/easy-api/issues/54)
+    * fix:support org.springframework.web.bind.annotation.RequestHeader [(#57)](https://github.com/tangcent/easy-api/issues/57)
+    * enhance:optimize the inference of the return type of the method [(#60)](https://github.com/tangcent/easy-api/issues/60)
+    * enhance:provide http properties settings [(#61)](https://github.com/tangcent/easy-api/issues/61)
+    * enhance:set toolTip for postman tree node [(#64)](https://github.com/tangcent/easy-api/pull/64)
+    * enhance:support recommend config [(#66)](https://github.com/tangcent/easy-api/pull/66)
+    * enhance:support class rule:ignoreField\[json.rule.field.ignore] [(#67)](https://github.com/tangcent/easy-api/pull/67)
+    * enhance:support YapiDashBoard [(#66)](https://github.com/tangcent/easy-yapi/issues/5)
+    * enhance:try resolve link to yapi [#2](https://github.com/tangcent/easy-yapi/issues/2)
+
+*   0.5.0 ~
+    *  fix:auto format xml/html response
+    *  fix:set prompt for json response
+    *  fix:optimized the cache
     
-    * chore: remove cache of recommend config [(#238)](https://github.com/tangcent/easy-yapi/pull/238)
+*   0.4.0 ~
+    *  enhance:quick API requests from code`[Alt + Insert -> Call]`
+    *  enhance:support request&response header
+    *  enhance:support download response
+    *  enhance:support host history
+    *  enhance:support response auto format
+    *  (beta)enhance:Export Api As Markdown\[Code -> ExportMarkdown]
+    *  fix:support Post File In `[Call Api Action]`
     
-    * chore: update recommend config [(#239)](https://github.com/tangcent/easy-yapi/pull/239)
+*   0.3.0
+    *  enhance:cache api export result
     
-    * feat: support DeferredResult by recommend [(#250)](https://github.com/tangcent/easy-yapi/pull/250)
-    
-    * feat: new recommend config \[support_enum_common] [(#251)](https://github.com/tangcent/easy-yapi/pull/251)
-    
-    * fix: fix class/type #isExtend [(#253)](https://github.com/tangcent/easy-yapi/pull/253)
-    
-    * fix: always use json settings. [(#261)](https://github.com/tangcent/easy-yapi/pull/261)
-    
-    * opti: new func: tool.traversal [(#265)](https://github.com/tangcent/easy-yapi/pull/265)
-    
-    * opti: support rule `field.default.value` [(#266)](https://github.com/tangcent/easy-yapi/pull/266)
-    
-    * fix: remove usage of Module.getModuleFilePath [(#267)](https://github.com/tangcent/easy-yapi/pull/267)
-    
-    
+*   0.2.0
+    *  enhance:support export api to postman`[Code -> ExportPostman]`

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.0.5.183.0'
+version '2.0.6.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.0.5.183.0
+plugin_version=2.0.6.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,19 +1,29 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.5">v2.0.5.183.0(2020-10-20)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.0.6">v2.0.6.183.0(2020-11-09)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> opti: new func: tool.traversal <a
-            href="https://github.com/tangcent/easy-yapi/pull/265">(#265)</a>
+
+    <li> feat: support rule util `session` <a
+            href="https://github.com/tangcent/easy-yapi/pull/273">(#273)</a>
     </li>
-    <li> opti: support rule `field.default.value` <a
-            href="https://github.com/tangcent/easy-yapi/pull/266">(#266)</a>
+
+    <li> feat: support new method `annValue` for rule elements <a
+            href="https://github.com/tangcent/easy-yapi/pull/274">(#274)</a>
     </li>
-</ul>
-<ul>fix:
-    <li> fix: always use json settings. <a
-            href="https://github.com/tangcent/easy-yapi/pull/261">(#261)</a>
+
+    <li> opti: support rule `param.before`&`param.after` <a
+            href="https://github.com/tangcent/easy-yapi/pull/275">(#275)</a>
     </li>
-    <li> fix: remove usage of Module.getModuleFilePath. <a
-            href="https://github.com/tangcent/easy-yapi/pull/267">(#267)</a>
+
+    <li> opti: several recommended configs is not selected by default any longer <a
+            href="https://github.com/tangcent/easy-yapi/pull/276">(#276)</a>
+    </li>
+
+    <li> feat: new recommend configs <a
+            href="https://github.com/tangcent/easy-yapi/pull/277">(#277)</a>
+    </li>
+
+    <li> opti: support repeat validation annotation <a
+            href="https://github.com/tangcent/easy-yapi/pull/278">(#278)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.0.5.183.0</version>
+    <version>2.0.6.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* feat: support rule util `session` [(#273)](https://github.com/tangcent/easy-yapi/pull/273)
    
* feat: support new method `annValue` for rule elements [(#274)](https://github.com/tangcent/easy-yapi/pull/274)
    
* opti: support rule `param.before`&`param.after` [(#275)](https://github.com/tangcent/easy-yapi/pull/275)
    
* opti: several recommended configs is not selected by default any longer [(#276)](https://github.com/tangcent/easy-yapi/pull/276)
    
* feat: new recommend configs [(#277)](https://github.com/tangcent/easy-yapi/pull/277)
    
* opti: support repeat validation annotation [(#278)](https://github.com/tangcent/easy-yapi/pull/278)
