### PR TITLE
opti: support param.before&param.after for methodDoc

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
@@ -349,10 +349,14 @@ open class DefaultMethodDocClassExporter : ClassExporter, Worker {
                     continue
                 }
 
-                processMethodParameter(method, methodDoc, param, paramDocComment?.get(param.name!!)?.toString())
+                ruleComputer.computer(ClassExportRuleKeys.PARAM_BEFORE, param)
+                try {
+                    processMethodParameter(method, methodDoc, param, paramDocComment?.get(param.name!!)?.toString())
+                } finally {
+                    ruleComputer.computer(ClassExportRuleKeys.PARAM_AFTER, param)
+                }
             }
         }
-
     }
 
     protected fun processMethodParameter(

--- a/idea-plugin/src/main/resources/.recommend.easy.api.config
+++ b/idea-plugin/src/main/resources/.recommend.easy.api.config
@@ -109,7 +109,9 @@ param.required=@javax.validation.constraints.NotEmpty
 field.required=@javax.validation.constraints.NotEmpty
 
 #[javax.validation(grouped)]
+#Support for javax.validation annotations(grouped)
 json.cache.disable=true
+json.group=groovy:session.get("json-group")
 param.before=groovy:```
     session.set("json-group", it.annValue("org.springframework.validation.annotation.Validated"))
 ```


### PR DESCRIPTION
fix #306 