### PR TITLE
opti: support param.required for methodDoc

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
@@ -367,7 +367,7 @@ open class DefaultMethodDocClassExporter : ClassExporter, Worker {
     ) {
         val typeObject = psiClassHelper!!.getTypeObject(param.type, method,
                 jsonSetting!!.jsonOption(JsonOption.READ_COMMENT))
-        methodDocHelper!!.addParam(methodDoc, param.name!!, typeObject, paramDesc)
+        methodDocHelper!!.addParam(methodDoc, param.name!!, typeObject, paramDesc, ruleComputer!!.computer(ClassExportRuleKeys.PARAM_REQUIRED, param) == true)
     }
 
     protected fun parseResponseBody(psiType: PsiType?, method: PsiMethod): Any? {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/MethodDocHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/MethodDocHelper.kt
@@ -19,8 +19,8 @@ interface MethodDocHelper {
 }
 
 //region utils------------------------------------------------------------------
-fun MethodDocHelper.addParam(methodDoc: MethodDoc, paramName: String, value: Any?, desc: String?) {
-    addParam(methodDoc, paramName, value, false, desc)
+fun MethodDocHelper.addParam(methodDoc: MethodDoc, paramName: String, value: Any?, desc: String?,required: Boolean) {
+    addParam(methodDoc, paramName, value, required, desc)
 }
 
 fun MethodDocHelper.addParam(methodDoc: MethodDoc, paramName: String, value: Any?, required: Boolean, desc: String?) {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/config/RecommendConfigLoader.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/config/RecommendConfigLoader.kt
@@ -19,11 +19,11 @@ object RecommendConfigLoader {
         return RECOMMEND_CONFIG_PLAINT
     }
 
-    fun buildRecommendConfig(codes: String): String {
+    fun buildRecommendConfig(codes: String, separator: CharSequence = "\n"): String {
         val set = codes.split(",").toSet()
         return RECOMMEND_CONFIGS
                 .filter { set.contains(it.code) || (it.default && !set.contains("-${it.code}")) }
-                .joinToString("\n") { it.content }
+                .joinToString(separator) { it.content }
     }
 
     fun addSelectedConfig(codes: String, code: String): String {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
@@ -255,7 +255,10 @@ class EasyApiSettingGUI {
 
         autoComputer.bind(this.previewTextArea!!)
                 .with<String>(this, "settings.recommendConfigs")
-                .eval { configs -> RecommendConfigLoader.buildRecommendConfig(configs) }
+                .eval { configs ->
+                    RecommendConfigLoader.buildRecommendConfig(configs,
+                            "\n#${"-".repeat(20)}\n")
+                }
 
         //endregion  general-----------------------------------------------------
 


### PR DESCRIPTION
基于methodDoc 导入yapi ,未校验 param_field 