### PR TITLE
release v2.1.1

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,12 @@
+* 2.1.0~
+
+    * fix: always trim the name of folder [(#314)](https://github.com/tangcent/easy-yapi/pull/314)
+    
+    * support param.required for methodDoc [(#315)](https://github.com/tangcent/easy-yapi/pull/315)
+    
+    * opti: support `setter` for `toJson(5)` [(#318)](https://github.com/tangcent/easy-yapi/pull/318)
+    
+    * opti: use raw as body and use unbox for query/form [(#320)](https://github.com/tangcent/easy-yapi/pull/320)
 
 * 2.0.0~
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.1.0.183.0'
+version '2.1.1.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.1.0.183.0
+plugin_version=2.1.1.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,20 +1,22 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.0">v2.1.0.183.0(2021-01-10)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.1">v2.1.1.183.0(2021-01-25)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
+<ul>fix:
+    <li> fix: always trim the name of folder <a
+            href="https://github.com/tangcent/easy-yapi/pull/314">(#314)</a>
+    </li>
+</ul>
 <ul>enhancement:
-    <li> opti: support org.springframework.lang.NonNull by recommend <a
-            href="https://github.com/tangcent/easy-yapi/pull/302">(#302)</a>
+    <li> fix: always trim the name of folder <a
+            href="https://github.com/tangcent/easy-yapi/pull/314">(#314)</a>
     </li>
-
-    <li> opti: ignore org.springframework.validation.BindingResult by recommend <a
-            href="https://github.com/tangcent/easy-yapi/pull/303">(#303)</a>
+    <li> support param.required for methodDoc <a
+            href="https://github.com/tangcent/easy-yapi/pull/315">(#315)</a>
     </li>
-
-    <li> opti: support param.before&param.after for methodDoc <a
-            href="https://github.com/tangcent/easy-yapi/pull/307">(#307)</a>
+    <li> opti: support `setter` for `toJson(5)` <a
+            href="https://github.com/tangcent/easy-yapi/pull/318">(#318)</a>
     </li>
-
-    <li> opti: preview recommendConfig with separator line <a
-            href="https://github.com/tangcent/easy-yapi/pull/309">(#309)</a>
+    <li> opti: use raw as body and use unbox for query/form <a
+            href="https://github.com/tangcent/easy-yapi/pull/320">(#320)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.1.0.183.0</version>
+    <version>2.1.1.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: always trim the name of folder [(#314)](https://github.com/tangcent/easy-yapi/pull/314)
    
* support param.required for methodDoc [(#315)](https://github.com/tangcent/easy-yapi/pull/315)
    
* opti: support `setter` for `toJson(5)` [(#318)](https://github.com/tangcent/easy-yapi/pull/318)
    
* opti: use raw as body and use unbox for query/form [(#320)](https://github.com/tangcent/easy-yapi/pull/320)
