### PR TITLE
fix：make yapi params ordered

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiFormatter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiFormatter.kt
@@ -139,10 +139,10 @@ open class YapiFormatter {
     private fun parseParamsBySchema(params: MutableList<Param>?, rootDesc: String?): String? {
         if (params == null) return null
 
-        val result: HashMap<String, Any?> = HashMap()
+        val result: HashMap<String, Any?> = LinkedHashMap()
 
         result["type"] = "object"
-        val properties: HashMap<String, Any?> = HashMap()
+        val properties: HashMap<String, Any?> = LinkedHashMap()
         var requireds: LinkedList<String>? = null
         for (param in params) {
 


### PR DESCRIPTION
修复生成的yapi文档参数顺序错乱问题