### PR TITLE
release v2.1.3

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -14,6 +14,12 @@
     
     * opti: log for method infer [(#325)](https://github.com/tangcent/easy-yapi/pull/325)
     
+    * opti: support spring.ui by recommend [(330)](https://github.com/tangcent/easy-yapi/pull/330)
+    
+    * opti: use `setPragma` instead of `setBusyTimeout` [(333)](https://github.com/tangcent/easy-yapi/pull/333)
+    
+    * opti: refactor ApiDashboard [(335)](https://github.com/tangcent/easy-yapi/pull/335)
+
 * 2.0.0~
 
     * feat: support rule util `session` [(#273)](https://github.com/tangcent/easy-yapi/pull/273)

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.1.2.183.0'
+version '2.1.3.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.1.2.183.0
+plugin_version=2.1.3.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,17 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.2">v2.1.2.183.0(2021-01-30)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.3">v2.1.3.183.0(2021-02-05)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
-<ul>fix:
-    <li> fix: resolve on-demand import <a
-            href="https://github.com/Earth-1610/intellij-kotlin/pull/84">(#84)</a>
-    </li>
-</ul>
 <ul>enhancement:
-    <li> opti: import default packages for `kotlin`&`scala` <a
-            href="https://github.com/Earth-1610/intellij-kotlin/pull/85">(#85)</a>
+    <li> opti: support spring.ui by recommend <a
+            href="https://github.com/tangcent/easy-yapi/pull/330">(#330)</a>
     </li>
 
-    <li> opti: log for method infer <a
-            href="https://github.com/tangcent/easy-yapi/pull/325">(#325)</a>
+    <li> opti: use `setPragma` instead of `setBusyTimeout` <a
+            href="https://github.com/tangcent/easy-yapi/pull/333">(#333)</a>
+    </li>
+
+    <li> opti: refactor ApiDashboard <a
+            href="https://github.com/tangcent/easy-yapi/pull/335">(#335)</a>
     </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.1.2.183.0</version>
+    <version>2.1.3.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* opti: support spring.ui by recommend [(330)](https://github.com/tangcent/easy-yapi/pull/330)

* opti: use `setPragma` instead of `setBusyTimeout` [(333)](https://github.com/tangcent/easy-yapi/pull/333)

* opti: refactor ApiDashboard [(335)](https://github.com/tangcent/easy-yapi/pull/335)
