### PR TITLE
opti: support `url.cache.expire`

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/SuvApiExportDialog.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/SuvApiExportDialog.kt
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.ui.components.JBCheckBox
 import com.itangcent.common.logger.traceError
+import com.itangcent.common.utils.GsonUtils
 import com.itangcent.common.utils.notNullOrEmpty
 import com.itangcent.idea.icons.EasyIcons
 import com.itangcent.idea.icons.iconOnly
@@ -173,7 +174,7 @@ class SuvApiExportDialog : JDialog() {
 
     private fun onOK() {
         val selectedChannel = this.channelComboBox!!.selectedItem
-        val selectedApis = psiClassHelper!!.copy(this.apiList!!.selectedValuesList!!) as List<*>
+        val selectedApis = GsonUtils.copy(this.apiList!!.selectedValuesList!!) as List<*>
         actionContext!!.runAsync {
             try {
                 this.apisHandle!!(selectedChannel, selectedApis)
@@ -184,7 +185,7 @@ class SuvApiExportDialog : JDialog() {
                 actionContext!!.unHold()
             }
         }
-        PropertiesComponent.getInstance().setValue(LAST_USED_CHANNEL, selectedChannel.toString())
+        PropertiesComponent.getInstance().setValue(LAST_USED_CHANNEL, selectedChannel?.toString())
         onCancel(false)
     }
 

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/json/Json5Formatter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/json/Json5Formatter.kt
@@ -17,6 +17,7 @@ class Json5Formatter : JsonFormatter {
         return sb.toString()
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun format(obj: Any?, deep: Int, end: Boolean, desc: String?, sb: StringBuilder) {
         when (obj) {
             null -> {


### PR DESCRIPTION
set the cache time of content of URL:
e.g.
`url.cache.expire=1d12h`
The available time unit and conversion:
`1d`=`1day`=`24hours`
`1h`=`1hour`=`60minutes`
`1m`=`1minute`=`60seconds`
`1s`=`1second`

---

ref: #345