### PR TITLE
release v2.1.5-rc

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -24,6 +24,14 @@
     
     * opti: support built-in config [(#341)](https://github.com/tangcent/easy-yapi/pull/341)
 
+    * opti: `properties.additional` support url [(#345)](https://github.com/tangcent/easy-yapi/pull/345)
+    
+    * opti: support `param.doc` for export methodDoc [(#347)](https://github.com/tangcent/easy-yapi/pull/347)
+    
+    * fix:change the action name from Debug to ScriptExecutor [(#348)](https://github.com/tangcent/easy-yapi/pull/348)
+    
+    * opti: support `url.cache.expire` [(#349)](https://github.com/tangcent/easy-yapi/pull/349)
+
 * 2.0.0~
 
     * feat: support rule util `session` [(#273)](https://github.com/tangcent/easy-yapi/pull/273)

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.1.4.183.0'
+version '2.1.5.183.0-rc'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.1.4.183.0
+plugin_version=2.1.5.183.0-rc
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,13 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.4">v2.1.4.183.0(2021-02-19)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.5-rc">v2.1.5.183.0-rc(2021-02-25)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-    <li> opti: support login mode <a
-            href="https://github.com/tangcent/easy-yapi/pull/340">(#340)</a>
+    <li> opti: `properties.additional` support url <a
+            href="https://github.com/tangcent/easy-yapi/pull/345">(#345)</a>
     </li>
-
-    <li> opti: support built-in config <a
-            href="https://github.com/tangcent/easy-yapi/pull/341">(#341)</a>
+    <li> opti: support `param.doc` for export methodDoc <a
+            href="https://github.com/tangcent/easy-yapi/pull/347">(#347)</a>
     </li>
-
+    <li> opti: support `url.cache.expire` <a
+            href="https://github.com/tangcent/easy-yapi/pull/349">(#349)</a>
+    </li>
+</ul>
+<ul>fix:
+    <li> fix:change the action name from Debug to ScriptExecutor <a
+            href="https://github.com/tangcent/easy-yapi/pull/348">(#348)</a>
+    </li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.1.4.183.0</version>
+    <version>2.1.5.183.0-rc</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* opti: `properties.additional` support url [(#345)](https://github.com/tangcent/easy-yapi/pull/345)

* opti: support `param.doc` for export methodDoc [(#347)](https://github.com/tangcent/easy-yapi/pull/347)

* fix:change the action name from Debug to ScriptExecutor [(#348)](https://github.com/tangcent/easy-yapi/pull/348)

* opti: support `url.cache.expire` [(#349)](https://github.com/tangcent/easy-yapi/pull/349)
