### PR TITLE
release v2.1.5

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -31,7 +31,11 @@
     * fix:change the action name from Debug to ScriptExecutor [(#348)](https://github.com/tangcent/easy-yapi/pull/348)
     
     * opti: support `url.cache.expire` [(#349)](https://github.com/tangcent/easy-yapi/pull/349)
-
+    
+    * opti: add recommend third config [(#351)](https://github.com/tangcent/easy-yapi/pull/351)
+    
+    * opti: show default built-in config in setting [(#353)](https://github.com/tangcent/easy-yapi/pull/353)
+    
 * 2.0.0~
 
     * feat: support rule util `session` [(#273)](https://github.com/tangcent/easy-yapi/pull/273)

--- a/build.gradle
+++ b/build.gradle
@@ -1,2 +1,2 @@
 group 'com.itangcent'
-version '2.1.5.183.0-rc'
+version '2.1.5.183.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.1.5.183.0-rc
+plugin_version=2.1.5.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.5-rc">v2.1.5.183.0-rc(2021-02-25)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.5">v2.1.5.183.0(2021-02-28)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
@@ -10,6 +10,12 @@
     </li>
     <li> opti: support `url.cache.expire` <a
             href="https://github.com/tangcent/easy-yapi/pull/349">(#349)</a>
+    </li>
+    <li> opti: add recommend third config <a
+            href="https://github.com/tangcent/easy-yapi/pull/351">(#351)</a>
+    </li>
+    <li> opti: show default built-in config in setting <a
+            href="https://github.com/tangcent/easy-yapi/pull/353">(#353)</a>
     </li>
 </ul>
 <ul>fix:

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.1.5.183.0-rc</version>
+    <version>2.1.5.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* opti: `properties.additional` support url [(#345)](https://github.com/tangcent/easy-yapi/pull/345)

* opti: support `param.doc` for export methodDoc [(#347)](https://github.com/tangcent/easy-yapi/pull/347)

* fix:change the action name from Debug to ScriptExecutor [(#348)](https://github.com/tangcent/easy-yapi/pull/348)

* opti: support `url.cache.expire` [(#349)](https://github.com/tangcent/easy-yapi/pull/349)

* opti: add recommend third config [(#351)](https://github.com/tangcent/easy-yapi/pull/351)

* opti: show default built-in config in setting [(#353)](https://github.com/tangcent/easy-yapi/pull/353)
