### PR TITLE
fix: bind `settings.builtInConfig` as nullable

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/dialog/EasyApiSettingGUI.kt
@@ -284,10 +284,10 @@ class EasyApiSettingGUI {
                 }
 
         autoComputer.bind(this.builtInConfigTextArea!!)
-                .with<String>(this, "settings.builtInConfig")
+                .with<String?>(this, "settings.builtInConfig")
                 .eval { it.takeIf { it.notNullOrBlank() } ?: DEFAULT_BUILT_IN_CONFIG }
 
-        autoComputer.bind<String>(this, "settings.builtInConfig")
+        autoComputer.bind<String?>(this, "settings.builtInConfig")
                 .with(builtInConfigTextArea!!)
                 .eval { it.takeIf { it != DEFAULT_BUILT_IN_CONFIG } ?: "" }
 


### PR DESCRIPTION
fix #357