### PR TITLE
release v2.1.8

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,7 @@
+* 2.1.8
+
+	* fix: use `asKV` instead of `as KV<>` [(#364)](https://github.com/tangcent/easy-yapi/pull/364)
+
 * 2.1.0~
 
     * fix: always trim the name of folder [(#314)](https://github.com/tangcent/easy-yapi/pull/314)

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.nio.charset.StandardCharsets
 
 group 'com.itangcent'
-version '2.1.6.183.0'
+version '2.1.8.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 org.gradle.workers.max=8
 idea_version=2017.3.5
 plugin_name=EasyYapi
-plugin_version=2.1.6.183.0
+plugin_version=2.1.8.183.0
 
 descriptionFile=parts/pluginDescription.html
 changesFile=parts/pluginChanges.html

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,28 +1,8 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.6">v2.1.6.183.0(2021-03-03)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.1.8">v2.1.8.183.0(2021-03-07)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
-<ul>enhancement:
-    <li> opti: `properties.additional` support url <a
-            href="https://github.com/tangcent/easy-yapi/pull/345">(#345)</a>
-    </li>
-    <li> opti: support `param.doc` for export methodDoc <a
-            href="https://github.com/tangcent/easy-yapi/pull/347">(#347)</a>
-    </li>
-    <li> opti: support `url.cache.expire` <a
-            href="https://github.com/tangcent/easy-yapi/pull/349">(#349)</a>
-    </li>
-    <li> opti: add recommend third config <a
-            href="https://github.com/tangcent/easy-yapi/pull/351">(#351)</a>
-    </li>
-    <li> opti: show default built-in config in setting <a
-            href="https://github.com/tangcent/easy-yapi/pull/353">(#353)</a>
-    </li>
-</ul>
 <ul>fix:
-    <li> fix:change the action name from Debug to ScriptExecutor <a
-            href="https://github.com/tangcent/easy-yapi/pull/348">(#348)</a>
-    </li>
-    <li> fix: bind `settings.builtInConfig` as nullable <a
-            href="https://github.com/tangcent/easy-yapi/pull/358">(#358)</a>
-    </li>
+	<li> fix: use `asKV` instead of `as KV<>` <a
+			href="https://github.com/tangcent/easy-yapi/pull/364">(#364)</a>
+	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.1.6.183.0</version>
+    <version>2.1.8.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: use `asKV` instead of `as KV<>` [(#364)](https://github.com/tangcent/easy-yapi/pull/364)
