### PR TITLE
feat: [methodDoc-yapi] parse params as query for `GET`

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/DefaultMethodDocClassExporter.kt
@@ -240,7 +240,7 @@ open class DefaultMethodDocClassExporter : ClassExporter, Worker {
                             }
 
                             override fun linkToType(plainText: String, linkType: PsiType): String? {
-                                return jvmClassHelper!!.resolveClassInType(linkType)?.let {
+                                return jvmClassHelper.resolveClassInType(linkType)?.let {
                                     linkResolver!!.linkToClass(it)
                                 }
                             }


### PR DESCRIPTION
- for `GET`: parse params as query
- for others: parse params as json body for multi-level display parameters