### PR TITLE
release v2.2.6

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,31 @@
+* 2.2.6
+
+	* fix: AbstractEasyApiConfigurable checkUI after createComponent [(#579)](https://github.com/tangcent/easy-yapi/pull/579)
+
+	* feat: update gui [(#578)](https://github.com/tangcent/easy-yapi/pull/578)
+
+	* fix: [curl] escape [&\] [(#577)](https://github.com/tangcent/easy-yapi/pull/577)
+
+	* test: add test case of YapiApiExporter [(#576)](https://github.com/tangcent/easy-yapi/pull/576)
+
+	* feat: support export apis to specified postman collection [(#575)](https://github.com/tangcent/easy-yapi/pull/575)
+
+	* feat: save yapi tokens in project scope [(#572)](https://github.com/tangcent/easy-yapi/pull/572)
+
+	* feat: show workspace with type [(#571)](https://github.com/tangcent/easy-yapi/pull/571)
+
+	* test: update CurlExporterTest [(#570)](https://github.com/tangcent/easy-yapi/pull/570)
+
+	* feat: support copy curl command from ApiDashBoard(YapiDashBoard) [(#569)](https://github.com/tangcent/easy-yapi/pull/569)
+
+	* fix: resolve LazilyParsedNumber as Integer [(#568)](https://github.com/tangcent/easy-yapi/pull/568)
+
+	* feat: add host to cache in exporting curl command [(#567)](https://github.com/tangcent/easy-yapi/pull/567)
+
+	* feat: select workspace by comboBox [(#566)](https://github.com/tangcent/easy-yapi/pull/566)
+
+	* feat: support export requests as curl command [(#565)](https://github.com/tangcent/easy-yapi/pull/565)
+
 * 2.2.5
 
 	* chore: add test case of PostmanApiHelper [(#562)](https://github.com/tangcent/easy-yapi/pull/562)

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,31 +1,40 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.6">v2.2.6.183.0(2021-08-14)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.6">v2.2.6.183.0(2021-09-05)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: disable [sync] for the node which is not loaded <a
-			href="https://github.com/tangcent/easy-yapi/pull/560">(#560)</a>
+	<li> feat: update gui <a
+			href="https://github.com/tangcent/easy-yapi/pull/578">(#578)</a>
 	</li>
-	<li> feat: optimize loading of postman collections <a
-			href="https://github.com/tangcent/easy-yapi/pull/557">(#557)</a>
+	<li> feat: support export apis to specified postman collection <a
+			href="https://github.com/tangcent/easy-yapi/pull/575">(#575)</a>
 	</li>
-	<li> feat: Support export to postman customize workspace <a
-			href="https://github.com/tangcent/easy-yapi/pull/524">(#524)</a>
+	<li> feat: save yapi tokens in project scope <a
+			href="https://github.com/tangcent/easy-yapi/pull/572">(#572)</a>
 	</li>
-	<li> feat: add default keyboard-shortcut of ApiCallAction <a
-			href="https://github.com/tangcent/easy-yapi/pull/553">(#553)</a>
+	<li> feat: show workspace with type <a
+			href="https://github.com/tangcent/easy-yapi/pull/571">(#571)</a>
 	</li>
-	<li> feat: trust [localhost]&[127.0.0.1] by default <a
-			href="https://github.com/tangcent/easy-yapi/pull/552">(#552)</a>
+	<li> feat: support copy curl command from ApiDashBoard(YapiDashBoard) <a
+			href="https://github.com/tangcent/easy-yapi/pull/569">(#569)</a>
 	</li>
-	<li> feat: keep changes in ApiCallDialog <a
-			href="https://github.com/tangcent/easy-yapi/pull/551">(#551)</a>
+	<li> feat: add the host to cache in exporting curl command <a
+			href="https://github.com/tangcent/easy-yapi/pull/567">(#567)</a>
 	</li>
-	<li> feat: populate default value or demo as field value <a
-			href="https://github.com/tangcent/easy-yapi/pull/548">(#548)</a>
+	<li> feat: select workspace by comboBox <a
+			href="https://github.com/tangcent/easy-yapi/pull/566">(#566)</a>
+	</li>
+	<li> feat: support export requests as curl command <a
+			href="https://github.com/tangcent/easy-yapi/pull/565">(#565)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: use "" instead of null in format request headers <a
-			href="https://github.com/tangcent/easy-yapi/pull/547">(#547)</a>
+	<li> fix: AbstractEasyApiConfigurable checkUI after createComponent <a
+			href="https://github.com/tangcent/easy-yapi/pull/579">(#579)</a>
+	</li>
+	<li> fix: [curl] escape [&\] <a
+			href="https://github.com/tangcent/easy-yapi/pull/577">(#577)</a>
+	</li>
+	<li> fix: resolve LazilyParsedNumber as Integer <a
+			href="https://github.com/tangcent/easy-yapi/pull/568">(#568)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
     <category>Web</category>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-<!--    <idea-version since-build="183.0"/>-->
+    <!--<idea-version since-build="183.0"/>-->
 
     <!--for compatible-->
     <!--<idea-version since-build="173.0" until-build="183.0"/>-->


### PR DESCRIPTION

* fix: AbstractEasyApiConfigurable checkUI after createComponent [(#579)](https://github.com/tangcent/easy-yapi/pull/579)

* feat: update gui [(#578)](https://github.com/tangcent/easy-yapi/pull/578)

* fix: [curl] escape [&\] [(#577)](https://github.com/tangcent/easy-yapi/pull/577)

* test: add test case of YapiApiExporter [(#576)](https://github.com/tangcent/easy-yapi/pull/576)

* feat: support export apis to specified postman collection [(#575)](https://github.com/tangcent/easy-yapi/pull/575)

* feat: save yapi tokens in project scope [(#572)](https://github.com/tangcent/easy-yapi/pull/572)

* feat: show workspace with type [(#571)](https://github.com/tangcent/easy-yapi/pull/571)

* test: update CurlExporterTest [(#570)](https://github.com/tangcent/easy-yapi/pull/570)

* feat: support copy curl command from ApiDashBoard(YapiDashBoard) [(#569)](https://github.com/tangcent/easy-yapi/pull/569)

* fix: resolve LazilyParsedNumber as Integer [(#568)](https://github.com/tangcent/easy-yapi/pull/568)

* feat: add host to cache in exporting curl command [(#567)](https://github.com/tangcent/easy-yapi/pull/567)

* feat: select workspace by comboBox [(#566)](https://github.com/tangcent/easy-yapi/pull/566)

* feat: support export requests as curl command [(#565)](https://github.com/tangcent/easy-yapi/pull/565)
