### PR TITLE
release v2.2.8

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,23 @@
+* 2.2.8
+
+	* feat: new rule `field.advanced` [(#605)](https://github.com/tangcent/easy-yapi/pull/605)
+
+	* fix: resolve Object as {} [(#603)](https://github.com/tangcent/easy-yapi/pull/603)
+
+	* chore: fix action text [(#601)](https://github.com/tangcent/easy-yapi/pull/601)
+
+	* feat: change action groups [(#600)](https://github.com/tangcent/easy-yapi/pull/600)
+
+	* feat: recommend configs of Jackson JsonNaming(namingStrategy) [(#595)](https://github.com/tangcent/easy-yapi/pull/595)
+
+	* test: add test case of RecommendConfigReader [(#591)](https://github.com/tangcent/easy-yapi/pull/591)
+
+	* test: add test case for ProjectHelperTest [(#589)](https://github.com/tangcent/easy-yapi/pull/589)
+
+	* chore: ignore `*Dialog`&`*Configurable`&`*Action.kt` for codecov [(#588)](https://github.com/tangcent/easy-yapi/pull/588)
+
+	* chore: ignore `*Dialog`&`*Configurable`&`*Action.kt` for codecov [(#587)](https://github.com/tangcent/easy-yapi/pull/587)
+
 * 2.2.7
 
 	* feat: `method&field` support  containingClass&defineClass [(#585)](https://github.com/tangcent/easy-yapi/pull/585)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.2.7.183.0'
+version '2.2.8.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.2.7.183.0
+plugin_version=2.2.8.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.7">v2.2.7.183.0(2021-09-12)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.8">v2.2.8.183.0(2021-09-27)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: `method&field` support  containingClass&defineClass <a
-			href="https://github.com/tangcent/easy-yapi/pull/585">(#585)</a>
+	<li> feat: new rule `field.advanced` <a
+			href="https://github.com/tangcent/easy-yapi/pull/605">(#605)</a>
 	</li>
-	<li> feat: new recommend config to support [not ignore `static final` field] <a
-			href="https://github.com/tangcent/easy-yapi/pull/583">(#583)</a>
+	<li> feat: change action groups <a
+			href="https://github.com/tangcent/easy-yapi/pull/600">(#600)</a>
+	</li>
+	<li> feat: recommend configs of Jackson JsonNaming(namingStrategy) <a
+			href="https://github.com/tangcent/easy-yapi/pull/595">(#595)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: apply setting not work <a
-			href="https://github.com/tangcent/easy-yapi/pull/582">(#582)</a>
+	<li> fix: resolve Object as {} <a
+			href="https://github.com/tangcent/easy-yapi/pull/603">(#603)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.2.7.183.0</version>
+    <version>2.2.8.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: new rule `field.advanced` [(#605)](https://github.com/tangcent/easy-yapi/pull/605)

* fix: resolve Object as {} [(#603)](https://github.com/tangcent/easy-yapi/pull/603)

* chore: fix action text [(#601)](https://github.com/tangcent/easy-yapi/pull/601)

* feat: change action groups [(#600)](https://github.com/tangcent/easy-yapi/pull/600)

* feat: recommend configs of Jackson JsonNaming(namingStrategy) [(#595)](https://github.com/tangcent/easy-yapi/pull/595)

* test: add test case of RecommendConfigReader [(#591)](https://github.com/tangcent/easy-yapi/pull/591)

* test: add test case for ProjectHelperTest [(#589)](https://github.com/tangcent/easy-yapi/pull/589)

* chore: ignore `*Dialog`&`*Configurable`&`*Action.kt` for codecov [(#588)](https://github.com/tangcent/easy-yapi/pull/588)

* chore: ignore `*Dialog`&`*Configurable`&`*Action.kt` for codecov [(#587)](https://github.com/tangcent/easy-yapi/pull/587)
