### PR TITLE
release v2.2.9

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.2.9
+
+	* fix: fix regex rule [(#620)](https://github.com/tangcent/easy-yapi/pull/620)
+
+	* feat: new event rules [(#616)](https://github.com/tangcent/easy-yapi/pull/616)
+
+	* feat: [ScriptExecutor] explicit class [(#615)](https://github.com/tangcent/easy-yapi/pull/615)
+
+	* feat: mock field of  java_date_types as datetime [(#610)](https://github.com/tangcent/easy-yapi/pull/610)
+
+	* feat: support jackson-JsonFormat & spring-DateTimeFormat [(#609)](https://github.com/tangcent/easy-yapi/pull/609)
+
 * 2.2.8
 
 	* feat: new rule `field.advanced` [(#605)](https://github.com/tangcent/easy-yapi/pull/605)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.2.8.183.0'
+version '2.2.9.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.2.8.183.0
+plugin_version=2.2.9.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,19 +1,22 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.8">v2.2.8.183.0(2021-09-27)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.9">v2.2.9.183.0(2021-10-17)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: new rule `field.advanced` <a
-			href="https://github.com/tangcent/easy-yapi/pull/605">(#605)</a>
+	<li> feat: new event rules <a
+			href="https://github.com/tangcent/easy-yapi/pull/616">(#616)</a>
 	</li>
-	<li> feat: change action groups <a
-			href="https://github.com/tangcent/easy-yapi/pull/600">(#600)</a>
+	<li> feat: [ScriptExecutor] explicit class <a
+			href="https://github.com/tangcent/easy-yapi/pull/615">(#615)</a>
 	</li>
-	<li> feat: recommend configs of Jackson JsonNaming(namingStrategy) <a
-			href="https://github.com/tangcent/easy-yapi/pull/595">(#595)</a>
+	<li> feat: mock field of  java_date_types as datetime <a
+			href="https://github.com/tangcent/easy-yapi/pull/610">(#610)</a>
+	</li>
+	<li> feat: support jackson-JsonFormat & spring-DateTimeFormat <a
+			href="https://github.com/tangcent/easy-yapi/pull/609">(#609)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: resolve Object as {} <a
-			href="https://github.com/tangcent/easy-yapi/pull/603">(#603)</a>
+	<li> fix: fix regex rule <a
+			href="https://github.com/tangcent/easy-yapi/pull/620">(#620)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.2.8.183.0</version>
+    <version>2.2.9.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: fix regex rule [(#620)](https://github.com/tangcent/easy-yapi/pull/620)

* feat: new event rules [(#616)](https://github.com/tangcent/easy-yapi/pull/616)

* feat: [ScriptExecutor] explicit class [(#615)](https://github.com/tangcent/easy-yapi/pull/615)

* feat: mock field of  java_date_types as datetime [(#610)](https://github.com/tangcent/easy-yapi/pull/610)

* feat: support jackson-JsonFormat & spring-DateTimeFormat [(#609)](https://github.com/tangcent/easy-yapi/pull/609)
