### PR TITLE
fix: remove redundant table header in markdown

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/markdown/MarkdownFormatter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/markdown/MarkdownFormatter.kt
@@ -281,7 +281,7 @@ class MarkdownFormatter {
                 handle("${hN(deep + 1)} RESPONSE\n\n")
                 handle("**Header：**\n\n")
                 handle("| name  |  value  |  required  | desc  |\n")
-                handle("| ------------ | ------------ | ------------ | ------------ | ------------ |\n")
+                handle("| ------------ | ------------ | ------------ | ------------ |\n")
                 response.headers!!.forEach {
                     handle(
                         "| ${it.name} | ${it.value ?: ""} | ${

--- a/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.DirectorySpringMarkdownApiExporterTest.txt
+++ b/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.DirectorySpringMarkdownApiExporterTest.txt
@@ -33,7 +33,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -81,7 +81,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -122,7 +122,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -163,7 +163,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -204,7 +204,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -285,7 +285,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -331,7 +331,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -378,7 +378,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -425,7 +425,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -472,7 +472,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -520,7 +520,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -568,7 +568,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -627,7 +627,7 @@
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -694,7 +694,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -741,7 +741,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -830,7 +830,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -905,7 +905,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**

--- a/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.SpringMarkdownApiExporterTest.txt
+++ b/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.SpringMarkdownApiExporterTest.txt
@@ -23,7 +23,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -70,7 +70,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -159,7 +159,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -234,7 +234,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**

--- a/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.SpringUltimateMarkdownApiExporterTest.txt
+++ b/idea-plugin/src/test/resources/result/com.itangcent.idea.plugin.api.export.markdown.MarkdownApiExporterTest.SpringUltimateMarkdownApiExporterTest.txt
@@ -23,7 +23,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -70,7 +70,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -159,7 +159,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**
@@ -234,7 +234,7 @@ not update anything
 **Header：**
 
 | name  |  value  |  required  | desc  |
-| ------------ | ------------ | ------------ | ------------ | ------------ |
+| ------------ | ------------ | ------------ | ------------ |
 | content-type | application/json;charset=UTF-8 | NO |   |
 
 **Body：**


### PR DESCRIPTION
fix #650