### PR TITLE
release v2.3.0

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,19 @@
+* 2.3.0
+
+	* feat: recommend config for `Jackson-JsonUnwrapped` [(#658)](https://github.com/tangcent/easy-yapi/pull/658)
+
+	* fix: remove redundant table header in markdown [(#654)](https://github.com/tangcent/easy-yapi/pull/654)
+
+	* feat: new rule `json.additional.field` [(#652)](https://github.com/tangcent/easy-yapi/pull/652)
+
+	* fix: read desc of class before compute by rule [(#649)](https://github.com/tangcent/easy-yapi/pull/649)
+
+	* feat: support quarkus [(#648)](https://github.com/tangcent/easy-yapi/pull/648)
+
+	* feat: support spring-feign [(#643)](https://github.com/tangcent/easy-yapi/pull/643)
+
+	* feat: support Condition [(#641)](https://github.com/tangcent/easy-yapi/pull/641)
+
 * 2.2.9
 
 	* fix: fix regex rule [(#620)](https://github.com/tangcent/easy-yapi/pull/620)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.2.9.183.0'
+version '2.3.0.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.2.9.183.0
+plugin_version=2.3.0.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,22 +1,28 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.2.9">v2.2.9.183.0(2021-10-17)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.0">v2.3.0.183.0(2021-11-20)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: new event rules <a
-			href="https://github.com/tangcent/easy-yapi/pull/616">(#616)</a>
+	<li> feat: recommend config for `Jackson-JsonUnwrapped` <a
+			href="https://github.com/tangcent/easy-yapi/pull/658">(#658)</a>
 	</li>
-	<li> feat: [ScriptExecutor] explicit class <a
-			href="https://github.com/tangcent/easy-yapi/pull/615">(#615)</a>
+	<li> feat: new rule `json.additional.field` <a
+			href="https://github.com/tangcent/easy-yapi/pull/652">(#652)</a>
 	</li>
-	<li> feat: mock field of  java_date_types as datetime <a
-			href="https://github.com/tangcent/easy-yapi/pull/610">(#610)</a>
+	<li> feat: support quarkus <a
+			href="https://github.com/tangcent/easy-yapi/pull/648">(#648)</a>
 	</li>
-	<li> feat: support jackson-JsonFormat & spring-DateTimeFormat <a
-			href="https://github.com/tangcent/easy-yapi/pull/609">(#609)</a>
+	<li> feat: support spring-feign <a
+			href="https://github.com/tangcent/easy-yapi/pull/643">(#643)</a>
+	</li>
+	<li> feat: support Condition <a
+			href="https://github.com/tangcent/easy-yapi/pull/641">(#641)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: fix regex rule <a
-			href="https://github.com/tangcent/easy-yapi/pull/620">(#620)</a>
+	<li> fix: remove redundant table header in markdown <a
+			href="https://github.com/tangcent/easy-yapi/pull/654">(#654)</a>
+	</li>
+	<li> fix: read desc of class before compute by rule <a
+			href="https://github.com/tangcent/easy-yapi/pull/649">(#649)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.2.9.183.0</version>
+    <version>2.3.0.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* feat: recommend config for `Jackson-JsonUnwrapped` [(#658)](https://github.com/tangcent/easy-yapi/pull/658)

* fix: remove redundant table header in markdown [(#654)](https://github.com/tangcent/easy-yapi/pull/654)

* feat: new rule `json.additional.field` [(#652)](https://github.com/tangcent/easy-yapi/pull/652)

* fix: read desc of class before compute by rule [(#649)](https://github.com/tangcent/easy-yapi/pull/649)

* feat: support quarkus [(#648)](https://github.com/tangcent/easy-yapi/pull/648)

* feat: support spring-feign [(#643)](https://github.com/tangcent/easy-yapi/pull/643)

* feat: support Condition [(#641)](https://github.com/tangcent/easy-yapi/pull/641)
