### PR TITLE
fix: remove usage of  ObjectTypeAdapter.FACTORY

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
@@ -51,8 +51,10 @@ object GsonExUtils {
         ) {
             factories = factories.getPropertyValue("list") ?: return
         }
-
-        (factories as MutableList<TypeAdapterFactory>).remove(ObjectTypeAdapter.FACTORY)
+        val objectTypeAdapterClassName = ObjectTypeAdapter::class.qualifiedName!!
+        (factories as MutableList<TypeAdapterFactory>).removeIf {
+            it::class.java.name.startsWith(objectTypeAdapterClassName)
+        }
     }
 
     fun toJson(bean: Any?): String {


### PR DESCRIPTION
### IntelliJ IDEA Ultimate IU-221.4501.1551 compatibility problem. 1 compatibility warning. 9 usages of deprecated API

EasyYapi 2.3.1.183.0 is binary incompatible with IntelliJ IDEA Ultimate IU-221.4501.155 due to the following problem
Field not found (1 problem)
```text
Access to unresolved field ObjectTypeAdapter.FACTORY (1 problem)
Method GsonExUtils.formatGson(Gson) contains a getstatic instruction referencing an unresolved field ObjectTypeAdapter.FACTORY. This can lead to NoSuchFieldError exception at runtime.
The field might have been declared in the super class: TypeAdapter
```