### PR TITLE
release v2.3.2

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,19 @@
+* 2.3.2
+
+	* feat: [generic] auto fix http method [(#697)](https://github.com/tangcent/easy-yapi/pull/697)
+
+	* feat: generic.spring.demo.config [(#696)](https://github.com/tangcent/easy-yapi/pull/696)
+
+	* chore: fix warnings [(#695)](https://github.com/tangcent/easy-yapi/pull/695)
+
+	* fix: use `any` instead of `forEach` to export api from superMethods [(#694)](https://github.com/tangcent/easy-yapi/pull/694)
+
+	* fix: remove usage of  ObjectTypeAdapter.FACTORY [(#693)](https://github.com/tangcent/easy-yapi/pull/693)
+
+	* feat: new Action FieldsToProperties [(#686)](https://github.com/tangcent/easy-yapi/pull/686)
+
+	* chore: update docs [(#680)](https://github.com/tangcent/easy-yapi/pull/680)
+
 * 2.3.1
 
 	* feat: support @RequestLine、@Headers、@Param、@Body [(#676)](https://github.com/tangcent/easy-yapi/pull/676)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.3.1.183.0'
+version '2.3.2.183.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.3.1.183.0
+plugin_version=2.3.2.183.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,31 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.1">v2.3.1.183.0(2021-12-26)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.2">v2.3.2.183.0(2022-02-27)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: support @RequestLine、@Headers、@Param、@Body <a
-			href="https://github.com/tangcent/easy-yapi/pull/676">(#676)</a>
+	<li> feat: [generic] auto fix http method <a
+			href="https://github.com/tangcent/easy-yapi/pull/697">(#697)</a>
 	</li>
-	<li> feat: try parse api info from super methods <a
-			href="https://github.com/tangcent/easy-yapi/pull/674">(#674)</a>
-	</li>
-	<li> feat: improve Settings UI <a
-			href="https://github.com/tangcent/easy-yapi/pull/672">(#672)</a>
-	</li>
-	<li> feat: [recommend] converter of reactivestreams.Publisher <a
-			href="https://github.com/tangcent/easy-yapi/pull/667">(#667)</a>
-	</li>
-	<li> feat: support custom annotation with Spring-RequestMapping <a
-			href="https://github.com/tangcent/easy-yapi/pull/663">(#663)</a>
-	</li>
-	<li> feat: convert [java.sql.Date]&[java.sql.Time] as java.lang.String <a
-			href="https://github.com/tangcent/easy-yapi/pull/662">(#662)</a>
+	<li> feat: new Action FieldsToProperties <a
+			href="https://github.com/tangcent/easy-yapi/pull/686">(#686)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: [json5] remove lead blank lines <a
-			href="https://github.com/tangcent/easy-yapi/pull/673">(#673)</a>
+	<li> fix: use `any` instead of `forEach` to export api from superMethods <a
+			href="https://github.com/tangcent/easy-yapi/pull/694">(#694)</a>
 	</li>
-	<li> fix: resolve multi-line root desc as block comments <a
-			href="https://github.com/tangcent/easy-yapi/pull/664">(#664)</a>
+	<li> fix: remove usage of  ObjectTypeAdapter.FACTORY <a
+			href="https://github.com/tangcent/easy-yapi/pull/693">(#693)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.3.1.183.0</version>
+    <version>2.3.2.183.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: [generic] auto fix http method [(#697)](https://github.com/tangcent/easy-yapi/pull/697)

* fix: use `any` instead of `forEach` to export api from superMethods [(#694)](https://github.com/tangcent/easy-yapi/pull/694)

* fix: remove usage of  ObjectTypeAdapter.FACTORY [(#693)](https://github.com/tangcent/easy-yapi/pull/693)

* feat: new Action FieldsToProperties [(#686)](https://github.com/tangcent/easy-yapi/pull/686)
