### PR TITLE
release v2.3.6

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.3.6
+
+	* chore: add Fastjson support [(#745)](https://github.com/tangcent/easy-yapi/pull/745)
+
+	* feat: init recommend config even if no module be switched [(#744)](https://github.com/tangcent/easy-yapi/pull/744)
+
+	* fix: set `readTimeout` for read resource by url [(#743)](https://github.com/tangcent/easy-yapi/pull/743)
+
+	* feat: new method for rule context `class` [(#739)](https://github.com/tangcent/easy-yapi/pull/739)
+
+	* feat: resolve RequestMapping from interfaces [(#738)](https://github.com/tangcent/easy-yapi/pull/738)
+
 * 2.3.5
 
 	* chore: update version of intellij-kotlin to 1.1.7 [(#731)](https://github.com/tangcent/easy-yapi/pull/731)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.3.5.191.0'
+version '2.3.6.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.3.5.191.0
+plugin_version=2.3.6.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,13 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.5">v2.3.5.191.0(2022-03-28)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.6">v2.3.6.191.0(2022-04-17)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: provide rules to customize tables in markdown <a
-			href="https://github.com/tangcent/easy-yapi/pull/724">(#724)</a>
+	<li> feat: init recommend config even if no module be switched <a
+			href="https://github.com/tangcent/easy-yapi/pull/744">(#744)</a>
+	</li>
+	<li> feat: new method for rule context `class` <a
+			href="https://github.com/tangcent/easy-yapi/pull/739">(#739)</a>
+	</li>
+	<li> feat: resolve RequestMapping from interfaces <a
+			href="https://github.com/tangcent/easy-yapi/pull/738">(#738)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: fix Writer <a
-			href="https://github.com/tangcent/easy-yapi/pull/726">(#726)</a>
+	<li> fix: set `readTimeout` for read resource by url <a
+			href="https://github.com/tangcent/easy-yapi/pull/743">(#743)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.3.5.191.0</version>
+    <version>2.3.6.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* chore: add Fastjson support [(#745)](https://github.com/tangcent/easy-yapi/pull/745)

* feat: init recommend config even if no module be switched [(#744)](https://github.com/tangcent/easy-yapi/pull/744)

* fix: set `readTimeout` for read resource by url [(#743)](https://github.com/tangcent/easy-yapi/pull/743)

* feat: new method for rule context `class` [(#739)](https://github.com/tangcent/easy-yapi/pull/739)

* feat: resolve RequestMapping from interfaces [(#738)](https://github.com/tangcent/easy-yapi/pull/738)
