### PR TITLE
release v2.3.9

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,13 @@
+* 2.3.9
+
+	* fix: not use '0' as example [(#771)](https://github.com/tangcent/easy-yapi/pull/771)
+
+	* fix: fix resize of ApiCallDialog [(#770)](https://github.com/tangcent/easy-yapi/pull/770)
+
+	* fix: fix  rule `field.default.value` [(#765)](https://github.com/tangcent/easy-yapi/pull/765)
+
+	* feat: not require confirmation to export apis from directory [(#766)](https://github.com/tangcent/easy-yapi/pull/766)
+
 * 2.3.8
 
 	* feat: wrap script result [(#762)](https://github.com/tangcent/easy-yapi/pull/762)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.3.8.191.0'
+version '2.3.9.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.3.8.191.0
+plugin_version=2.3.9.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,19 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.8">v2.3.8.191.0(2022-05-15)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.3.9">v2.3.9.191.0(2022-05-30)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: wrap script result <a
-			href="https://github.com/tangcent/easy-yapi/pull/762">(#762)</a>
+	<li> feat: not require confirmation to export apis from directory <a
+			href="https://github.com/tangcent/easy-yapi/pull/766">(#766)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: refactor the thread model <a
-			href="https://github.com/tangcent/easy-yapi/pull/760">(#760)</a>
+	<li> fix: not use '0' as example <a
+			href="https://github.com/tangcent/easy-yapi/pull/771">(#771)</a>
 	</li>
-	<li> fix: interval sleep during parsing <a
-			href="https://github.com/tangcent/easy-yapi/pull/757">(#757)</a>
+	<li> fix: fix resize of ApiCallDialog <a
+			href="https://github.com/tangcent/easy-yapi/pull/770">(#770)</a>
+	</li>
+	<li> fix: fix  rule `field.default.value` <a
+			href="https://github.com/tangcent/easy-yapi/pull/765">(#765)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.3.8.191.0</version>
+    <version>2.3.9.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: not use '0' as example [(#771)](https://github.com/tangcent/easy-yapi/pull/771)

* fix: fix resize of ApiCallDialog [(#770)](https://github.com/tangcent/easy-yapi/pull/770)

* fix: fix  rule `field.default.value` [(#765)](https://github.com/tangcent/easy-yapi/pull/765)

* feat: not require confirmation to export apis from directory [(#766)](https://github.com/tangcent/easy-yapi/pull/766)
