### PR TITLE
release v2.4.5

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,11 @@
+* 2.4.5
+
+	* fix: set resolveMulti to first in javax.validation.config [(#821)](https://github.com/tangcent/easy-yapi/pull/821)
+
+	* feat: add an option to update or skip existed apis in yapi [(#817)](https://github.com/tangcent/easy-yapi/pull/817)
+
+	* feat: asks how to convert enum on the first use [(#813)](https://github.com/tangcent/easy-yapi/pull/813)
+
 * 2.4.4
 
 	* fix: resolve desc of return type [(#807)](https://github.com/tangcent/easy-yapi/pull/807)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.4.4.191.0'
+version '2.4.5.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.4.4.191.0
+plugin_version=2.4.5.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,11 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.4.4">v2.4.4.191.0(2022-07-31)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.4.5">v2.4.5.191.0(2022-08-24)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
-<ul>fix:
-	<li> fix: resolve desc of return type <a
-			href="https://github.com/tangcent/easy-yapi/pull/807">(#807)</a>
+<ul>enhancement:
+	<li> feat: add an option to update or skip existed apis in yapi <a
+			href="https://github.com/tangcent/easy-yapi/pull/817">(#817)</a>
 	</li>
-	<li> fix: support parse apis in several modules to one collection <a
-			href="https://github.com/tangcent/easy-yapi/pull/806">(#806)</a>
+	<li> feat: asks how to convert enum on the first use <a
+			href="https://github.com/tangcent/easy-yapi/pull/813">(#813)</a>
+	</li>
+</ul>
+<ul>fix:
+	<li> fix: set resolveMulti to first in javax.validation.config <a
+			href="https://github.com/tangcent/easy-yapi/pull/821">(#821)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.4.4.191.0</version>
+    <version>2.4.5.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: set resolveMulti to first in javax.validation.config [(#821)](https://github.com/tangcent/easy-yapi/pull/821)

* feat: add an option to update or skip existed apis in yapi [(#817)](https://github.com/tangcent/easy-yapi/pull/817)

* feat: asks how to convert enum on the first use [(#813)](https://github.com/tangcent/easy-yapi/pull/813)
