### PR TITLE
release v2.4.6

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.4.6
+
+	* amend: use :Log() instead of define [(#837)](https://github.com/tangcent/easy-yapi/pull/837)
+
+	* fix: parse FeignClient#path [(#835)](https://github.com/tangcent/easy-yapi/pull/835)
+
+	* feat: support export apis from actuator [(#834)](https://github.com/tangcent/easy-yapi/pull/834)
+
+	* fix: convert java.math.BigInteger to java.lang.Long [(#828)](https://github.com/tangcent/easy-yapi/pull/828)
+
+	* test: DefaultYapiApiHelperTest [(#824)](https://github.com/tangcent/easy-yapi/pull/824)
+
 * 2.4.5
 
 	* fix: set resolveMulti to first in javax.validation.config [(#821)](https://github.com/tangcent/easy-yapi/pull/821)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.4.5.191.0'
+version '2.4.6.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.4.5.191.0
+plugin_version=2.4.6.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.4.5">v2.4.5.191.0(2022-08-24)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.4.6">v2.4.6.191.0(2022-09-27)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: add an option to update or skip existed apis in yapi <a
-			href="https://github.com/tangcent/easy-yapi/pull/817">(#817)</a>
-	</li>
-	<li> feat: asks how to convert enum on the first use <a
-			href="https://github.com/tangcent/easy-yapi/pull/813">(#813)</a>
+	<li> feat: support export apis from actuator <a
+			href="https://github.com/tangcent/easy-yapi/pull/834">(#834)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: set resolveMulti to first in javax.validation.config <a
-			href="https://github.com/tangcent/easy-yapi/pull/821">(#821)</a>
+	<li> fix: parse FeignClient#path <a
+			href="https://github.com/tangcent/easy-yapi/pull/835">(#835)</a>
+	</li>
+	<li> fix: convert java.math.BigInteger to java.lang.Long <a
+			href="https://github.com/tangcent/easy-yapi/pull/828">(#828)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.4.5.191.0</version>
+    <version>2.4.6.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* amend: use :Log() instead of define [(#837)](https://github.com/tangcent/easy-yapi/pull/837)

* fix: parse FeignClient#path [(#835)](https://github.com/tangcent/easy-yapi/pull/835)

* feat: support export apis from actuator [(#834)](https://github.com/tangcent/easy-yapi/pull/834)

* fix: convert java.math.BigInteger to java.lang.Long [(#828)](https://github.com/tangcent/easy-yapi/pull/828)

* test: DefaultYapiApiHelperTest [(#824)](https://github.com/tangcent/easy-yapi/pull/824)
