### PR TITLE
release v2.5.1

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,13 @@
+* 2.5.1
+
+	* chore: polish ContextualPsiClassHelper [(#889)](https://github.com/tangcent/easy-yapi/pull/889)
+
+	* fix: support ConfigurationProperties("prefix") [(#888)](https://github.com/tangcent/easy-yapi/pull/888)
+
+	* fix: Gson no longer always parse number to double [(#885)](https://github.com/tangcent/easy-yapi/pull/885)
+
+	* chore: remove unnecessary log [(#881)](https://github.com/tangcent/easy-yapi/pull/881)
+
 * 2.5.0
 
 	* fix: check group with `javax.validation.groups.Default` [(#877)](https://github.com/tangcent/easy-yapi/pull/877)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.5.0.191.0'
+version '2.5.1.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.5.0.191.0
+plugin_version=2.5.1.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,8 +1,11 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.0">v2.5.0.191.0(2022-12-11)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.1">v2.5.1.191.0(2022-12-25)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>fix:
-	<li> fix: check group with `javax.validation.groups.Default` <a
-			href="https://github.com/tangcent/easy-yapi/pull/877">(#877)</a>
+	<li> fix: support ConfigurationProperties("prefix") <a
+			href="https://github.com/tangcent/easy-yapi/pull/888">(#888)</a>
+	</li>
+	<li> fix: Gson no longer always parse number to double <a
+			href="https://github.com/tangcent/easy-yapi/pull/885">(#885)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.5.0.191.0</version>
+    <version>2.5.1.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* chore: polish ContextualPsiClassHelper [(#889)](https://github.com/tangcent/easy-yapi/pull/889)

* fix: support ConfigurationProperties("prefix") [(#888)](https://github.com/tangcent/easy-yapi/pull/888)

* fix: Gson no longer always parse number to double [(#885)](https://github.com/tangcent/easy-yapi/pull/885)

* chore: remove unnecessary log [(#881)](https://github.com/tangcent/easy-yapi/pull/881)
