### PR TITLE
release v2.5.4

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,17 @@
+* 2.5.4
+
+	* feat: provide aliases for several rule tools [(#925)](https://github.com/tangcent/easy-yapi/pull/925)
+
+	* chore: update version of intellij-kotlin to 1.4.5 [(#924)](https://github.com/tangcent/easy-yapi/pull/924)
+
+	* fix: fix api response in postman [(#923)](https://github.com/tangcent/easy-yapi/pull/923)
+
+	* feat: new rule tool: runtime [(#922)](https://github.com/tangcent/easy-yapi/pull/922)
+
+	* feat: support jakarta.validation [(#918)](https://github.com/tangcent/easy-yapi/pull/918)
+
+	* feat: support export apis from groovy [(#912)](https://github.com/tangcent/easy-yapi/pull/912)
+
 * 2.5.3
 
 	* chore: update swagger config [(#904)](https://github.com/tangcent/easy-yapi/pull/904)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '2.5.3.191.0'
+version '2.5.4.191.0'
 
 @SuppressWarnings("GroovyAssignabilityCheck")
 static def majorVersion(version) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.5.3.191.0
+plugin_version=2.5.4.191.0
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 systemProp.file.encoding=UTF-8
 org.gradle.daemon=true

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,13 +1,22 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.3">v2.5.3.191.0(2023-01-16)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.4">v2.5.4.191.0(2023-02-27)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: new script method `class.toObject` <a
-			href="https://github.com/tangcent/easy-yapi/pull/903">(#903)</a>
+	<li> feat: provide aliases for several rule tools <a
+			href="https://github.com/tangcent/easy-yapi/pull/925">(#925)</a>
+	</li>
+	<li> feat: new rule tool: runtime <a
+			href="https://github.com/tangcent/easy-yapi/pull/922">(#922)</a>
+	</li>
+	<li> feat: support jakarta.validation <a
+			href="https://github.com/tangcent/easy-yapi/pull/918">(#918)</a>
+	</li>
+	<li> feat: support export apis from groovy <a
+			href="https://github.com/tangcent/easy-yapi/pull/912">(#912)</a>
 	</li>
 </ul>
 <ul>fix:
-	<li> fix: fix helper.resolveLink(s) <a
-			href="https://github.com/tangcent/easy-yapi/pull/900">(#900)</a>
+	<li> fix: fix api response in postman <a
+			href="https://github.com/tangcent/easy-yapi/pull/923">(#923)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.5.3.191.0</version>
+    <version>2.5.4.191.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: provide aliases for several rule tools [(#925)](https://github.com/tangcent/easy-yapi/pull/925)

* chore: update version of intellij-kotlin to 1.4.5 [(#924)](https://github.com/tangcent/easy-yapi/pull/924)

* fix: fix api response in postman [(#923)](https://github.com/tangcent/easy-yapi/pull/923)

* feat: new rule tool: runtime [(#922)](https://github.com/tangcent/easy-yapi/pull/922)

* feat: support jakarta.validation [(#918)](https://github.com/tangcent/easy-yapi/pull/918)

* feat: support export apis from groovy [(#912)](https://github.com/tangcent/easy-yapi/pull/912)
