### PR TITLE
release v2.5.7

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.5.7
+
+	* feat: output field.demo value to postman/markdown [(#958)](https://github.com/tangcent/easy-yapi/pull/958)
+
+	* chore: update version of intellij-kotlin to 1.5.0 [(#957)](https://github.com/tangcent/easy-yapi/pull/957)
+
+	* chore: polish SettingBinder [(#956)](https://github.com/tangcent/easy-yapi/pull/956)
+
+	* feat: read yapi token from config [(#955)](https://github.com/tangcent/easy-yapi/pull/955)
+
+	* fix: set _id back after save api to yapi success [(#952)](https://github.com/tangcent/easy-yapi/pull/952)
+
 * 2.5.6
 
 	* feat: add several icons to resources [(#947)](https://github.com/tangcent/easy-yapi/pull/947)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.5.6.212.0
+plugin_version=2.5.7.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,20 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.6">v2.5.6.212.0(2023-04-09)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.7">v2.5.7.212.0(2023-04-16)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: add several icons to resources <a
-			href="https://github.com/tangcent/easy-yapi/pull/947">(#947)</a>
+	<li> feat: output field.demo value to postman/markdown <a
+			href="https://github.com/tangcent/easy-yapi/pull/958">(#958)</a>
 	</li>
-	<li> feat: YapiApiHelper.copyApi support copy by module instead of token <a
-			href="https://github.com/tangcent/easy-yapi/pull/945">(#945)</a>
+	<li> feat: read yapi token from config <a
+			href="https://github.com/tangcent/easy-yapi/pull/955">(#955)</a>
 	</li>
-	<li> feat: new script method 'runtime.async' <a
-			href="https://github.com/tangcent/easy-yapi/pull/943">(#943)</a>
-	</li>
-	<li> feat: new method YapiApiHelper.copyApi <a
-			href="https://github.com/tangcent/easy-yapi/pull/941">(#941)</a>
-	</li>
-	<li> feat: new script methods for 'runtime' <a
-			href="https://github.com/tangcent/easy-yapi/pull/940">(#940)</a>
+</ul>
+<ul>fix:
+	<li> fix: set _id back after save api to yapi success <a
+			href="https://github.com/tangcent/easy-yapi/pull/952">(#952)</a>
 	</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.5.6.212.0</version>
+    <version>2.5.7.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: output field.demo value to postman/markdown [(#958)](https://github.com/tangcent/easy-yapi/pull/958)

* chore: update version of intellij-kotlin to 1.5.0 [(#957)](https://github.com/tangcent/easy-yapi/pull/957)

* chore: polish SettingBinder [(#956)](https://github.com/tangcent/easy-yapi/pull/956)

* feat: read yapi token from config [(#955)](https://github.com/tangcent/easy-yapi/pull/955)

* fix: set _id back after save api to yapi success [(#952)](https://github.com/tangcent/easy-yapi/pull/952)
