### PR TITLE
release v2.5.8

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,7 @@
+* 2.5.8
+
+	* amend: remove deprecated API usages [(#961)](https://github.com/tangcent/easy-yapi/pull/961)
+
 * 2.5.7
 
 	* feat: output field.demo value to postman/markdown [(#958)](https://github.com/tangcent/easy-yapi/pull/958)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.5.7.212.0
+plugin_version=2.5.8.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,16 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.7">v2.5.7.212.0(2023-04-16)</a>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.5.8">v2.5.8.212.0(2023-04-19)</a>
 <br/>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 <ul>enhancement:
-	<li> feat: output field.demo value to postman/markdown <a
-			href="https://github.com/tangcent/easy-yapi/pull/958">(#958)</a>
-	</li>
-	<li> feat: read yapi token from config <a
-			href="https://github.com/tangcent/easy-yapi/pull/955">(#955)</a>
-	</li>
+    <li> feat: output field.demo value to postman/markdown <a
+            href="https://github.com/tangcent/easy-yapi/pull/958">(#958)</a>
+    </li>
+    <li> feat: read yapi token from config <a
+            href="https://github.com/tangcent/easy-yapi/pull/955">(#955)</a>
+    </li>
 </ul>
 <ul>fix:
-	<li> fix: set _id back after save api to yapi success <a
-			href="https://github.com/tangcent/easy-yapi/pull/952">(#952)</a>
-	</li>
+    <li> fix: set _id back after save api to yapi success <a
+            href="https://github.com/tangcent/easy-yapi/pull/952">(#952)</a>
+    </li>
 </ul>

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/DefaultMethodInferHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/DefaultMethodInferHelper.kt
@@ -723,7 +723,7 @@ class DefaultMethodInferHelper : MethodInferHelper {
     private fun getSimpleFields(psiType: PsiType?, context: PsiElement): Any? {
         actionContext!!.checkStatus()
         when {
-            psiType == null || psiType == PsiType.VOID -> return null
+            psiType == null -> return null
             psiType is PsiPrimitiveType -> return PsiTypesUtil.getDefaultValue(psiType)
             psiClassHelper!!.isNormalType(psiType) -> return psiClassHelper.getDefaultValue(psiType)
             psiType is PsiArrayType -> {
@@ -764,7 +764,7 @@ class DefaultMethodInferHelper : MethodInferHelper {
         }
         actionContext!!.checkStatus()
         when {
-            psiType == null || psiType == PsiType.VOID -> return null
+            psiType == null -> return null
             psiType is PsiPrimitiveType -> return PsiTypesUtil.getDefaultValue(psiType)
             psiClassHelper!!.isNormalType(psiType) -> return psiClassHelper.getDefaultValue(psiType)
             psiType is PsiArrayType -> {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/GsonExUtils.kt
@@ -1,15 +1,13 @@
 package com.itangcent.idea.utils
 
-import com.google.gson.JsonParser
 import com.itangcent.common.utils.GsonUtils
 
 @Deprecated(replaceWith = ReplaceWith("GsonUtils"), message = "use GsonUtils")
 typealias GsonExUtils = GsonUtils
 
 fun GsonUtils.prettyJsonStr(json: String): String {
-    val jsonParser = JsonParser()
-    val jsonObject = jsonParser.parse(json).asJsonObject
-    return GsonUtils.prettyJson(jsonObject)
+    val jsonObject = parseToJsonTree(json)
+    return prettyJson(jsonObject)
 }
 
 fun String.resolveGsonLazily(): String {

--- a/idea-plugin/src/main/kotlin/com/itangcent/utils/ExtensibleKit.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/utils/ExtensibleKit.kt
@@ -2,17 +2,17 @@ package com.itangcent.utils
 
 import com.itangcent.common.constant.Attrs
 import com.itangcent.common.utils.Extensible
+import com.itangcent.common.utils.GsonUtils
 import com.itangcent.common.utils.mapToTypedArray
 import com.itangcent.intellij.extend.unbox
 import kotlin.reflect.KClass
 
 object ExtensibleKit {
 
-    private val JSON_PARSER = com.google.gson.JsonParser()
     private val GSON = com.google.gson.Gson()
 
     fun <T : Extensible> KClass<T>.fromJson(json: String): T {
-        val jsonElement = JSON_PARSER.parse(json)
+        val jsonElement = GsonUtils.parseToJsonTree(json)!!
         val t = GSON.fromJson(jsonElement, this.java)
         jsonElement.asJsonObject.entrySet()
                 .filter { it.key.startsWith(Attrs.PREFIX) }
@@ -22,7 +22,7 @@ object ExtensibleKit {
 
     fun <T : Extensible> KClass<T>.fromJson(json: String, vararg exts: String): T {
         val extNames = exts.removePrefix(Attrs.PREFIX)
-        val jsonElement = JSON_PARSER.parse(json)
+        val jsonElement = GsonUtils.parseToJsonTree(json)!!
         val t = GSON.fromJson(jsonElement, this.java)
         jsonElement.asJsonObject.entrySet()
                 .filter { extNames.contains(it.key) }

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.5.7.212.0</version>
+    <version>2.5.8.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION

* amend: remove deprecated API usages [(#961)](https://github.com/tangcent/easy-yapi/pull/961)

* feat: output field.demo value to postman/markdown [(#958)](https://github.com/tangcent/easy-yapi/pull/958)

* chore: update version of intellij-kotlin to 1.5.0 [(#957)](https://github.com/tangcent/easy-yapi/pull/957)

* chore: polish SettingBinder [(#956)](https://github.com/tangcent/easy-yapi/pull/956)

* feat: read yapi token from config [(#955)](https://github.com/tangcent/easy-yapi/pull/955)

* fix: set _id back after save api to yapi success [(#952)](https://github.com/tangcent/easy-yapi/pull/952)
