### PR TITLE
release 2.6.3

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,9 @@
+* 2.6.3
+* amend: remove CompensateRateLimiter  [(#1034)](https://github.com/tangcent/easy-yapi/pull/1034)
+
+* feat: add rules `postman.format.after`, `yapi.format.after`  [(#1033)](https://github.com/tangcent/easy-yapi/pull/1033)
+
+* chore: remove deprecated utils  [(#1024)](https://github.com/tangcent/easy-yapi/pull/1024)
 * 2.6.2
 	* refactor: remove usage of KV  [(#1020)](https://github.com/tangcent/easy-yapi/pull/1020)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 plugin_name=EasyYapi
-plugin_version=2.6.2.212.0
+plugin_version=2.6.3.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2
-itangcent_intellij_version=1.5.52-SNAPSHOT
+itangcent_intellij_version=1.5.6

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,12 +1,8 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.6.2">v2.6.2(2023-08-27)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.6.3">v2.6.3(2023-09-18)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <ul>
-  <li style="list-style: none">fixes:</li>
+  <li style="list-style: none">enhancements:</li>
 
-  <li>fixes: fix: fix issue with SessionStorage not works (<a href="https://github.com/tangcent/easy-yapi/pull/1016">#1016</a>)</li>
-
-  <li>fixes: fix: fix thread warning (<a href="https://github.com/tangcent/easy-yapi/pull/1012">#1012</a>)</li>
-
-  <li>fixes: fix: added support for strict check in jakarta.validation and javax.validation (<a href="https://github.com/tangcent/easy-yapi/pull/1013">#1013</a>)</li>
+  <li>feat: add rules `postman.format.after`, `yapi.format.after` (<a href="https://github.com/tangcent/easy-yapi/pull/1033">#1033</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.6.2.212.0</version>
+    <version>2.6.3.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* amend: remove CompensateRateLimiter  [(#1034)](https://github.com/tangcent/easy-yapi/pull/1034)

* feat: add rules `postman.format.after`, `yapi.format.after`  [(#1033)](https://github.com/tangcent/easy-yapi/pull/1033)

* chore: remove deprecated utils  [(#1024)](https://github.com/tangcent/easy-yapi/pull/1024)