### PR TITLE
release 2.6.4

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,9 +1,21 @@
+* 2.6.4
+
+	* feat: Add recommended configuration for Jackson JsonPropertyOrder  [(#1048)](https://github.com/tangcent/easy-yapi/pull/1048)
+
+	* feat: Add new rule field.order.with  [(#1047)](https://github.com/tangcent/easy-yapi/pull/1047)
+
+	* feat: Apply field rules to getter and setter methods  [(#1044)](https://github.com/tangcent/easy-yapi/pull/1044)
+
+	* chore: polish YapiFormatter  [(#1043)](https://github.com/tangcent/easy-yapi/pull/1043)
+
 * 2.6.3
-* amend: remove CompensateRateLimiter  [(#1034)](https://github.com/tangcent/easy-yapi/pull/1034)
 
-* feat: add rules `postman.format.after`, `yapi.format.after`  [(#1033)](https://github.com/tangcent/easy-yapi/pull/1033)
+	* amend: remove CompensateRateLimiter  [(#1034)](https://github.com/tangcent/easy-yapi/pull/1034)
 
-* chore: remove deprecated utils  [(#1024)](https://github.com/tangcent/easy-yapi/pull/1024)
+    * feat: add rules `postman.format.after`, `yapi.format.after`  [(#1033)](https://github.com/tangcent/easy-yapi/pull/1033)
+
+    * chore: remove deprecated utils  [(#1024)](https://github.com/tangcent/easy-yapi/pull/1024)
+
 * 2.6.2
 	* refactor: remove usage of KV  [(#1020)](https://github.com/tangcent/easy-yapi/pull/1020)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.6.3.212.0
+plugin_version=2.6.4.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,8 +1,12 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.6.3">v2.6.3(2023-09-18)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.6.4">v2.6.4(2023-10-22)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <ul>
   <li style="list-style: none">enhancements:</li>
 
-  <li>feat: add rules `postman.format.after`, `yapi.format.after` (<a href="https://github.com/tangcent/easy-yapi/pull/1033">#1033</a>)</li>
+  <li>enhancements: feat: Add recommended configuration for Jackson JsonPropertyOrder (<a href="https://github.com/tangcent/easy-yapi/pull/1048">#1048</a>)</li>
+
+  <li>enhancements: feat: Add new rule field.order.with (<a href="https://github.com/tangcent/easy-yapi/pull/1047">#1047</a>)</li>
+
+  <li>enhancements: feat: Apply field rules to getter and setter methods (<a href="https://github.com/tangcent/easy-yapi/pull/1044">#1044</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.6.3.212.0</version>
+    <version>2.6.4.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: Add recommended configuration for Jackson JsonPropertyOrder  [(#1048)](https://github.com/tangcent/easy-yapi/pull/1048)

* feat: Add new rule field.order.with  [(#1047)](https://github.com/tangcent/easy-yapi/pull/1047)

* feat: Apply field rules to getter and setter methods  [(#1044)](https://github.com/tangcent/easy-yapi/pull/1044)

* chore: polish YapiFormatter  [(#1043)](https://github.com/tangcent/easy-yapi/pull/1043)
