### PR TITLE
fixed: 修复easy-yapi的bug

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/RequestClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/RequestClassExporter.kt
@@ -637,8 +637,8 @@ abstract class RequestClassExporter : ClassExporter {
                             request,
                             path,
                             tinyQueryParam(
-                                parent?.getAs<Boolean>(Attrs.DEFAULT_VALUE_ATTR, key)
-                                    ?: value
+                                parent?.getAs<String>(Attrs.DEFAULT_VALUE_ATTR, key)
+                                    ?: value.takeIfNotOriginal()
                             ),
                             parent?.getAs<Boolean>(Attrs.REQUIRED_ATTR, key) ?: false,
                             KVUtils.getUltimateComment(parent?.getAs(Attrs.COMMENT_ATTR), key)
@@ -718,7 +718,7 @@ abstract class RequestClassExporter : ClassExporter {
                                     parameterExportContext,
                                     request, path,
                                     tinyQueryParam(
-                                        (parent?.getAs<Boolean>(Attrs.DEFAULT_VALUE_ATTR, key)
+                                        (parent?.getAs<String>(Attrs.DEFAULT_VALUE_ATTR, key)
                                             ?: value.takeIfNotOriginal())
                                     )?.toString(),
                                     parent?.getAs<Boolean>(Attrs.REQUIRED_ATTR, key) ?: false,

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/suv/SuvApiExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/suv/SuvApiExporter.kt
@@ -248,7 +248,7 @@ open class SuvApiExporter {
 
             builder.bind(RuleParser::class) { it.with(SuvRuleParser::class).singleton() }
             builder.bind(RuleComputeListener::class) { it.with(RuleComputeListenerRegistry::class).singleton() }
-            builder.bind(PsiClassHelper::class) { it.with(CustomizedPsiClassHelper::class).singleton() }
+            builder.bind(PsiClassHelper::class) { it.with(YapiPsiClassHelper::class).singleton() }
 
             builder.bind(ResourceResolver::class) { it.with(CachedResourceResolver::class).singleton() }
             builder.bind(FileApiCacheRepository::class) { it.with(DefaultFileApiCacheRepository::class).singleton() }

--- a/idea-plugin/src/main/resources/.recommend.easy.api.config
+++ b/idea-plugin/src/main/resources/.recommend.easy.api.config
@@ -370,14 +370,6 @@ class.prefix.path=${server.servlet.context-path}
 #ignore serialVersionUID
 constant.field.ignore=groovy:it.name()=="serialVersionUID"
 
-#[support_mock_for_general]*
-
-#mock for date
-
-###set resolveMulti = first
-java_date_types=["java.util.Date","java.sql.Timestamp","java.time.LocalDate","java.time.LocalDateTime"]
-field.mock[groovy:${java_date_types}.contains(it.type().name())&&it.jsonType().name()=="java.lang.String"] = groovy:"@datetime"
-field.mock[groovy:${java_date_types}.contains(it.type().name())&&it.jsonType().name()=="java.lang.Long"] = groovy:"@timestamp@string(\"number\", 3)"
 ###set resolveMulti = error
 
 #[private_protected_field_only]

--- a/third/jakarta.validation-group.config
+++ b/third/jakarta.validation-group.config
@@ -1,0 +1,491 @@
+# rules for jakarta.validation
+json.cache.disable=true
+json.group=groovy:session.get("json-group")
+param.before=groovy:```
+    session.set("json-group", it.annValue("org.springframework.validation.annotation.Validated"))
+```
+param.after=groovy:```
+    session.remove("json-group")
+```
+jakarta_check_groups=```
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("jakarta.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("jakarta.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    return true
+                }
+            }
+        }
+    }
+    return false
+```
+jakarta_check_groups_return_flag=```
+    def flag = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("jakarta.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("jakarta.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flag = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+jakarta_check_groups_return_flagMax=```
+    def flagMax = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("jakarta.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("jakarta.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flagMax = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+
+jakarta_check_groups_return_flagMin=```
+    def flagMin = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("jakarta.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("jakarta.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flagMin = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+#Support for jakarta.validation annotations
+field.required[@jakarta.validation.constraints.NotBlank]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.NotBlank")
+    ${jakarta_check_groups}
+```
+field.required[@jakarta.validation.constraints.NotNull]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.NotNull")
+     ${jakarta_check_groups}
+```
+field.required[@jakarta.validation.constraints.NotEmpty]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.NotEmpty")
+    ${jakarta_check_groups}
+```
+param.required=@jakarta.validation.constraints.NotBlank
+param.required=@jakarta.validation.constraints.NotNull
+param.required=@jakarta.validation.constraints.NotEmpty
+
+
+
+###set resolveMulti = first
+# define var
+number_min=-9999
+number_max=9999
+float_dmin=2
+java_integer_types=["java.lang.Integer","int","java.lang.Long","long","java.lang.Short","short","java.math.BigInteger"]
+java_float_types=["java.lang.String","java.lang.Float","float","java.lang.Double","double","java.math.BigDecimal"]
+# mock_integer_or_float=${java_integer_types}.contains(it.type().name())?"@integer":"@float"
+
+# AssertTrue|AssertFalse
+field.mock[@jakarta.validation.constraints.AssertTrue]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.AssertTrue")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return true
+    }
+```
+field.demo[@jakarta.validation.constraints.AssertTrue]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.AssertTrue")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return true
+    }
+```
+field.mock[@jakarta.validation.constraints.AssertFalse]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.AssertFalse")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return false
+    }
+```
+field.demo[@jakarta.validation.constraints.AssertFalse]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.AssertFalse")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return false
+    }
+```
+
+# DecimalMax+DecimalMin -mock
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+    ${jakarta_check_groups_return_flagMin}
+    annMaps = it.annMaps("jakarta.validation.constraints.DecimalMax")
+    ${jakarta_check_groups_return_flagMax}
+    if(flagMin&&flagMax){
+        return "@integer("+it.ann("jakarta.validation.constraints.DecimalMin")+","+it.ann("jakarta.validation.constraints.DecimalMax")+")"
+    }else if(flagMin&&!flagMax){
+        return "@integer("+it.ann("jakarta.validation.constraints.DecimalMin")+")"
+    }else if(!flagMin&&flagMax){
+        return "@integer(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+")"
+    }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+    ${jakarta_check_groups_return_flagMin}
+    annMaps = it.annMaps("jakarta.validation.constraints.DecimalMax")
+    ${jakarta_check_groups_return_flagMax}
+    if(flagMin&&flagMax){
+        return "@float("+it.ann("jakarta.validation.constraints.DecimalMin")+","+it.ann("jakarta.validation.constraints.DecimalMax")+",${float_dmin})"
+    }else if(flagMin&&!flagMax){
+        return "@float("+it.ann("jakarta.validation.constraints.DecimalMin")+",${number_max},${float_dmin})"
+    }else if(!flagMin&&flagMax){
+        return "@float(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+",${float_dmin})"
+    }
+```
+
+# DecimalMax|DecimalMin  -mock
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+      def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMax")
+      ${jakarta_check_groups_return_flagMax}
+      if(flagMax){
+         return "@integer(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+")"
+      }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+     ${jakarta_check_groups_return_flagMin}
+     if(flagMin){
+         return "@integer("+it.ann("jakarta.validation.constraints.DecimalMin")+")"
+     }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMax")
+     ${jakarta_check_groups_return_flagMax}
+     if(flagMax){
+         return "@float(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+",${float_dmin})"
+     }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+     ${jakarta_check_groups_return_flagMin}
+     if(flagMin){
+         return "@float("+it.ann("jakarta.validation.constraints.DecimalMin")+",${number_max},${float_dmin})"
+     }
+```
+
+# DecimalMax、DecimalMin  -advanced
+field.advanced[@jakarta.validation.constraints.DecimalMax]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMax")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        def ann = it.annMap("jakarta.validation.constraints.DecimalMax")
+        return [maximum:ann["value"],exclusiveMaximum:(ann["inclusive"]==false)]
+    }
+```
+field.advanced[@jakarta.validation.constraints.DecimalMin]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        def ann = it.annMap("jakarta.validation.constraints.DecimalMin")
+        return [minimum:ann["value"],exclusiveMinimum:(ann["inclusive"]==false)]
+    }
+```
+
+# jakarta.validation.constraints.Digits
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Digits")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        def max = "9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer")).toInteger()
+        return "@integer("+(-max)+","+max+")"
+    }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Digits")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+            def max = ("9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("jakarta.validation.constraints.Digits","fraction"))).toDouble()
+            return "@float("+(-max)+","+max+",0,"+it.ann("jakarta.validation.constraints.Digits","fraction")+")"
+    }
+```
+
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Digits")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+          def max = "9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer")).toInteger()
+          return [minimum:-max,maximum:max]
+    }
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Digits")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+          def max = ("9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("jakarta.validation.constraints.Digits","fraction"))).toDouble()
+          return [minimum:-max,maximum:max]
+    }
+```
+
+# jakarta.validation.constraints.Email
+field.mock[@jakarta.validation.constraints.Email]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Email")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return "@email"
+    }
+```
+field.advanced[@jakarta.validation.constraints.Email]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.Email")
+    ${jakarta_check_groups_return_flag}
+    def emailData = [:]
+    if(flag){
+        emailData["format"] = "email"
+    }
+    return emailData
+```
+
+# Max+Min
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&it.hasAnn("jakarta.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+        def annMaps = it.annMaps("jakarta.validation.constraints.Min")
+        ${jakarta_check_groups_return_flagMin}
+        annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+        ${jakarta_check_groups_return_flagMax}
+        if(flagMin&&flagMax){
+            return  "@integer("+it.ann("jakarta.validation.constraints.Min")+","+it.ann("jakarta.validation.constraints.Max")+")"
+        }else if(flagMin&&!flagMax){
+            return "@integer("+it.ann("jakarta.validation.constraints.Min")+")"
+        }else if(!flagMin&&flagMax){
+            return "@integer(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+        }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&it.hasAnn("jakarta.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.Min")
+     ${jakarta_check_groups_return_flagMin}
+     annMaps = it.annMaps("jakarta.validation.constraints.DecimalMin")
+     ${jakarta_check_groups_return_flagMax}
+      if(flagMin&&flagMax){
+          return  "@float("+it.ann("jakarta.validation.constraints.Min")+","+it.ann("jakarta.validation.constraints.Max")+",${float_dmin})"
+      }else if(flagMin&&!flagMax){
+          return "@float("+it.ann("jakarta.validation.constraints.Min")+",${number_max},${float_dmin})"
+      }else if(!flagMin&&flagMax){
+          return "@float(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+      }
+```
+
+# Max|Min
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+      def annMaps = it.annMaps("jakarta.validation.constraints.Max")
+      ${jakarta_check_groups_return_flagMax}
+      if(flagMax){
+         return  "@integer(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+      }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.Min")
+     ${jakarta_check_groups_return_flagMin}
+     if(flagMin){
+         return "@integer("+it.ann("jakarta.validation.constraints.Min")+")"
+     }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.Max")
+          ${jakarta_check_groups_return_flagMax}
+          if(flagMax){
+             return  "@float(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+          }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.Min")
+     ${jakarta_check_groups_return_flagMin}
+     if(flagMin){
+         return "@float("+it.ann("jakarta.validation.constraints.Min")+",${number_max},${float_dmin})"
+     }
+```
+
+# Max、Min  -advanced
+field.advanced[@jakarta.validation.constraints.Max]=groovy:```
+        def annMaps = it.annMaps("jakarta.validation.constraints.Max")
+        ${jakarta_check_groups_return_flag}
+        if(flag){
+            def ann = it.annMap("jakarta.validation.constraints.Max")
+            return [maximum:it.ann("jakarta.validation.constraints.Max")]
+        }
+```
+field.advanced[@jakarta.validation.constraints.Min]=groovy:```
+        def annMaps = it.annMaps("jakarta.validation.constraints.Min")
+        ${jakarta_check_groups_return_flag}
+        if(flag){
+            def ann = it.annMap("jakarta.validation.constraints.Min")
+            return [minimum:it.ann("jakarta.validation.constraints.Min")]
+        }
+```
+
+# Negative&NegativeOrZero
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+        def annMaps = it.annMaps("jakarta.validation.constraints.Negative")
+        ${jakarta_check_groups_return_flag}
+        if(flag){
+            return  "@integer(${number_min},-1)"
+        }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.NegativeOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+         def annMaps = it.annMaps("jakarta.validation.constraints.NegativeOrZero")
+                ${jakarta_check_groups_return_flag}
+                if(flag){
+                    return  "@integer(${number_min},0)"
+        }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("jakarta.validation.constraints.Negative")
+                ${jakarta_check_groups_return_flag}
+                if(flag){
+                    return  "@float(${number_min},0.01,${float_dmin})"
+        }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.NegativeOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+ def annMaps = it.annMaps("jakarta.validation.constraints.NegativeOrZero")
+                ${jakarta_check_groups_return_flag}
+                if(flag){
+                    return  "@float(${number_min},0,${float_dmin})"
+        }
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.Negative")
+    ${jakarta_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = -1
+    }
+    return neData
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.Negative")
+    ${jakarta_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = -0.001
+    }
+    return neData
+```
+field.advanced[@jakarta.validation.constraints.NegativeOrZero]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.NegativeOrZero")
+    ${jakarta_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = 0
+    }
+    return neData
+```
+
+# jakarta.validation.constraints.Pattern
+field.advanced[@jakarta.validation.constraints.Pattern]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Pattern")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return tool.toJson([pattern:it.ann("jakarta.validation.constraints.Pattern","regexp")])
+    }
+```
+
+# Positive&PositiveOrZero
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("jakarta.validation.constraints.Positive")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return "@integer(1,${number_max})"
+    }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.PositiveOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("jakarta.validation.constraints.PositiveOrZero")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return "@integer(0,${number_max})"
+    }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("jakarta.validation.constraints.Positive")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return "@float(0.01,${number_max},${float_dmin})"
+    }
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.PositiveOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("jakarta.validation.constraints.PositiveOrZero")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+        return "@float(0,${number_max},${float_dmin})"
+    }
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.Positive")
+    ${jakarta_check_groups_return_flag}
+    def poData = [:]
+    if(flag){
+        poData["minimum"] = 1
+    }
+    return poData
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("jakarta.validation.constraints.Positive")
+    ${jakarta_check_groups_return_flag}
+    def poData = [:]
+    if(flag){
+        poData["minimum"] = 0.001
+    }
+    return poData
+```
+field.advanced[@jakarta.validation.constraints.PositiveOrZero]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.PositiveOrZero")
+        ${jakarta_check_groups_return_flag}
+        def poData = [:]
+        if(flag){
+            poData["minimum"] = 0
+        }
+        return poData
+```
+
+# jakarta.validation.constraints.Size
+
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Size")&&it.jsonType().name()=="java.lang.String"]=groovy:```
+   def annMaps = it.annMaps("jakarta.validation.constraints.Size")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+           def ann = it.annMap("jakarta.validation.constraints.Size")
+           if(ann.containsKey("min")&&ann.containsKey("max")){
+               return "@string("+ann["min"]+","+ann["max"]+")"
+           }else if(ann.containsKey("min")){
+               return "@string("+ann["min"]+")"
+           }else if(ann.containsKey("max")){
+               return "@string(0,"+ann["max"]+")"
+           }
+    }
+```
+field.advanced[@jakarta.validation.constraints.Size]=groovy:```
+    def annMaps = it.annMaps("jakarta.validation.constraints.Size")
+    ${jakarta_check_groups_return_flag}
+    if(flag){
+          def element = (it.jsonType().name() == "java.lang.String")?"Length":"Items"
+          def ann = it.annMap("jakarta.validation.constraints.Size")
+          def advanced = [:]
+          if(ann.containsKey("min")){
+              advanced["min"+element] = ann["min"]
+          }
+          if(ann.containsKey("max")){
+              advanced["max"+element] = ann["max"]
+          }
+          return advanced
+    }
+```
+###set resolveMulti = error

--- a/third/jakarta.validation.config
+++ b/third/jakarta.validation.config
@@ -1,0 +1,137 @@
+# rules for jakarta.validation
+
+#Support for jakarta.validation annotations
+param.required=@jakarta.validation.constraints.NotBlank
+param.required=@jakarta.validation.constraints.NotNull
+param.required=@jakarta.validation.constraints.NotEmpty
+field.required=@jakarta.validation.constraints.NotBlank
+field.required=@jakarta.validation.constraints.NotNull
+field.required=@jakarta.validation.constraints.NotEmpty
+
+###set resolveMulti = first
+# define var
+number_min=-9999
+number_max=9999
+float_dmin=2
+java_integer_types=["java.lang.Integer","int","java.lang.Long","long","java.lang.Short","short","java.math.BigInteger"]
+java_float_types=["java.lang.String","java.lang.Float","float","java.lang.Double","double","java.math.BigDecimal"]
+# mock_integer_or_float=${java_integer_types}.contains(it.type().name())?"@integer":"@float"
+
+# AssertTrue|AssertFalse
+field.mock[@jakarta.validation.constraints.AssertFalse]=false
+field.demo[@jakarta.validation.constraints.AssertFalse]=false
+field.mock[@jakarta.validation.constraints.AssertTrue]=true
+field.demo[@jakarta.validation.constraints.AssertTrue]=true
+
+# DecimalMax+DecimalMin -mock
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer("+it.ann("jakarta.validation.constraints.DecimalMin")+","+it.ann("jakarta.validation.constraints.DecimalMax")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float("+it.ann("jakarta.validation.constraints.DecimalMin")+","+it.ann("jakarta.validation.constraints.DecimalMax")+",${float_dmin})"
+
+# DecimalMax|DecimalMin  -mock
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer("+it.ann("jakarta.validation.constraints.DecimalMin")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMax")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(0,"+it.ann("jakarta.validation.constraints.DecimalMax")+",${float_dmin})"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float("+it.ann("jakarta.validation.constraints.DecimalMin")+",${number_max},${float_dmin})"
+
+# DecimalMax、DecimalMin  -advanced
+field.advanced[@jakarta.validation.constraints.DecimalMax]=groovy:```
+    def ann = it.annMap("jakarta.validation.constraints.DecimalMax")
+    return [maximum:ann["value"],exclusiveMaximum:(ann["inclusive"]==false)]
+```
+field.advanced[@jakarta.validation.constraints.DecimalMin]=groovy:```
+    def ann = it.annMap("jakarta.validation.constraints.DecimalMin")
+    return [minimum:ann["value"],exclusiveMinimum:(ann["inclusive"]==false)]
+```
+
+# jakarta.validation.constraints.Digits
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def max = "9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer")).toInteger()
+    return "@integer("+(-max)+","+max+")"
+```
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def max = ("9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("jakarta.validation.constraints.Digits","fraction"))).toDouble()
+    return "@float("+(-max)+","+max+",0,"+it.ann("jakarta.validation.constraints.Digits","fraction")+")"
+```
+
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def max = "9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer")).toInteger()
+    return [minimum:-max,maximum:max]
+```
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def max = ("9".repeat(it.annValue("jakarta.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("jakarta.validation.constraints.Digits","fraction"))).toDouble()
+    return [minimum:-max,maximum:max]
+```
+
+
+# jakarta.validation.constraints.Email
+field.mock[@jakarta.validation.constraints.Email]=groovy:"@email"
+field.advanced[@jakarta.validation.constraints.Email]={"format":"email"}
+
+# Max+Min
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&it.hasAnn("jakarta.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer("+it.ann("jakarta.validation.constraints.Min")+","+it.ann("jakarta.validation.constraints.Max")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&it.hasAnn("jakarta.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float("+it.ann("jakarta.validation.constraints.Min")+","+it.ann("jakarta.validation.constraints.Max")+",${float_dmin})"
+
+# Max|Min
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer("+it.ann("jakarta.validation.constraints.Min")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Max")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(0,"+it.ann("jakarta.validation.constraints.Max")+")"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float("+it.ann("jakarta.validation.constraints.Min")+",${number_max},${float_dmin})"
+
+# Max、Min  -advanced
+field.advanced[@jakarta.validation.constraints.Max]=groovy:```
+    return [maximum:it.ann("jakarta.validation.constraints.Max")]
+```
+field.advanced[@jakarta.validation.constraints.Min]=groovy:```
+    return [minimum:it.ann("jakarta.validation.constraints.Min")]
+```
+
+# Negative&NegativeOrZero
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(${number_min},-1)"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.NegativeOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(${number_min},0)"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(${number_min},0.01,${float_dmin})"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.NegativeOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(${number_min},0,${float_dmin})"
+
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]={maximum:-1}
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]={maximum:-0.001}
+field.advanced[@jakarta.validation.constraints.NegativeOrZero]={"maximum":0}
+
+# jakarta.validation.constraints.Pattern
+field.advanced[@jakarta.validation.constraints.Pattern]=groovy:```
+    return tool.toJson([pattern:it.ann("jakarta.validation.constraints.Pattern","regexp")])
+```
+
+# Positive&PositiveOrZero
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(1,${number_max})"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.PositiveOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:"@integer(0,${number_max})"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(0.01,${number_max},${float_dmin})"
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.PositiveOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:"@float(0,${number_max},${float_dmin})"
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]={minimum:1}
+field.advanced[groovy:it.hasAnn("jakarta.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]={minimum:0.001}
+field.advanced[@jakarta.validation.constraints.PositiveOrZero]={minimum:0}
+
+# jakarta.validation.constraints.Size
+
+field.mock[groovy:it.hasAnn("jakarta.validation.constraints.Size")&&it.jsonType().name()=="java.lang.String"]=groovy:```
+    def ann = it.annMap("jakarta.validation.constraints.Size")
+    if(ann.containsKey("min")&&ann.containsKey("max")){
+        return "@string("+ann["min"]+","+ann["max"]+")"
+    }else if(ann.containsKey("min")){
+        return "@string("+ann["min"]+")"
+    }else if(ann.containsKey("max")){
+        return "@string(0,"+ann["max"]+")"
+    }
+```
+field.advanced[@jakarta.validation.constraints.Size]=groovy:```
+    def element = (it.jsonType().name() == "java.lang.String")?"Length":"Items"
+    def ann = it.annMap("jakarta.validation.constraints.Size")
+    def advanced = [:]
+    if(ann.containsKey("min")){
+        advanced["min"+element] = ann["min"]
+    }
+    if(ann.containsKey("max")){
+        advanced["max"+element] = ann["max"]
+    }
+    return advanced
+```
+###set resolveMulti = error
+

--- a/third/javax.validation-group.config
+++ b/third/javax.validation-group.config
@@ -1,0 +1,491 @@
+added# rules for javax.validation
+json.cache.disable=true
+json.group=groovy:session.get("json-group")
+param.before=groovy:```
+    session.set("json-group", it.annValue("org.springframework.validation.annotation.Validated"))
+```
+param.after=groovy:```
+    session.remove("json-group")
+```
+javax_check_groups=```
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("javax.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("javax.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    return true
+                }
+            }
+        }
+    }
+    return false
+```
+javax_check_groups_return_flag=```
+    def flag = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("javax.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("javax.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flag = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+javax_check_groups_return_flagMax=```
+    def flagMax = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("javax.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("javax.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flagMax = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+
+javax_check_groups_return_flagMin=```
+    def flagMin = false
+    for(annMap in annMaps){
+        def fieldGroups = annMap["groups"] ?: [helper.findClass("javax.validation.groups.Default")]
+        def paramGroups = session.get("json-group") ?: [helper.findClass("javax.validation.groups.Default")]
+        for(fieldGroup in fieldGroups){
+            for(paramGroup in paramGroups){
+                if(paramGroup.isExtend(fieldGroup.name())){
+                    flagMin = true
+                    break
+                }
+            }
+        }
+    }
+```
+
+#Support for javax.validation annotations
+field.required[@javax.validation.constraints.NotBlank]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.NotBlank")
+    ${javax_check_groups}
+```
+field.required[@javax.validation.constraints.NotNull]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.NotNull")
+     ${javax_check_groups}
+```
+field.required[@javax.validation.constraints.NotEmpty]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.NotEmpty")
+    ${javax_check_groups}
+```
+param.required=@javax.validation.constraints.NotBlank
+param.required=@javax.validation.constraints.NotNull
+param.required=@javax.validation.constraints.NotEmpty
+
+
+
+###set resolveMulti = first
+# define var
+number_min=-9999
+number_max=9999
+float_dmin=2
+java_integer_types=["java.lang.Integer","int","java.lang.Long","long","java.lang.Short","short","java.math.BigInteger"]
+java_float_types=["java.lang.String","java.lang.Float","float","java.lang.Double","double","java.math.BigDecimal"]
+# mock_integer_or_float=${java_integer_types}.contains(it.type().name())?"@integer":"@float"
+
+# AssertTrue|AssertFalse
+field.mock[@javax.validation.constraints.AssertTrue]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.AssertTrue")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return true
+    }
+```
+field.demo[@javax.validation.constraints.AssertTrue]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.AssertTrue")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return true
+    }
+```
+field.mock[@javax.validation.constraints.AssertFalse]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.AssertFalse")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return false
+    }
+```
+field.demo[@javax.validation.constraints.AssertFalse]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.AssertFalse")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return false
+    }
+```
+
+# DecimalMax+DecimalMin -mock
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMax")&&it.hasAnn("javax.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+    ${javax_check_groups_return_flagMin}
+    annMaps = it.annMaps("javax.validation.constraints.DecimalMax")
+    ${javax_check_groups_return_flagMax}
+    if(flagMin&&flagMax){
+        return "@integer("+it.ann("javax.validation.constraints.DecimalMin")+","+it.ann("javax.validation.constraints.DecimalMax")+")"
+    }else if(flagMin&&!flagMax){
+        return "@integer("+it.ann("javax.validation.constraints.DecimalMin")+")"
+    }else if(!flagMin&&flagMax){
+        return "@integer(0,"+it.ann("javax.validation.constraints.DecimalMax")+")"
+    }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMax")&&it.hasAnn("javax.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+    ${javax_check_groups_return_flagMin}
+    annMaps = it.annMaps("javax.validation.constraints.DecimalMax")
+    ${javax_check_groups_return_flagMax}
+    if(flagMin&&flagMax){
+        return "@float("+it.ann("javax.validation.constraints.DecimalMin")+","+it.ann("javax.validation.constraints.DecimalMax")+",${float_dmin})"
+    }else if(flagMin&&!flagMax){
+        return "@float("+it.ann("javax.validation.constraints.DecimalMin")+",${number_max},${float_dmin})"
+    }else if(!flagMin&&flagMax){
+        return "@float(0,"+it.ann("javax.validation.constraints.DecimalMax")+",${float_dmin})"
+    }
+```
+
+# DecimalMax|DecimalMin  -mock
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMax")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+      def annMaps = it.annMaps("javax.validation.constraints.DecimalMax")
+      ${javax_check_groups_return_flagMax}
+      if(flagMax){
+         return "@integer(0,"+it.ann("javax.validation.constraints.DecimalMax")+")"
+      }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMin")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+     ${javax_check_groups_return_flagMin}
+     if(flagMin){
+         return "@integer("+it.ann("javax.validation.constraints.DecimalMin")+")"
+     }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMax")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.DecimalMax")
+     ${javax_check_groups_return_flagMax}
+     if(flagMax){
+         return "@float(0,"+it.ann("javax.validation.constraints.DecimalMax")+",${float_dmin})"
+     }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.DecimalMin")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+     ${javax_check_groups_return_flagMin}
+     if(flagMin){
+         return "@float("+it.ann("javax.validation.constraints.DecimalMin")+",${number_max},${float_dmin})"
+     }
+```
+
+# DecimalMax、DecimalMin  -advanced
+field.advanced[@javax.validation.constraints.DecimalMax]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.DecimalMax")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        def ann = it.annMap("javax.validation.constraints.DecimalMax")
+        return [maximum:ann["value"],exclusiveMaximum:(ann["inclusive"]==false)]
+    }
+```
+field.advanced[@javax.validation.constraints.DecimalMin]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        def ann = it.annMap("javax.validation.constraints.DecimalMin")
+        return [minimum:ann["value"],exclusiveMinimum:(ann["inclusive"]==false)]
+    }
+```
+
+# javax.validation.constraints.Digits
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Digits")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        def max = "9".repeat(it.annValue("javax.validation.constraints.Digits","integer")).toInteger()
+        return "@integer("+(-max)+","+max+")"
+    }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Digits")
+    ${javax_check_groups_return_flag}
+    if(flag){
+            def max = ("9".repeat(it.annValue("javax.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("javax.validation.constraints.Digits","fraction"))).toDouble()
+            return "@float("+(-max)+","+max+",0,"+it.ann("javax.validation.constraints.Digits","fraction")+")"
+    }
+```
+
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Digits")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Digits")
+    ${javax_check_groups_return_flag}
+    if(flag){
+          def max = "9".repeat(it.annValue("javax.validation.constraints.Digits","integer")).toInteger()
+          return [minimum:-max,maximum:max]
+    }
+```
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Digits")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Digits")
+    ${javax_check_groups_return_flag}
+    if(flag){
+          def max = ("9".repeat(it.annValue("javax.validation.constraints.Digits","integer"))+"."+"9".repeat(it.annValue("javax.validation.constraints.Digits","fraction"))).toDouble()
+          return [minimum:-max,maximum:max]
+    }
+```
+
+# javax.validation.constraints.Email
+field.mock[@javax.validation.constraints.Email]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Email")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return "@email"
+    }
+```
+field.advanced[@javax.validation.constraints.Email]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.Email")
+    ${javax_check_groups_return_flag}
+    def emailData = [:]
+    if(flag){
+        emailData["format"] = "email"
+    }
+    return emailData
+```
+
+# Max+Min
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Max")&&it.hasAnn("javax.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+        def annMaps = it.annMaps("javax.validation.constraints.Min")
+        ${javax_check_groups_return_flagMin}
+        annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+        ${javax_check_groups_return_flagMax}
+        if(flagMin&&flagMax){
+            return  "@integer("+it.ann("javax.validation.constraints.Min")+","+it.ann("javax.validation.constraints.Max")+")"
+        }else if(flagMin&&!flagMax){
+            return "@integer("+it.ann("javax.validation.constraints.Min")+")"
+        }else if(!flagMin&&flagMax){
+            return "@integer(0,"+it.ann("javax.validation.constraints.Max")+")"
+        }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Max")&&it.hasAnn("javax.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.Min")
+     ${javax_check_groups_return_flagMin}
+     annMaps = it.annMaps("javax.validation.constraints.DecimalMin")
+     ${javax_check_groups_return_flagMax}
+      if(flagMin&&flagMax){
+          return  "@float("+it.ann("javax.validation.constraints.Min")+","+it.ann("javax.validation.constraints.Max")+",${float_dmin})"
+      }else if(flagMin&&!flagMax){
+          return "@float("+it.ann("javax.validation.constraints.Min")+",${number_max},${float_dmin})"
+      }else if(!flagMin&&flagMax){
+          return "@float(0,"+it.ann("javax.validation.constraints.Max")+")"
+      }
+```
+
+# Max|Min
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Max")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+      def annMaps = it.annMaps("javax.validation.constraints.Max")
+      ${javax_check_groups_return_flagMax}
+      if(flagMax){
+         return  "@integer(0,"+it.ann("javax.validation.constraints.Max")+")"
+      }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Min")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.Min")
+     ${javax_check_groups_return_flagMin}
+     if(flagMin){
+         return "@integer("+it.ann("javax.validation.constraints.Min")+")"
+     }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Max")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.Max")
+          ${javax_check_groups_return_flagMax}
+          if(flagMax){
+             return  "@float(0,"+it.ann("javax.validation.constraints.Max")+")"
+          }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Min")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.Min")
+     ${javax_check_groups_return_flagMin}
+     if(flagMin){
+         return "@float("+it.ann("javax.validation.constraints.Min")+",${number_max},${float_dmin})"
+     }
+```
+
+# Max、Min  -advanced
+field.advanced[@javax.validation.constraints.Max]=groovy:```
+        def annMaps = it.annMaps("javax.validation.constraints.Max")
+        ${javax_check_groups_return_flag}
+        if(flag){
+            def ann = it.annMap("javax.validation.constraints.Max")
+            return [maximum:it.ann("javax.validation.constraints.Max")]
+        }
+```
+field.advanced[@javax.validation.constraints.Min]=groovy:```
+        def annMaps = it.annMaps("javax.validation.constraints.Min")
+        ${javax_check_groups_return_flag}
+        if(flag){
+            def ann = it.annMap("javax.validation.constraints.Min")
+            return [minimum:it.ann("javax.validation.constraints.Min")]
+        }
+```
+
+# Negative&NegativeOrZero
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+        def annMaps = it.annMaps("javax.validation.constraints.Negative")
+        ${javax_check_groups_return_flag}
+        if(flag){
+            return  "@integer(${number_min},-1)"
+        }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.NegativeOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+         def annMaps = it.annMaps("javax.validation.constraints.NegativeOrZero")
+                ${javax_check_groups_return_flag}
+                if(flag){
+                    return  "@integer(${number_min},0)"
+        }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+     def annMaps = it.annMaps("javax.validation.constraints.Negative")
+                ${javax_check_groups_return_flag}
+                if(flag){
+                    return  "@float(${number_min},0.01,${float_dmin})"
+        }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.NegativeOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+ def annMaps = it.annMaps("javax.validation.constraints.NegativeOrZero")
+                ${javax_check_groups_return_flag}
+                if(flag){
+                    return  "@float(${number_min},0,${float_dmin})"
+        }
+```
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Negative")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.Negative")
+    ${javax_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = -1
+    }
+    return neData
+```
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Negative")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.Negative")
+    ${javax_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = -0.001
+    }
+    return neData
+```
+field.advanced[@javax.validation.constraints.NegativeOrZero]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.NegativeOrZero")
+    ${javax_check_groups_return_flag}
+    def neData = [:]
+    if(flag){
+        neData["maximum"] = 0
+    }
+    return neData
+```
+
+# javax.validation.constraints.Pattern
+field.advanced[@javax.validation.constraints.Pattern]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Pattern")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return tool.toJson([pattern:it.ann("javax.validation.constraints.Pattern","regexp")])
+    }
+```
+
+# Positive&PositiveOrZero
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("javax.validation.constraints.Positive")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return "@integer(1,${number_max})"
+    }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.PositiveOrZero")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("javax.validation.constraints.PositiveOrZero")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return "@integer(0,${number_max})"
+    }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("javax.validation.constraints.Positive")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return "@float(0.01,${number_max},${float_dmin})"
+    }
+```
+field.mock[groovy:it.hasAnn("javax.validation.constraints.PositiveOrZero")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+   def annMaps = it.annMaps("javax.validation.constraints.PositiveOrZero")
+    ${javax_check_groups_return_flag}
+    if(flag){
+        return "@float(0,${number_max},${float_dmin})"
+    }
+```
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Positive")&&${java_integer_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.Positive")
+    ${javax_check_groups_return_flag}
+    def poData = [:]
+    if(flag){
+        poData["minimum"] = 1
+    }
+    return poData
+```
+field.advanced[groovy:it.hasAnn("javax.validation.constraints.Positive")&&${java_float_types}.contains(it.jsonType().name())]=groovy:```
+  def annMaps = it.annMaps("javax.validation.constraints.Positive")
+    ${javax_check_groups_return_flag}
+    def poData = [:]
+    if(flag){
+        poData["minimum"] = 0.001
+    }
+    return poData
+```
+field.advanced[@javax.validation.constraints.PositiveOrZero]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.PositiveOrZero")
+        ${javax_check_groups_return_flag}
+        def poData = [:]
+        if(flag){
+            poData["minimum"] = 0
+        }
+        return poData
+```
+
+# javax.validation.constraints.Size
+
+field.mock[groovy:it.hasAnn("javax.validation.constraints.Size")&&it.jsonType().name()=="java.lang.String"]=groovy:```
+   def annMaps = it.annMaps("javax.validation.constraints.Size")
+    ${javax_check_groups_return_flag}
+    if(flag){
+           def ann = it.annMap("javax.validation.constraints.Size")
+           if(ann.containsKey("min")&&ann.containsKey("max")){
+               return "@string("+ann["min"]+","+ann["max"]+")"
+           }else if(ann.containsKey("min")){
+               return "@string("+ann["min"]+")"
+           }else if(ann.containsKey("max")){
+               return "@string(0,"+ann["max"]+")"
+           }
+    }
+```
+field.advanced[@javax.validation.constraints.Size]=groovy:```
+    def annMaps = it.annMaps("javax.validation.constraints.Size")
+    ${javax_check_groups_return_flag}
+    if(flag){
+          def element = (it.jsonType().name() == "java.lang.String")?"Length":"Items"
+          def ann = it.annMap("javax.validation.constraints.Size")
+          def advanced = [:]
+          if(ann.containsKey("min")){
+              advanced["min"+element] = ann["min"]
+          }
+          if(ann.containsKey("max")){
+              advanced["max"+element] = ann["max"]
+          }
+          return advanced
+    }
+```
+###set resolveMulti = error

--- a/third/swagger3.config
+++ b/third/swagger3.config
@@ -3,7 +3,9 @@
 #Hidden
 ignore=@io.swagger.v3.oas.annotations.Hidden
 field.ignore=@io.swagger.v3.oas.annotations.Hidden
+field.ignore=@io.swagger.v3.oas.annotations.media.Schema#hidden
 param.ignore=@io.swagger.v3.oas.annotations.Hidden
+param.ignore=@io.swagger.v3.oas.annotations.media.Schema#hidden
 
 #Operation
 api.name=@io.swagger.v3.oas.annotations.Operation#summary
@@ -17,15 +19,28 @@ api.tag[@io.swagger.v3.oas.annotations.Operation#deprecated]=deprecated
 #Tag(s)
 api.tag=@io.swagger.v3.oas.annotations.tags.Tag#name
 api.tag[@io.swagger.v3.oas.annotations.tags.Tags]=groovy:```
-    @it.annValue("io.swagger.v3.oas.annotations.tags.Tags").collect{it.name}
+    def maps = it.annMap("io.swagger.v3.oas.annotations.tags.Tags")
+    tool.substringBetween(maps.value.collect{it.name}.toString(),"[","]")
 ```
 
 #Parameter
 param.ignore=@io.swagger.v3.oas.annotations.Parameter#hidden
-param.required=@io.swagger.v3.oas.annotations.Parameter#required
 param.doc[@io.swagger.v3.oas.annotations.Parameter#deprecated]=「已废弃」
 param.doc=@io.swagger.v3.oas.annotations.Parameter#description
+param.doc=@io.swagger.v3.oas.annotations.parameters.RequestBody#description
+param.doc=@io.swagger.v3.oas.annotations.media.Schema#description
+param.required=@io.swagger.v3.oas.annotations.Parameter#required
+param.required=@io.swagger.v3.oas.annotations.parameters.RequestBody#required
+param.required=@io.swagger.v3.oas.annotations.media.Schema#required
+param.default.value=@io.swagger.v3.oas.annotations.media.Schema#defaultValue
 
+#Schema
+field.doc=@io.swagger.v3.oas.annotations.media.Schema#description
+field.name=@io.swagger.v3.oas.annotations.media.Schema#name
+field.default.value=@io.swagger.v3.oas.annotations.media.Schema#defaultValue
+field.example=@io.swagger.v3.oas.annotations.media.Schema#example
+field.required=@io.swagger.v3.oas.annotations.media.Schema#required
+class.doc=@io.swagger.v3.oas.annotations.media.Schema#name
 
 # resolve the parameters from Parameter
 resolve_parameter=```
@@ -65,7 +80,6 @@ export.after[@io.swagger.v3.oas.annotations.Operation]=groovy:```
         ${resolve_parameter}
     }
 ```
-
 
 # Resolve the response from `APIResponse` into the API description
 resolve_swagger3_api_response=```


### PR DESCRIPTION
fixed: `recommend.easy.api.config` 这个文件的`#[support_mock_for_general]* ` 这个规则，在你将所有的时间日期转换之后，就不在生效了
added: 新增jakarta.validation的表单校验功能`jakarta.validation.config`是表单检验，和`jakarta.validation-group.config`是分组校验
added: 新增远程配置文件`javax.validation`分组校验规则，补充了内置规则不完善的缺陷
fixed: 修复`SuvApiExporter.kt`的导出没有mock的功能
fixed: `Attrs.DEFAULT_VALUE_ATTR`泛型不对，但是getBean无法获取默认值
added：新增`swagger3`对于`@Schema`注解的支持