### PR TITLE
chore: fix compatibility issues in compatibility verification

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/feign/FeignRequestClassExporter.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/feign/FeignRequestClassExporter.kt
@@ -15,7 +15,6 @@ import com.itangcent.idea.plugin.api.export.condition.ConditionOnSimple
 import com.itangcent.idea.plugin.api.export.core.*
 import com.itangcent.idea.plugin.api.export.spring.SpringRequestClassExporter
 import com.itangcent.idea.plugin.condition.ConditionOnSetting
-import org.apache.commons.lang.StringUtils.lowerCase
 
 /**
  * Support export apis from client that annotated with @FeignClient
@@ -104,7 +103,7 @@ open class FeignRequestClassExporter : SpringRequestClassExporter() {
                 val name = it.first
                 val value = it.second.trim()
                 if (name.equalIgnoreCase("content-type")) {
-                    if (lowerCase(value).contains("application/json")) {
+                    if (value.lowercase().contains("application/json")) {
                         methodExportContext.setExt("paramType", "body")
                     }
                 }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/http/HttpClientFileSaver.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/http/HttpClientFileSaver.kt
@@ -11,9 +11,11 @@ import com.intellij.util.io.createDirectories
 import com.intellij.util.io.readText
 import com.itangcent.intellij.context.ActionContext
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 /**
@@ -67,7 +69,7 @@ class HttpClientFileSaver {
         val file = scratchesPath.resolve(module).resolve(fileName).apply {
             parent.createDirectories()
         }
-        file.writeText(content(file.takeIf { Files.exists(it) }?.readText()))
+        file.writeText(content(file.takeIf { Files.exists(it) }?.readText(StandardCharsets.UTF_8)))
 
         return (localFileSystem.refreshAndFindFileByPath(file.toString())
             ?: throw IOException("Unable to find file: $file"))


### PR DESCRIPTION
IntelliJ IDEA Ultimate (241.14494.127) compatibility warning. 

- 1 usage of scheduled for removal API
    - EasyYapi 2.6.8.212.0 uses API scheduled for removal in future releases
    - Scheduled for removal class usage (1)
        - StringUtils (1) (scheduled for removal in a future release)
        - Deprecated class StringUtils is referenced in FeignRequestClassExporter.resolveHeader(...). This class will be removed in a future release

- 1 deprecated API usage
    - EasyYapi 2.6.8.212.0 uses deprecated API, which may be removed in future releases leading to binary and source code incompatibilities
    - Deprecated method usage (1)
        - PathKt.readText(Path) (1)
        - Deprecated method PathKt.readText(Path) is invoked in HttpClientFileSaver.saveHttpFile(...)