### PR TITLE
release 2.7.1

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,9 @@
+* 2.7.1
+	* fix: resolve 'module_path' property resolution issue  [(#1137)](https://github.com/tangcent/easy-yapi/pull/1137)
+
+	* feat: added functionality to choose between apache and okHttp for sending HTTP requests via settings  [(#1132)](https://github.com/tangcent/easy-yapi/pull/1132)
+
+	* docs: remove Travis CI build status badge from README  [(#1136)](https://github.com/tangcent/easy-yapi/pull/1136)
 * 2.7.0
 	* feat: add rules `param.name`, `param.type`  [(#1128)](https://github.com/tangcent/easy-yapi/pull/1128)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.7.0.212.0
+plugin_version=2.7.1.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,18 +1,14 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.0">v2.7.0(2024-04-15)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.1">v2.7.1(2024-05-12)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
 <ul>
-  <li>feat: add rules `param.name`, `param.type` (<a href="https://github.com/tangcent/easy-yapi/pull/1128">#1128</a>)</li>
-
-  <li>feat: add support for io.swagger.v3.oas.annotations.media.Schema annotation (<a href="https://github.com/tangcent/easy-yapi/pull/1127">#1127</a>)</li>
-
-  <li>feat: Replace gson and jsoup with IntelliJ code style for JSON/XML/HTML formatting (<a href="https://github.com/tangcent/easy-yapi/pull/1119">#1119</a>)</li>
+  <li>feat: added functionality to choose between apache and okHttp for sending HTTP requests via settings (<a href="https://github.com/tangcent/easy-yapi/pull/1132">#1132</a>)</li>
 </ul>
 
 <h3>Fixes:</h3>
 
 <ul>
-  <li>fix: fix issue where the configuration was not being loaded before actions were performed (<a href="https://github.com/tangcent/easy-yapi/pull/1123">#1123</a>)</li>
+  <li>fix: resolve 'module_path' property resolution issue (<a href="https://github.com/tangcent/easy-yapi/pull/1137">#1137</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.7.0.212.0</version>
+    <version>2.7.1.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: resolve 'module_path' property resolution issue  [(#1137)](https://github.com/tangcent/easy-yapi/pull/1137)

* feat: added functionality to choose between apache and okHttp for sending HTTP requests via settings  [(#1132)](https://github.com/tangcent/easy-yapi/pull/1132)

* docs: remove Travis CI build status badge from README  [(#1136)](https://github.com/tangcent/easy-yapi/pull/1136)