### PR TITLE
release 2.7.2

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,11 @@
+* 2.7.2
+	* fix: remove Non-extendable interface usage  [(#1146)](https://github.com/tangcent/easy-yapi/pull/1146)
+
+	* chore: polish Postman API helper classes and cache management  [(#1145)](https://github.com/tangcent/easy-yapi/pull/1145)
+
+	* fix: correct content-type for Postman API export  [(#1144)](https://github.com/tangcent/easy-yapi/pull/1144)
+
+	* test: add test case to verify rendering of non-English content in BundledMarkdownRender  [(#1142)](https://github.com/tangcent/easy-yapi/pull/1142)
 * 2.7.1
 	* fix: resolve 'module_path' property resolution issue  [(#1137)](https://github.com/tangcent/easy-yapi/pull/1137)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.7.1.212.0
+plugin_version=2.7.2.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,14 +1,12 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.1">v2.7.1(2024-05-12)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.2">v2.7.2(2024-06-30)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
-<ul>
-  <li>feat: added functionality to choose between apache and okHttp for sending HTTP requests via settings (<a href="https://github.com/tangcent/easy-yapi/pull/1132">#1132</a>)</li>
-</ul>
-
 <h3>Fixes:</h3>
 
 <ul>
-  <li>fix: resolve 'module_path' property resolution issue (<a href="https://github.com/tangcent/easy-yapi/pull/1137">#1137</a>)</li>
+  <li>fix: remove Non-extendable interface usage (<a href="https://github.com/tangcent/easy-yapi/pull/1146">#1146</a>)</li>
+
+  <li>fix: correct content-type for Postman API export (<a href="https://github.com/tangcent/easy-yapi/pull/1144">#1144</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.7.1.212.0</version>
+    <version>2.7.2.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: remove Non-extendable interface usage  [(#1146)](https://github.com/tangcent/easy-yapi/pull/1146)

* chore: polish Postman API helper classes and cache management  [(#1145)](https://github.com/tangcent/easy-yapi/pull/1145)

* fix: correct content-type for Postman API export  [(#1144)](https://github.com/tangcent/easy-yapi/pull/1144)
