### PR TITLE
release 2.7.3

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,15 @@
+* 2.7.3
+	* feat: support Jackson JsonView  [(#1162)](https://github.com/tangcent/easy-yapi/pull/1162)
+
+	* feat: add 'yapi.no_update.description' to stop api description updates  [(#1170)](https://github.com/tangcent/easy-yapi/pull/1170)
+
+	* feat: omit content-type header when no parameters are present  [(#1169)](https://github.com/tangcent/easy-yapi/pull/1169)
+
+	* build: update IntelliJ plugin version from 1.14.2 to 1.17.1  [(#1166)](https://github.com/tangcent/easy-yapi/pull/1166)
+
+	* feat(script): add support for 'mavenId()' in 'class'  [(#1155)](https://github.com/tangcent/easy-yapi/pull/1155)
+
+	* chore: add missing space in log message for setting Postman privateToken  [(#1148)](https://github.com/tangcent/easy-yapi/pull/1148)
 * 2.7.2
 	* fix: remove Non-extendable interface usage  [(#1146)](https://github.com/tangcent/easy-yapi/pull/1146)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 plugin_name=EasyYapi
-plugin_version=2.7.2.212.0
+plugin_version=2.7.3.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2
-itangcent_intellij_version=1.6.6
+itangcent_intellij_version=1.7.0

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,12 +1,14 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.2">v2.7.2(2024-06-30)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.3">v2.7.3(2024-10-25)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
-<h3>Fixes:</h3>
-
 <ul>
-  <li>fix: remove Non-extendable interface usage (<a href="https://github.com/tangcent/easy-yapi/pull/1146">#1146</a>)</li>
+  <li>feat: support Jackson JsonView (<a href="https://github.com/tangcent/easy-yapi/pull/1162">#1162</a>)</li>
 
-  <li>fix: correct content-type for Postman API export (<a href="https://github.com/tangcent/easy-yapi/pull/1144">#1144</a>)</li>
+  <li>feat: add 'yapi.no_update.description' to stop api description updates (<a href="https://github.com/tangcent/easy-yapi/pull/1170">#1170</a>)</li>
+
+  <li>feat: omit content-type header when no parameters are present (<a href="https://github.com/tangcent/easy-yapi/pull/1169">#1169</a>)</li>
+
+  <li>feat(script): add support for 'mavenId()' in 'class' (<a href="https://github.com/tangcent/easy-yapi/pull/1155">#1155</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.7.2.212.0</version>
+    <version>2.7.3.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: support Jackson JsonView  [(#1162)](https://github.com/tangcent/easy-yapi/pull/1162)

* feat: add 'yapi.no_update.description' to stop api description updates  [(#1170)](https://github.com/tangcent/easy-yapi/pull/1170)

* feat: omit content-type header when no parameters are present  [(#1169)](https://github.com/tangcent/easy-yapi/pull/1169)

* build: update IntelliJ plugin version from 1.14.2 to 1.17.1  [(#1166)](https://github.com/tangcent/easy-yapi/pull/1166)

* feat(script): add support for 'mavenId()' in 'class'  [(#1155)](https://github.com/tangcent/easy-yapi/pull/1155)

* chore: add missing space in log message for setting Postman privateToken  [(#1148)](https://github.com/tangcent/easy-yapi/pull/1148)