### PR TITLE
release 2.7.5

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,11 @@
+* 2.7.5
+	* feat: Introduces a new ApiDashboardPanel for API testing  [(#1191)](https://github.com/tangcent/easy-yapi/pull/1191)
+
+	* chore: remove the usage of ThrottleHelper  [(#1189)](https://github.com/tangcent/easy-yapi/pull/1189)
+
+	* feat: Add Support for Meta-Spring Controller Annotations  [(#1187)](https://github.com/tangcent/easy-yapi/pull/1187)
+
+	* fix: correct YapiSaveInterceptor order for no_update.description config  [(#1185)](https://github.com/tangcent/easy-yapi/pull/1185)
 * 2.7.4
 	* build: update project dependencies  [(#1180)](https://github.com/tangcent/easy-yapi/pull/1180)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.7.4.212.0
+plugin_version=2.7.5.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,10 +1,16 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.4">v2.7.4(2025-01-01)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.5">v2.7.5(2025-03-01)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
+<ul>
+  <li>feat: Introduces a new ApiDashboardPanel for API testing (<a href="https://github.com/tangcent/easy-yapi/pull/1191">#1191</a>)</li>
+
+  <li>feat: Add Support for Meta-Spring Controller Annotations (<a href="https://github.com/tangcent/easy-yapi/pull/1187">#1187</a>)</li>
+</ul>
+
 <h3>Fixes:</h3>
 
 <ul>
-  <li>fix: update methods in ScriptRuleParser to avoid return types with parameter type erasure (<a href="https://github.com/tangcent/easy-yapi/pull/1176">#1176</a>)</li>
+  <li>fix: correct YapiSaveInterceptor order for no_update.description config (<a href="https://github.com/tangcent/easy-yapi/pull/1185">#1185</a>)</li>
 </ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.7.4.212.0</version>
+    <version>2.7.5.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* feat: Introduces a new ApiDashboardPanel for API testing  [(#1191)](https://github.com/tangcent/easy-yapi/pull/1191)

* chore: remove the usage of ThrottleHelper  [(#1189)](https://github.com/tangcent/easy-yapi/pull/1189)

* feat: Add Support for Meta-Spring Controller Annotations  [(#1187)](https://github.com/tangcent/easy-yapi/pull/1187)

* fix: correct YapiSaveInterceptor order for no_update.description config  [(#1185)](https://github.com/tangcent/easy-yapi/pull/1185)
