### PR TITLE
release 2.7.7

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,5 @@
+* 2.7.7
+	* fix: several ApiExport actions cannot export method docs  [(#1201)](https://github.com/tangcent/easy-yapi/pull/1201)
 * 2.7.6
 	* feat: implement cookie persistence in ApiDashboardPanel  [(#1198)](https://github.com/tangcent/easy-yapi/pull/1198)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 plugin_name=EasyYapi
-plugin_version=2.7.6.212.0
+plugin_version=2.7.7.212.0
 kotlin.code.style=official
 kotlin_version=1.8.0
 junit_version=5.9.2
-itangcent_intellij_version=1.7.4
+itangcent_intellij_version=1.7.5

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,12 +1,10 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.6">v2.7.6(2025-03-09)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.7.7">v2.7.7(2025-03-12)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
 
-<ul>
-  <li>feat: implement cookie persistence in ApiDashboardPanel (<a href="https://github.com/tangcent/easy-yapi/pull/1198">#1198</a>)</li>
-
-  <li>feat: Improve ApiDashboard lifecycle management and context handling (<a href="https://github.com/tangcent/easy-yapi/pull/1197">#1197</a>)</li>
-</ul>
-
 <h3>Fixes:</h3>
+
+<ul>
+  <li>fix: several ApiExport actions cannot export method docs (<a href="https://github.com/tangcent/easy-yapi/pull/1201">#1201</a>)</li>
+</ul>

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
-    <version>2.7.6.212.0</version>
+    <version>2.7.7.212.0</version>
     <vendor email="pentatangcent@gmail.com" url="https://github.com/tangcent">Tangcent</vendor>
 
     <description><![CDATA[ Description will be added by gradle build]]></description>


### PR DESCRIPTION
* fix: several ApiExport actions cannot export method docs  [(#1201)](https://github.com/tangcent/easy-yapi/pull/1201)