### PR TITLE
refactor(postman): standardize rule key naming pattern

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/RequestBuilderListener.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/RequestBuilderListener.kt
@@ -121,11 +121,11 @@ interface RequestBuilderListener {
         bodyDesc: String?,
     )
 
+    //endregion
+
     fun startProcessMethod(methodExportContext: MethodExportContext, request: Request)
 
     fun processCompleted(methodExportContext: MethodExportContext, request: Request)
-
-    //endregion
 }
 
 //region utils------------------------------------------------------------------

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanExportRuleKeys.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanExportRuleKeys.kt
@@ -24,7 +24,8 @@ object PostmanExportRuleKeys {
      * @see [https://learning.postman.com/docs/writing-scripts/pre-request-scripts]
      */
     val CLASS_POST_PRE_REQUEST: RuleKey<String> = SimpleRuleKey(
-        "class.postman.prerequest",
+        "postman.class.prerequest",
+        alias = arrayOf("class.postman.prerequest"),
         StringRuleMode.MERGE
     )
 
@@ -35,7 +36,8 @@ object PostmanExportRuleKeys {
      * @see [https://learning.postman.com/docs/writing-scripts/pre-request-scripts]
      */
     val COLLECTION_POST_PRE_REQUEST: RuleKey<String> = SimpleRuleKey(
-        "collection.postman.prerequest",
+        "postman.collection.prerequest",
+        alias = arrayOf("collection.postman.prerequest"),
         StringRuleMode.MERGE
     )
 
@@ -56,7 +58,8 @@ object PostmanExportRuleKeys {
      * @see [https://learning.postman.com/docs/writing-scripts/test-scripts/]
      */
     val CLASS_POST_TEST: RuleKey<String> = SimpleRuleKey(
-        "class.postman.test",
+        "postman.class.test",
+        alias = arrayOf("class.postman.test"),
         StringRuleMode.MERGE
     )
 
@@ -67,7 +70,8 @@ object PostmanExportRuleKeys {
      * @see [https://learning.postman.com/docs/writing-scripts/test-scripts/]
      */
     val COLLECTION_POST_TEST: RuleKey<String> = SimpleRuleKey(
-        "collection.postman.test",
+        "postman.collection.test",
+        alias = arrayOf("collection.postman.test"),
         StringRuleMode.MERGE
     )
 

--- a/idea-plugin/src/test/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanFormatFolderHelperTest.kt
+++ b/idea-plugin/src/test/kotlin/com/itangcent/idea/plugin/api/export/postman/PostmanFormatFolderHelperTest.kt
@@ -29,7 +29,20 @@ internal class PostmanFormatFolderHelperTest : PluginContextLightCodeInsightFixt
 
     override fun customConfig(): String {
         //language=Properties
-        return "# read folder name from tag `folder`\nfolder.name=#folder\nclass.postman.prerequest=```\npm.environment.set(\"token\", \"123456\");\n```\nclass.postman.test=```\npm.test(\"Successful POST request\", function () {\npm.expect(pm.response.code).to.be.oneOf([201,202]);\n});\n```"
+        return """
+            # read folder name from tag `folder`
+            folder.name=#folder
+            
+            postman.class.prerequest=```
+            pm.environment.set("token", "123456");
+            ```
+            
+            postman.class.test=```
+            pm.test("Successful POST request", function () {
+            pm.expect(pm.response.code).to.be.oneOf([201,202]);
+            });
+            ```
+        """.trimIndent()
     }
 
     override fun setUp() {
@@ -173,6 +186,5 @@ internal class PostmanFormatFolderHelperTest : PluginContextLightCodeInsightFixt
             assertNull(it.getExt(PostmanExportRuleKeys.POST_PRE_REQUEST.name()))
             assertNull(it.getExt(PostmanExportRuleKeys.POST_TEST.name()))
         }
-
     }
 }


### PR DESCRIPTION
- Update rule keys to consistently start with "postman." prefix:
  - CLASS_POST_PRE_REQUEST
  - COLLECTION_POST_PRE_REQUEST
  - CLASS_POST_TEST
  - COLLECTION_POST_TEST
- Keep original keys as aliases for backward compatibility