### PR TITLE
chore: Add debug logging around field.advanced computation in YapiPsiClassHelper

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiPsiClassHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/yapi/YapiPsiClassHelper.kt
@@ -62,13 +62,22 @@ class YapiPsiClassHelper : CustomizedPsiClassHelper() {
             }
 
         //compute `field.advanced`
+        logger.debug("-".repeat(30))
+        logger.debug("Computing advanced value for field: ${accessibleField.jsonFieldName()}")
+        logger.debug(
+            "Loaded rules:" + configReader.read(YapiClassExportRuleKeys.FIELD_ADVANCED.name())?.joinToString("\n")
+        )
         val advancedValue = ruleComputer.computer(
             YapiClassExportRuleKeys.FIELD_ADVANCED,
             accessibleField
         )
         if (advancedValue.notNullOrEmpty()) {
             fields.sub(Attrs.ADVANCED_ATTR)[accessibleField.jsonFieldName()] = advancedValue
+            logger.debug("Computed advanced value for field ${accessibleField.jsonFieldName()}: $advancedValue")
+        } else {
+            logger.debug("No advanced value computed for field: ${accessibleField.jsonFieldName()}")
         }
+        logger.debug("-".repeat(30))
 
         super.afterParseField(accessibleField, resourcePsiClass, resolveContext, fields)
     }


### PR DESCRIPTION
This PR introduces additional logging to assist in debugging and investigating an issue, referenced as [#1245](https://github.com/tangcent/easy-yapi/issues/1245).

Please note: This PR is for debug purposes only and is not intended for merging into `master`. The changes are temporary and will be reverted once the issue is identified and resolved.