### PR TITLE
chore: Replace deprecated `URL` constructor calls with `asUrl()` extension

### DIFF
--- a/common-api/src/main/kotlin/com/itangcent/http/RequestUtils.kt
+++ b/common-api/src/main/kotlin/com/itangcent/http/RequestUtils.kt
@@ -2,7 +2,6 @@ package com.itangcent.http
 
 import com.itangcent.common.constant.Attrs
 import com.itangcent.common.utils.*
-import java.net.URL
 
 object RequestUtils {
 
@@ -57,7 +56,7 @@ object RequestUtils {
             return url
         }
         return try {
-            URL(url)
+            url.asUrl()
             url
         } catch (e: Exception) {
             protocol.removeSuffix("://") + "://" + url
@@ -79,11 +78,11 @@ object RequestUtils {
             return this
         }
 
-        fun host(host: String?): UrlBuild {
+        fun host(host: String): UrlBuild {
             try {
-                val parsedURL = URL(host)
+                val parsedURL = host.asUrl()
                 this.protocol = parsedURL.protocol
-                this.host = host!!.removePrefix(this.protocol!! + "://")
+                this.host = host.removePrefix(this.protocol!! + "://")
             } catch (e: Exception) {
                 this.host = host
             }

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/config/CachedResourceResolver.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/config/CachedResourceResolver.kt
@@ -5,6 +5,7 @@ import com.google.inject.Singleton
 import com.itangcent.common.logger.Log
 import com.itangcent.common.logger.traceError
 import com.itangcent.common.utils.TimeSpanUtils
+import com.itangcent.common.utils.asUrl
 import com.itangcent.idea.plugin.api.cache.ProjectCacheRepository
 import com.itangcent.idea.plugin.settings.helper.HttpSettingsHelper
 import com.itangcent.idea.sqlite.SqliteDataResourceHelper
@@ -51,7 +52,7 @@ open class CachedResourceResolver : DefaultResourceResolver() {
     }
 
     override fun createUrlResource(url: String): URLResource {
-        return CachedURLResource(URL(url))
+        return CachedURLResource(url.asUrl())
     }
 
     open inner class CachedURLResource(url: URL) : URLResource(url) {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/icons/EasyIcons.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/icons/EasyIcons.kt
@@ -3,6 +3,7 @@ package com.itangcent.idea.icons
 import com.intellij.util.ReflectionUtil
 import com.itangcent.common.logger.Log
 import com.itangcent.common.spi.SpiUtils
+import com.itangcent.common.utils.asUrl
 import com.itangcent.common.utils.invokeMethod
 import com.itangcent.common.utils.safe
 import com.itangcent.idea.sqlite.encodeBase64
@@ -155,7 +156,7 @@ object EasyIcons : Log() {
     }
 
     private fun tryLoadByUrl(vararg urls: String): Icon? {
-        return tryLoadByUrl(*urls.map { URL(it) }.toTypedArray())
+        return tryLoadByUrl(*urls.map { it.asUrl() }.toTypedArray())
     }
 
     private fun tryLoadByUrl(vararg urls: URL): Icon? {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/helper/HttpSettingsHelperImpl.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/settings/helper/HttpSettingsHelperImpl.kt
@@ -4,11 +4,11 @@ import com.google.inject.ImplementedBy
 import com.google.inject.Inject
 import com.google.inject.Singleton
 import com.intellij.openapi.ui.Messages
+import com.itangcent.common.utils.asUrl
 import com.itangcent.idea.plugin.settings.SettingBinder
 import com.itangcent.idea.plugin.settings.update
 import com.itangcent.idea.plugin.utils.RegexUtils
 import com.itangcent.idea.swing.MessagesHelper
-import java.net.URL
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -104,7 +104,7 @@ class HttpSettingsHelperImpl : HttpSettingsHelper {
             HOST_RESOLVERS.forEach { resolver ->
                 resolver(url)?.let { return it.removeSuffix("/") }
             }
-            return URL(url).let { "${it.protocol}://${it.host}" }.removeSuffix("/")
+            return url.asUrl().let { "${it.protocol}://${it.host}" }.removeSuffix("/")
         } catch (e: Exception) {
             return url
         }

--- a/idea-plugin/src/test/kotlin/com/itangcent/idea/plugin/api/export/markdown/TemplateMarkdownFormatterTest.kt
+++ b/idea-plugin/src/test/kotlin/com/itangcent/idea/plugin/api/export/markdown/TemplateMarkdownFormatterTest.kt
@@ -4,6 +4,7 @@ import com.itangcent.common.model.Header
 import com.itangcent.common.model.Param
 import com.itangcent.common.model.Request
 import com.itangcent.common.model.URL
+import com.itangcent.common.utils.asUrl
 import com.itangcent.intellij.config.resource.Resource
 import com.itangcent.test.StringResource
 import com.itangcent.testFramework.PluginContextLightCodeInsightFixtureTestCase
@@ -277,7 +278,7 @@ class TemplateMarkdownFormatterTest : PluginContextLightCodeInsightFixtureTestCa
     fun testUnreachableTemplate() {
         val resource = object : Resource() {
             override val url: java.net.URL
-                get() = java.net.URL("file:template.md")
+                get() = "file:template.md".asUrl()
 
             override val content: String?
                 get() = "template content"

--- a/idea-plugin/src/test/kotlin/com/itangcent/test/StringResource.kt
+++ b/idea-plugin/src/test/kotlin/com/itangcent/test/StringResource.kt
@@ -1,5 +1,6 @@
 package com.itangcent.test
 
+import com.itangcent.common.utils.asUrl
 import com.itangcent.intellij.config.resource.Resource
 import java.io.InputStream
 import java.net.URL
@@ -9,7 +10,7 @@ class StringResource(
     private val str: String,
 ) : Resource() {
     override val url: URL
-        get() = URL(_url)
+        get() = _url.asUrl()
 
     override val bytes: ByteArray
         get() = str.toByteArray(Charsets.UTF_8)


### PR DESCRIPTION
 fix #1246