### PR TITLE
fix: improve module finding logic by prioritizing subclass context for inherited API methods

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/DefaultFormatFolderHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/api/export/core/DefaultFormatFolderHelper.kt
@@ -52,14 +52,10 @@ open class DefaultFormatFolderHelper : FormatFolderHelper {
         }
 
         if (resource is PsiResource) {
-            resource.resource()?.let {
-                tryResolveFolder(it, false)
-            }?.let {
+            tryResolveFolder(resource.resource(), false)?.let {
                 return it
             }
-            resource.resourceClass()?.let {
-                return tryResolveFolder(it)
-            }
+            return tryResolveFolder(resource.resourceClass())
         }
 
         if (resource is PsiClass) {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/psi/PsiResource.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/psi/PsiResource.kt
@@ -7,10 +7,9 @@ import com.itangcent.common.model.Doc
 
 interface PsiResource {
 
-    fun resourceClass(): PsiClass?
+    fun resourceClass(): PsiClass
 
-    fun resource(): PsiElement?
-
+    fun resource(): PsiElement
 }
 
 fun Doc?.resourceClass(): PsiClass? {

--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/ModuleHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/ModuleHelper.kt
@@ -14,9 +14,11 @@ interface ModuleHelper {
 
     fun findModule(resource: Any): String?
 
+    fun findModule(psiClass: PsiClass, psiMethod: PsiMethod): String?
+
     fun findModule(psiMethod: PsiMethod): String?
 
-    fun findModule(cls: PsiClass): String?
+    fun findModule(psiClass: PsiClass): String?
 
     fun findModule(psiFile: PsiFile): String?
 

--- a/idea-plugin/src/test/kotlin/com/itangcent/idea/utils/DefaultModuleHelperTest.kt
+++ b/idea-plugin/src/test/kotlin/com/itangcent/idea/utils/DefaultModuleHelperTest.kt
@@ -17,6 +17,7 @@ internal class DefaultModuleHelperTest : PluginContextLightCodeInsightFixtureTes
 
     private lateinit var testCtrlPsiFile: PsiFile
     private lateinit var testCtrlPsiClass: PsiClass
+    private lateinit var baseControllerPsiClass: PsiClass
     private lateinit var userCtrlPsiFile: PsiFile
     private lateinit var userCtrlPsiClass: PsiClass
 
@@ -27,6 +28,7 @@ internal class DefaultModuleHelperTest : PluginContextLightCodeInsightFixtureTes
         super.setUp()
         testCtrlPsiFile = loadFile("api/TestCtrl.java")!!
         testCtrlPsiClass = (testCtrlPsiFile as PsiClassOwner).classes[0]
+        baseControllerPsiClass = loadClass("api/BaseController.java")!!
         userCtrlPsiFile = loadFile("api/UserCtrl.java")!!
         userCtrlPsiClass = (userCtrlPsiFile as PsiClassOwner).classes[0]
     }
@@ -40,24 +42,55 @@ internal class DefaultModuleHelperTest : PluginContextLightCodeInsightFixtureTes
         return "module=#module"
     }
 
-    fun testFindModule() {
+    fun testFindModuleWithString() {
+        // Test findModule with String parameter
         assertEquals(null, moduleHelper.findModule("any thing"))
+    }
+
+    fun testFindModuleWithPsiFile() {
+        // Test findModule with PsiFile parameter
         assertEquals(this.module.name, moduleHelper.findModule(testCtrlPsiFile))
         assertEquals(this.module.name, moduleHelper.findModule(testCtrlPsiFile as Any))
+        assertEquals(this.module.name, moduleHelper.findModule(userCtrlPsiFile))
+        assertEquals(this.module.name, moduleHelper.findModule(userCtrlPsiFile as Any))
+    }
+
+    fun testFindModuleWithPsiClass() {
+        // Test findModule with PsiClass parameter
         assertEquals(this.module.name, moduleHelper.findModule(testCtrlPsiClass))
         assertEquals(this.module.name, moduleHelper.findModule(testCtrlPsiClass as Any))
         assertEquals(this.module.name, moduleHelper.findModule(PsiClassResource(testCtrlPsiClass)))
+        assertEquals("users", moduleHelper.findModule(userCtrlPsiClass))
+        assertEquals("users", moduleHelper.findModule(userCtrlPsiClass as Any))
+    }
+
+    fun testFindModuleWithPsiMethod() {
+        // Test findModule with PsiMethod parameter
         assertEquals("test-only", moduleHelper.findModule(testCtrlPsiClass.methods[0]))
         assertEquals("test-only", moduleHelper.findModule(testCtrlPsiClass.methods[0] as Any))
         assertEquals("test-only", moduleHelper.findModule(PsiMethodResource(testCtrlPsiClass.methods[0], testCtrlPsiClass)))
-        assertEquals(this.module.name, moduleHelper.findModule(userCtrlPsiFile))
-        assertEquals(this.module.name, moduleHelper.findModule(userCtrlPsiFile as Any))
-        assertEquals("users", moduleHelper.findModule(userCtrlPsiClass))
-        assertEquals("users", moduleHelper.findModule(userCtrlPsiClass as Any))
         assertEquals("users", moduleHelper.findModule(userCtrlPsiClass.methods[0]))
         assertEquals("users", moduleHelper.findModule(userCtrlPsiClass.methods[0] as Any))
+    }
 
-        //findModuleByPath--------------------------------------------
+    fun testFindModuleWithInheritedMethods() {
+        // Test findModule with inherited methods (issue #1267)
+        // Calling with explicit class+method should prioritize subclass's module
+        assertEquals(
+            "users",
+            moduleHelper.findModule(userCtrlPsiClass, baseControllerPsiClass.methods[0])
+        )
+        // Calling via PsiMethodResource with resourceClass=subclass should also return subclass module
+        assertEquals(
+            "users",
+            moduleHelper.findModule(
+                PsiMethodResource(baseControllerPsiClass.methods[0], userCtrlPsiClass)
+            )
+        )
+    }
+
+    fun testFindModuleByPath() {
+        // Test findModuleByPath with various path formats
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/src/main/kotlin/com/itangcent"))
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/src/main/java/com/itangcent"))
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/src/main/scala/com/itangcent"))
@@ -66,6 +99,5 @@ internal class DefaultModuleHelperTest : PluginContextLightCodeInsightFixtureTes
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/kotlin/com/itangcent"))
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/java/com/itangcent"))
         assertEquals("idea-plugin", moduleHelper.findModuleByPath("easy-yapi/idea-plugin/scala/com/itangcent"))
-
     }
 }

--- a/idea-plugin/src/test/kotlin/com/itangcent/mock/ConstantModuleHelper.kt
+++ b/idea-plugin/src/test/kotlin/com/itangcent/mock/ConstantModuleHelper.kt
@@ -13,11 +13,18 @@ class ConstantModuleHelper(private val module: String) : ModuleHelper {
         return module
     }
 
+    override fun findModule(
+        psiClass: PsiClass,
+        psiMethod: PsiMethod
+    ): String? {
+        return module
+    }
+
     override fun findModule(psiMethod: PsiMethod): String {
         return module
     }
 
-    override fun findModule(cls: PsiClass): String {
+    override fun findModule(psiClass: PsiClass): String {
         return module
     }
 


### PR DESCRIPTION
- Add support for finding module by class+method combination to properly handle inherited methods
- Make PsiResource methods non-nullable to simplify usage
- Update tests to verify module resolution for inherited methods

---

fix #1266