### PR TITLE
fix: declare incompatible-with easy-api to prevent action ID conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ plugin-adapter/build/
 plugin-adapter/plugin-adapter-markdown/build/
 gradle/wrapper/caches
 gradle/wrapper/daemon
+build
+bin

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -27,9 +27,12 @@
     <depends optional="true">org.jetbrains.idea.maven</depends>
     <depends optional="true">com.intellij.gradle</depends>
 
+    <!-- EasyYapi is a superset of EasyApi. They share the same action IDs, so they cannot coexist. -->
+    <incompatible-with>com.itangcent.idea.plugin.easy-api</incompatible-with>
+
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add the tool window extension -->
-        <toolWindow id="API Dashboard" 
+        <toolWindow id="API Dashboard"
                    secondary="true"
                    icon="AllIcons.Toolwindows.ToolWindowRun"
                    anchor="right"


### PR DESCRIPTION
When both easy-api and easy-yapi are installed, duplicate action IDs cause IDEA to fail on startup. Use the platform-native <incompatible-with> element so IntelliJ prevents both plugins from being enabled simultaneously and lets the user choose which to keep.