### PR TITLE
fix: resolve MavenId binary incompatibility with IntelliJ IDEA 2025.1+ (IU-261)

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/MavenHelper.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/utils/MavenHelper.kt
@@ -32,6 +32,8 @@ object MavenHelper {
 
     /**
      * Retrieves the Maven ID of a PsiClass using Maven.
+     * Uses reflection to access MavenId to avoid binary incompatibility
+     * with newer IntelliJ versions where MavenId class may be in a different classloader.
      *
      * @param psiClass the PsiClass for which the Maven ID is to be retrieved.
      * @return MavenIdData if found, null otherwise.
@@ -43,11 +45,16 @@ object MavenHelper {
 
         val mavenProjectsManager = MavenProjectsManager.getInstance(project)
         val mavenProject = mavenProjectsManager.findProject(module) ?: return null
-        val mavenId = mavenProject.mavenId
+        // Use reflection to access mavenId and its properties to avoid direct dependency on
+        // org.jetbrains.idea.maven.model.MavenId which may not be resolvable in some IDEA versions
+        val mavenId = mavenProject.javaClass.getMethod("getMavenId").invoke(mavenProject) ?: return null
+        val groupId = mavenId.javaClass.getMethod("getGroupId").invoke(mavenId) as? String ?: return null
+        val artifactId = mavenId.javaClass.getMethod("getArtifactId").invoke(mavenId) as? String ?: return null
+        val version = mavenId.javaClass.getMethod("getVersion").invoke(mavenId) as? String ?: return null
         return MavenIdData(
-            groupId = mavenId.groupId!!,
-            artifactId = mavenId.artifactId!!,
-            version = mavenId.version!!
+            groupId = groupId,
+            artifactId = artifactId,
+            version = version
         )
     }
 


### PR DESCRIPTION
## Summary

Fix binary incompatibility with IntelliJ IDEA IU-261.22158.121 caused by unresolved class `org.jetbrains.idea.maven.model.MavenId`.

fix https://github.com/tangcent/easy-yapi/issues/1277

## Problem

`MavenHelper.getMavenIdByMaven(PsiClass)` directly accessed `mavenProject.mavenId`, which generates bytecode referencing `org.jetbrains.idea.maven.model.MavenId` as a return type. In IntelliJ IDEA 2025.1+ (build 261), the Maven model module was extracted into a separate classloader, making `MavenId` no longer resolvable from the plugin's classloader. This leads to `NoSuchClassError` at runtime.

## Fix

Replace direct property access with reflection for the entire call chain:

1. Call `getMavenId()` on `MavenProject` via reflection
2. Call `getGroupId()`, `getArtifactId()`, `getVersion()` on the returned object via reflection

This avoids any compile-time or runtime dependency on `org.jetbrains.idea.maven.model.MavenId`.