### PR TITLE
fix: avoid shell interpretation of PR body in CI workflows

### DIFF
--- a/.github/workflows/pr-close-issue.yml
+++ b/.github/workflows/pr-close-issue.yml
@@ -12,9 +12,11 @@ jobs:
       - name: Check for issue number
         id: check_issue
         shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Store PR body in a file to avoid shell interpretation issues
-          echo '${{ github.event.pull_request.body }}' > pr_body.txt
+          # Store PR body in a file using env var to avoid shell interpretation issues
+          printf '%s' "$PR_BODY" > pr_body.txt
           
           # Check for issue reference pattern
           if grep -q "#[0-9]\\+" pr_body.txt; then

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Check for issue number
         id: check_issue
         shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Store PR body in a file to avoid shell interpretation issues
-          echo '${{ github.event.pull_request.body }}' > pr_body.txt
+          # Store PR body in a file using env var to avoid shell interpretation issues
+          printf '%s' "$PR_BODY" > pr_body.txt
           
           # Check for issue reference pattern
           if grep -q "#[0-9]\\+" pr_body.txt; then


### PR DESCRIPTION
## Summary

Fix CI workflow failures caused by special characters (backticks, single quotes, etc.) in PR body text being interpreted as shell commands.

## Problem

Both pr-package.yml and pr-close-issue.yml used direct GitHub Actions template substitution inside shell scripts:

    echo '${{ github.event.pull_request.body }}'

This causes the PR body content to be injected directly into the shell script, where backticks are interpreted as command substitution and single quotes break quoting. This led to CI failures like:

    NoSuchClassError: command not found
    syntax error: unexpected end of file

## Fix

Pass the PR body as an environment variable and use printf to write it safely:

    env:
      PR_BODY: ${{ github.event.pull_request.body }}
    run: |
      printf '%s' "$PR_BODY" > pr_body.txt

This avoids any shell interpretation of the PR body content.