### PR TITLE
fix: resolve IconLoader.findIcon NoSuchMethodError with IDEA 2024.1+

### DIFF
--- a/idea-plugin/src/main/kotlin/com/itangcent/idea/icons/EasyIcons.kt
+++ b/idea-plugin/src/main/kotlin/com/itangcent/idea/icons/EasyIcons.kt
@@ -183,7 +183,8 @@ object DefaultIconLoader : IconLoader {
 
     override fun findIcon(url: URL?): Icon? {
         url ?: return null
-        return com.intellij.openapi.util.IconLoader.findIcon(tryLoadCache(url))
+        val cachedUrl = tryLoadCache(url)
+        return javax.swing.ImageIcon(cachedUrl)
     }
 
     private fun tryLoadCache(url: URL): URL {


### PR DESCRIPTION
## Summary
Fix binary incompatibility with IconLoader.findIcon(URL) method in IntelliJ IDEA 2024.1+

## Problem
EasyYapi was binary incompatible with IntelliJ IDEA IU-233.15619.7 due to:
- Method not found: IconLoader.findIcon$default(...)
- Invocation of unresolved method IconLoader.findIcon(URL)

This could lead to NoSuchMethodError exception at runtime.

## Solution
Replace the deprecated/removed IconLoader.findIcon(URL) API with javax.swing.ImageIcon
- This approach is compatible with all IntelliJ versions
- Avoids binary incompatibility issues with newer IDEA versions

## Testing
- Build completed successfully
- No compilation errors