### PR TITLE
Release v2.8.5

### DIFF
--- a/IDEA_CHANGELOG.md
+++ b/IDEA_CHANGELOG.md
@@ -1,3 +1,11 @@
+* 2.8.5
+	* fix: fix IconLoader compatibility  [(#1281)](https://github.com/tangcent/easy-yapi/pull/1281)
+
+	* fix: use reflection to access MavenId to avoid binary incompatibility with IDEA 261+  [(#1279)](https://github.com/tangcent/easy-yapi/pull/1279)
+
+	* fix: avoid shell interpretation of PR body in CI workflows  [(#1280)](https://github.com/tangcent/easy-yapi/pull/1280)
+
+	* fix: declare incompatible-with easy-api to prevent action ID conflicts  [(#1278)](https://github.com/tangcent/easy-yapi/pull/1278)
 * 2.8.4
 	* fix: improve module finding logic by prioritizing subclass context for inherited API methods  [(#1268)](https://github.com/tangcent/easy-yapi/pull/1268)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 plugin_name=EasyYapi
-plugin_version=2.8.4.212.0
+plugin_version=2.8.5.212.0
 kotlin.code.style=official
 kotlin_version=2.1.0
 junit_version=5.9.2

--- a/idea-plugin/parts/pluginChanges.html
+++ b/idea-plugin/parts/pluginChanges.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.8.4">v2.8.4(2026-01-13)</a><br>
+<a href="https://github.com/tangcent/easy-yapi/releases/tag/v2.8.5">v2.8.5(2026-03-16)</a><br>
 <a href="https://github.com/tangcent/easy-yapi/blob/master/IDEA_CHANGELOG.md">Full Changelog</a>
 
 <h3>Enhancements:</h3>
@@ -6,5 +6,11 @@
 <h3>Fixes:</h3>
 
 <ul>
-  <li>fix: improve module finding logic by prioritizing subclass context for inherited API methods (<a href="https://github.com/tangcent/easy-yapi/pull/1268">#1268</a>)</li>
+  <li>fix: fix IconLoader compatibility (<a href="https://github.com/tangcent/easy-yapi/pull/1281">#1281</a>)</li>
+
+  <li>fix: use reflection to access MavenId to avoid binary incompatibility with IDEA 261+ (<a href="https://github.com/tangcent/easy-yapi/pull/1279">#1279</a>)</li>
+
+  <li>fix: avoid shell interpretation of PR body in CI workflows (<a href="https://github.com/tangcent/easy-yapi/pull/1280">#1280</a>)</li>
+
+  <li>fix: declare incompatible-with easy-api to prevent action ID conflicts (<a href="https://github.com/tangcent/easy-yapi/pull/1278">#1278</a>)</li>
 </ul>


### PR DESCRIPTION
## Release Changes

* fix: fix IconLoader compatibility (#1281)
* fix: use reflection to access MavenId to avoid binary incompatibility with IDEA 261+ (#1279)
* fix: avoid shell interpretation of PR body in CI workflows (#1280)
* fix: declare incompatible-with easy-api to prevent action ID conflicts