### PR TITLE
release/v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the EasyAPI plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-02
+
+### Added
+-  add toString() methods to ScriptPsi contexts
+
+### Fixed
+-  expire setting binder cache after timeout
+-  improve yapi token diagnostics and test coverage (#1292)
+-  improve API scan performance and add auto-scan toggle
+-  inherited controller export — superMethod perf, generic param scoping, resolver early-exit
+-  add path formatting/sanitization for YAPI export (#1288)
+
+---
+
 ## [3.0.0] - TBD
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.itangcent"
-version = "3.0.0.252.0"
+version = "3.0.1.252.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Release Changes

* chore: add release script
* fix: expire setting binder cache after timeout
* fix: improve yapi token diagnostics and test coverage (#1292)
* fix: improve API scan performance and add auto-scan toggle
* fix: inherited controller export — superMethod perf, generic param scoping, resolver early-exit
* fix: add path formatting/sanitization for YAPI export (#1288)
* feat: add toString() methods to ScriptPsi contexts