### PR TITLE
fix: support forked yapi success response format

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
@@ -37,23 +37,6 @@ class DefaultYapiApiClient(
     private val httpClient: HttpClient
 ) : YapiApiClient {
 
-    companion object {
-        private const val GET_PROJECT = "/api/project/get"
-        private const val LIST_MENU = "/api/interface/list_menu"
-        private const val SAVE_API = "/api/interface/save"
-        private const val GET_CAT_MENU = "/api/interface/getCatMenu"
-        private const val ADD_CAT = "/api/interface/add_cat"
-        private const val LIST_CAT = "/api/interface/list_cat"
-
-        /**
-         * Page size for [LIST_CAT] requests. Auto-tuned upward (×1.4) when a response hits the
-         * current limit, capped at 5000. Shared across instances so the tuned value persists for
-         * the lifetime of the process.
-         */
-        @Volatile
-        private var apiPageLimit: Int = 1000
-    }
-
     /** Cached project ID for this client instance. Populated on first [getProjectId] call. */
     private var cachedProjectId: String? = null
 
@@ -236,26 +219,57 @@ class DefaultYapiApiClient(
     /**
      * Parses a raw [HttpResponse] into a typed [YapiResponse].
      *
+     * Handles multiple YAPI server response formats:
+     * - Standard YAPI: `{"errcode":0, "errmsg":"...", "data":{...}}`
+     * - Some forks:    `{"code":0, "message":"成功", "data":{...}}`
+     *
+     * Success is determined by: `errcode == 0`, or `code == 0`, or `message` being a known
+     * success string (e.g. "成功", "成功！") when no code field is present.
+     *
      * Failure cases:
      * - HTTP status != 200
      * - Body is not valid JSON
-     * - `errcode` field is non-zero (YAPI application-level error)
+     * - Response code field is non-zero (YAPI application-level error)
      * - [handle] returns null (missing expected data)
      *
      * @param res The raw HTTP response
      * @param handle Extracts the typed result from the parsed JSON body
      */
-    fun <T> parseResponse(res: HttpResponse, handle: (JsonObject) -> T?): YapiResponse<T> {
+    private fun <T> parseResponse(res: HttpResponse, handle: (JsonObject) -> T?): YapiResponse<T> {
         if (res.code != 200) return YapiResponse.failure("HTTP ${res.code}")
         val json = runCatching { GsonUtils.fromJson<JsonObject>(res.body ?: "") }.getOrNull()
             ?: return YapiResponse.failure("Invalid JSON response")
-        val errcode = json.get("errcode")?.asInt
-        if (errcode != 0) {
-            val errmsg = json.get("errmsg")?.asString ?: "Unknown error (errcode: $errcode)"
-            return YapiResponse.failure(errmsg)
+        val errcode = json.get("errcode")?.asInt ?: json.get("code")?.asInt
+        val errmsg = json.get("errmsg")?.asString ?: json.get("message")?.asString
+        val isSuccess = errmsg in SUCCESS_MESSAGES || errcode in SUCCESS_CODES
+        if (!isSuccess) {
+            return YapiResponse.failure(errmsg ?: "Unknown error (errcode: $errcode)")
         }
         return handle(json)?.let { YapiResponse.success(it) }
             ?: YapiResponse.failure("Empty data in response")
+    }
+
+    companion object {
+        private const val GET_PROJECT = "/api/project/get"
+        private const val LIST_MENU = "/api/interface/list_menu"
+        private const val SAVE_API = "/api/interface/save"
+        private const val GET_CAT_MENU = "/api/interface/getCatMenu"
+        private const val ADD_CAT = "/api/interface/add_cat"
+        private const val LIST_CAT = "/api/interface/list_cat"
+
+        /** Known success messages from various YAPI forks. */
+        private val SUCCESS_MESSAGES = setOf("成功", "成功！")
+
+        /** Known success codes: 0 (standard YAPI) and 200 (some forks). */
+        private val SUCCESS_CODES = setOf(0, 200)
+
+        /**
+         * Page size for [LIST_CAT] requests. Auto-tuned upward (×1.4) when a response hits the
+         * current limit, capped at 5000. Shared across instances so the tuned value persists for
+         * the lifetime of the process.
+         */
+        @Volatile
+        private var apiPageLimit: Int = 1000
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClientTest.kt
@@ -78,6 +78,24 @@ class DefaultYapiApiClientTest {
     }
 
     // -------------------------------------------------------------------------
+    // Helpers for fork-style responses (code/message instead of errcode/errmsg)
+    // -------------------------------------------------------------------------
+
+    /** Builds a fork-style success JSON: {"code":0,"message":"成功！",...} */
+    private fun forkSuccessJson(data: Any? = null): String {
+        val obj = JsonObject().apply {
+            addProperty("code", 0)
+            addProperty("message", "成功！")
+            if (data is JsonObject) add("data", data)
+            else if (data is JsonArray) add("data", data)
+        }
+        return obj.toString()
+    }
+
+    private fun forkErrorJson(code: Int = 401, message: String = "token无效"): String =
+        """{"code":$code,"message":"$message"}"""
+
+    // -------------------------------------------------------------------------
     // getProjectId
     // -------------------------------------------------------------------------
 
@@ -147,48 +165,122 @@ class DefaultYapiApiClientTest {
         assertFalse(result.isSuccess)
     }
 
-    // -------------------------------------------------------------------------
-    // parseResponse
-    // -------------------------------------------------------------------------
-
     @Test
-    fun `parseResponse returns failure for non-200 status`() {
-        val res = mockResponse("{}", code = 500)
-        val result = client.parseResponse(res) { "data" }
-        assertFalse(result.isSuccess)
-        assertTrue(result.errorMessage()!!.contains("500"))
-    }
+    fun `getProjectId resolves via list_menu when fork server returns code 0 without data`() = runBlocking {
+        // Fork server returns {"code":0,"message":"成功！"} with no data from GET_PROJECT
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse("""{"code":0,"message":"成功！"}"""))
 
-    @Test
-    fun `parseResponse returns failure for non-zero errcode`() {
-        val res = mockResponse(errorJson(40011, "token invalid"))
-        val result = client.parseResponse(res) { "data" }
-        assertFalse(result.isSuccess)
-        assertEquals("token invalid", result.errorMessage())
-    }
+        // list_menu returns an item with project_id
+        val menuItem = JsonObject().apply { addProperty("project_id", "55") }
+        val menuArray = JsonArray().apply { add(menuItem) }
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/list_menu") }))
+            .thenReturn(mockResponse("""{"code":0,"message":"成功！","data":${menuArray}}"""))
 
-    @Test
-    fun `parseResponse returns failure for invalid JSON`() {
-        val res = mockResponse("not-json")
-        val result = client.parseResponse(res) { "data" }
-        assertFalse(result.isSuccess)
-    }
-
-    @Test
-    fun `parseResponse returns failure when handler returns null`() {
-        val res = mockResponse(successJson(JsonObject()))
-        val result = client.parseResponse<String>(res) { null }
-        assertFalse(result.isSuccess)
-        assertTrue(result.errorMessage()!!.contains("Empty data"))
-    }
-
-    @Test
-    fun `parseResponse returns success with extracted data`() {
-        val data = JsonObject().apply { addProperty("_id", "123") }
-        val res = mockResponse(successJson(data))
-        val result = client.parseResponse(res) { it.getAsJsonObject("data")?.get("_id")?.asString }
+        val result = client.getProjectId()
         assertTrue(result.isSuccess)
-        assertEquals("123", result.getOrNull())
+        assertEquals("55", result.getOrNull())
+    }
+
+    // -------------------------------------------------------------------------
+    // Fork-format response handling (code/message instead of errcode/errmsg)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getProjectId resolves from GET_PROJECT with fork code 0 response`() = runBlocking {
+        val data = projectDataJson("200")
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse(forkSuccessJson(data)))
+
+        val result = client.getProjectId()
+        assertTrue(result.isSuccess)
+        assertEquals("200", result.getOrNull())
+    }
+
+    @Test
+    fun `getProjectId resolves when errcode is non-zero but errmsg indicates success`() = runBlocking {
+        // Some forks return errcode=200 with errmsg="成功" to mean success
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse("""{"errcode":200,"errmsg":"成功","data":{"_id":"42"}}"""))
+
+        val result = client.getProjectId()
+        assertTrue(result.isSuccess)
+        assertEquals("42", result.getOrNull())
+    }
+
+    @Test
+    fun `getProjectId resolves when errcode is 200 with no message`() = runBlocking {
+        // errcode=200 alone is a success code
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse("""{"errcode":200,"data":{"_id":"99"}}"""))
+
+        val result = client.getProjectId()
+        assertTrue(result.isSuccess)
+        assertEquals("99", result.getOrNull())
+    }
+
+    @Test
+    fun `getProjectId fails when fork server returns non-zero code`() = runBlocking {
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse(forkErrorJson(401, "token无效")))
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/list_menu") }))
+            .thenReturn(mockResponse(forkErrorJson(401, "token无效")))
+
+        val result = client.getProjectId()
+        assertFalse(result.isSuccess)
+    }
+
+    @Test
+    fun `listCarts works with fork-format responses`() = runBlocking {
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse(forkSuccessJson(projectDataJson("1"))))
+
+        val cartsArray = JsonArray().apply { add(cartJson(30, "Fork Cart")) }
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/getCatMenu") }))
+            .thenReturn(mockResponse(forkSuccessJson(cartsArray)))
+
+        val result = client.listCarts()
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()!!.size)
+        assertEquals("Fork Cart", result.getOrNull()!![0].name)
+    }
+
+    @Test
+    fun `uploadApi succeeds with fork-format responses`() = runBlocking {
+        val emptyList = JsonObject().apply { add("list", JsonArray()) }
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/list_cat") }))
+            .thenReturn(mockResponse(forkSuccessJson(emptyList)))
+
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/save") }))
+            .thenReturn(mockResponse(forkSuccessJson(JsonObject())))
+
+        val result = client.uploadApi(testDoc(), "cat1")
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `uploadApi fails when fork server returns error code`() = runBlocking {
+        val emptyList = JsonObject().apply { add("list", JsonArray()) }
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/list_cat") }))
+            .thenReturn(mockResponse(forkSuccessJson(emptyList)))
+
+        whenever(httpClient.execute(argThat { url.contains("/api/interface/save") }))
+            .thenReturn(mockResponse(forkErrorJson(500, "save failed")))
+
+        val result = client.uploadApi(testDoc(), "cat1")
+        assertFalse(result.isSuccess)
+        assertEquals("save failed", result.errorMessage())
+    }
+
+    @Test
+    fun `getProjectId handles response with only success message and no code field`() = runBlocking {
+        // Some forks return just {"message":"成功","data":{...}}
+        whenever(httpClient.execute(argThat { url.contains("/api/project/get") }))
+            .thenReturn(mockResponse("""{"message":"成功","data":{"_id":"333"}}"""))
+
+        val result = client.getProjectId()
+        assertTrue(result.isSuccess)
+        assertEquals("333", result.getOrNull())
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- accept fork-style YAPI response fields (`code`/`message`) in addition to standard `errcode`/`errmsg`
- treat fork success variants (message-only success and `errcode=200`) as successful responses
- extend `DefaultYapiApiClientTest` with fork-format success/failure coverage

## Verification
- ./gradlew test --tests com.itangcent.easyapi.exporter.yapi.DefaultYapiApiClientTest

Closes #1289
