### PR TITLE
feat: support api.status&api.open rule and fix tag export for YAPI

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
@@ -23,6 +23,7 @@ data class ApiEndpoint(
     val folder: String? = null,
     val description: String? = null,
     val tags: List<String> = emptyList(),
+    val open: Boolean = false,
     val sourceClass: com.intellij.psi.PsiClass? = null,
     val sourceMethod: com.intellij.psi.PsiMethod? = null,
     val className: String? = null,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
@@ -23,6 +23,7 @@ data class ApiEndpoint(
     val folder: String? = null,
     val description: String? = null,
     val tags: List<String> = emptyList(),
+    val status: String? = null,
     val open: Boolean = false,
     val sourceClass: com.intellij.psi.PsiClass? = null,
     val sourceMethod: com.intellij.psi.PsiMethod? = null,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -120,7 +120,7 @@ class SpringMvcClassExporter(
                 val description = metadataResolver.resolveMethodDoc(method)
                 val classDesc = metadataResolver.resolveClassDoc(psiClass)
                 val tags = metadataResolver.resolveApiTag(method)
-                    ?.split("\n")?.map { it.trim() }?.filter { it.isNotBlank() }
+                    ?.split(",", "\n")?.map { it.trim() }?.distinct()?.filter { it.isNotBlank() }
                     ?: emptyList()
 
                 val resolvedBindings = resolveParameterBindings(resolvedMethod)
@@ -134,6 +134,7 @@ class SpringMvcClassExporter(
                 val additionalParams = metadataResolver.resolveAdditionalParams(method)
                 val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
                 val apiOpen = metadataResolver.isApiOpen(method)
+                val apiStatus = metadataResolver.resolveApiStatus(method)
 
                 val defaultHttpMethod = metadataResolver.resolveDefaultHttpMethod(method)
                     ?.let { HttpMethod.fromSpring(it) }
@@ -171,6 +172,7 @@ class SpringMvcClassExporter(
                         folder = folder,
                         description = description,
                         tags = tags,
+                        status = apiStatus,
                         open = apiOpen,
                         sourceClass = psiClass,
                         sourceMethod = method,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -133,6 +133,7 @@ class SpringMvcClassExporter(
                 val additionalHeaders = metadataResolver.resolveAdditionalHeaders(method)
                 val additionalParams = metadataResolver.resolveAdditionalParams(method)
                 val additionalResponseHeaders = metadataResolver.resolveAdditionalResponseHeaders(method)
+                val apiOpen = metadataResolver.isApiOpen(method)
 
                 val defaultHttpMethod = metadataResolver.resolveDefaultHttpMethod(method)
                     ?.let { HttpMethod.fromSpring(it) }
@@ -170,6 +171,7 @@ class SpringMvcClassExporter(
                         folder = folder,
                         description = description,
                         tags = tags,
+                        open = apiOpen,
                         sourceClass = psiClass,
                         sourceMethod = method,
                         className = psiClass.qualifiedName ?: psiClass.name,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
@@ -314,6 +314,7 @@ class DefaultYapiApiClient(
         )
         doc.reqBodyType?.let { map["req_body_type"] = it }
         doc.resBodyType?.let { map["res_body_type"] = it }
+        doc.open?.let { map["api_opened"] = it }
         existingId?.let { map["id"] = it }
         return GsonUtils.toJson(map)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
@@ -305,6 +305,7 @@ class DefaultYapiApiClient(
             "req_body_other" to (doc.reqBodyOther ?: ""),
             "res_body" to (doc.resBody ?: ""),
             "tags" to (doc.tags ?: emptyList<String>()),
+            "tag" to (doc.tag ?: emptyList<String>()),
             "req_body_form" to (doc.reqBodyForm?.map {
                 linkedMapOf(
                     "name" to it.name, "example" to (it.example ?: ""), "type" to it.type,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
@@ -160,7 +160,8 @@ class YapiFormatter(
             resBody = resBody,
             resBodyType = if (httpMeta?.responseBody != null) "json" else null,
             resBodyIsJsonSchema = resBodyIsJsonSchema,
-            tags = endpoint.tags.ifEmpty { null }
+            tags = endpoint.tags.ifEmpty { null },
+            open = if (endpoint.open) true else null
         )
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
@@ -148,7 +148,7 @@ class YapiFormatter(
             path = formatPath(endpoint.path),
             method = httpMeta?.method?.name?.lowercase() ?: "get",
             desc = endpoint.description,
-            status = "done",
+            status = endpoint.status ?: "done",
             tag = endpoint.tags,
             reqHeaders = headers.ifEmpty { null },
             reqQuery = query.ifEmpty { null },

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/ApiMetadataResolver.kt
@@ -150,6 +150,10 @@ class ApiMetadataResolver(
     suspend fun resolveApiStatus(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.API_STATUS, method)
     }
+
+    suspend fun isApiOpen(method: PsiMethod): Boolean {
+        return engine.evaluate(RuleKeys.API_OPEN, method)
+    }
     
     suspend fun resolveModule(method: PsiMethod): String? {
         return engine.evaluate(RuleKeys.MODULE, method)

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -17,7 +17,7 @@ object RuleKeys {
 
     // ── API metadata ──────────────────────────────────────────────
     val API_NAME = RuleKey.string("api.name")
-    val API_TAG             = RuleKey.string("api.tag")
+    val API_TAG             = RuleKey.string("api.tag", StringRuleMode.MERGE_DISTINCT)
     val API_STATUS          = RuleKey.string("api.status")
     val API_OPEN            = RuleKey.boolean("api.open")
     val FOLDER_NAME = RuleKey.string("folder.name")

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleKeys.kt
@@ -19,6 +19,7 @@ object RuleKeys {
     val API_NAME = RuleKey.string("api.name")
     val API_TAG             = RuleKey.string("api.tag")
     val API_STATUS          = RuleKey.string("api.status")
+    val API_OPEN            = RuleKey.boolean("api.open")
     val FOLDER_NAME = RuleKey.string("folder.name")
     val MODULE = RuleKey.string("module")
     val IGNORE = RuleKey.boolean("ignore")

--- a/src/main/resources/extensions/yapi.config
+++ b/src/main/resources/extensions/yapi.config
@@ -1,0 +1,23 @@
+---
+code: yapi
+description: YAPI export rules (api.open, api.status, api.tag, field.mock)
+default-enabled: true
+---
+
+#yapi tag for java
+api.tag[@java.lang.Deprecated]=deprecated
+api.tag[#deprecated]=deprecated
+api.tag[groovy:it.containingClass().hasAnn("java.lang.Deprecated")]=deprecated
+api.tag[groovy:it.containingClass().hasDoc("deprecated")]=deprecated
+#yapi tag for kotlin
+api.tag[@kotlin.Deprecated]=deprecated
+api.tag[groovy:it.containingClass().hasAnn("kotlin.Deprecated")]=deprecated
+#yapi tag
+api.tag=#tag
+#yapi status
+api.status[#undone]=undone
+api.status[#todo]=undone
+#api open
+api.open[#open]=true
+#yapi mock
+field.mock=#mock

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
@@ -1,0 +1,164 @@
+package com.itangcent.easyapi.config.source
+
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.exporter.springmvc.SpringMvcClassExporter
+import com.itangcent.easyapi.psi.model.FieldModel
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class YapiConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: SpringMvcClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = SpringMvcClassExporter(project)
+    }
+
+    private fun loadTestFiles() {
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/RestController.java")
+        loadFile("spring/Controller.java")
+        loadFile("model/Result.java")
+        loadFile("model/IResult.java")
+        loadFile("model/UserInfo.java")
+        loadFile("java/lang/Deprecated.java",
+            "package java.lang;\npublic @interface Deprecated {}")
+        loadFile("api/yapi/YapiController.java")
+        loadFile("api/yapi/ItemDTO.java")
+        loadFile("api/yapi/DeprecatedController.java")
+        loadFile("api/yapi/DeprecatedDocController.java")
+    }
+
+    override fun createConfigReader(): TestConfigReader {
+        val yapiConfig = javaClass.getResourceAsStream("/extensions/yapi.config")
+            ?.bufferedReader()?.readText() ?: ""
+        return TestConfigReader.fromConfigText(yapiConfig)
+    }
+
+    // ── field.mock=#mock ─────────────────────────────────────────
+
+    fun testFieldMockWithMockTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val createEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.POST &&
+            it.httpMetadata?.path?.contains("create") == true
+        }
+        assertNotNull("Should find POST /yapi/create endpoint", createEndpoint)
+
+        val body = createEndpoint?.httpMetadata?.body
+        assertNotNull("POST endpoint should have request body", body)
+        assertNotNull("Body should be an ObjectModel", body?.asObject())
+
+        val idField = findField(body!!, "id")
+        assertNotNull("Should find id field in body. Available fields: ${body.asObject()?.fields?.keys}", idField)
+        assertEquals(
+            "Field with @mock tag should have mock value",
+            "123",
+            idField?.mock
+        )
+
+        val nameField = findField(body, "name")
+        assertNotNull("Should find name field in body", nameField)
+        assertEquals(
+            "Field with @mock tag should have mock value",
+            "test-item",
+            nameField?.mock
+        )
+    }
+
+    fun testFieldMockWithoutMockTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val createEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.POST &&
+            it.httpMetadata?.path?.contains("create") == true
+        }
+        assertNotNull("Should find POST /yapi/create endpoint", createEndpoint)
+
+        val body = createEndpoint?.httpMetadata?.body
+        assertNotNull("POST endpoint should have request body", body)
+
+        val descField = findField(body!!, "description")
+        assertNotNull("Should find description field in body", descField)
+        assertNull(
+            "Field without @mock tag should not have mock value",
+            descField?.mock
+        )
+    }
+
+    // ── api.tag[@java.lang.Deprecated]=deprecated ────────────────
+
+    fun testApiTagWithJavaDeprecatedAnnotation() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.DeprecatedController")
+        assertNotNull("Should find DeprecatedController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val oldEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("deprecated/old") == true
+        }
+        assertNotNull("Should find GET /deprecated/old endpoint", oldEndpoint)
+        assertTrue(
+            "Endpoint in @Deprecated class should have 'deprecated' tag",
+            oldEndpoint?.tags?.contains("deprecated") == true
+        )
+    }
+
+    // ── api.tag[#deprecated]=deprecated ──────────────────────────
+
+    fun testApiTagWithDeprecatedDocTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.DeprecatedDocController")
+        assertNotNull("Should find DeprecatedDocController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val oldEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("doc/old") == true
+        }
+        assertNotNull("Should find GET /doc/old endpoint", oldEndpoint)
+        assertTrue(
+            "Endpoint with @deprecated javadoc tag should have 'deprecated' tag",
+            oldEndpoint?.tags?.contains("deprecated") == true
+        )
+    }
+
+    fun testApiTagWithoutDeprecatedDocTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.DeprecatedDocController")
+        assertNotNull("Should find DeprecatedDocController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val newEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("doc/new") == true
+        }
+        assertNotNull("Should find GET /doc/new endpoint", newEndpoint)
+        assertFalse(
+            "Endpoint without @deprecated javadoc tag should not have 'deprecated' tag",
+            newEndpoint?.tags?.contains("deprecated") == true
+        )
+    }
+
+    private fun findField(model: ObjectModel, name: String): FieldModel? {
+        val obj = model.asObject() ?: return null
+        return obj.fields[name]
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
@@ -80,6 +80,44 @@ class YapiConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
+    // ── api.status[#undone]=undone / api.status[#todo]=undone ────
+
+    fun testApiStatusWithUndoneTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val createEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.POST &&
+            it.httpMetadata?.path?.contains("create") == true
+        }
+        assertNotNull("Should find POST /yapi/create endpoint", createEndpoint)
+        assertEquals(
+            "Endpoint with @undone tag should have status=undone",
+            "undone",
+            createEndpoint?.status
+        )
+    }
+
+    fun testApiStatusWithTodoTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val updateEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.POST &&
+            it.httpMetadata?.path?.contains("update") == true
+        }
+        assertNotNull("Should find POST /yapi/update endpoint", updateEndpoint)
+        assertEquals(
+            "Endpoint with @todo tag should have status=undone",
+            "undone",
+            updateEndpoint?.status
+        )
+    }
+
     // ── field.mock=#mock ─────────────────────────────────────────
 
     fun testFieldMockWithMockTag() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/YapiConfigIntegrationTest.kt
@@ -44,6 +44,42 @@ class YapiConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         return TestConfigReader.fromConfigText(yapiConfig)
     }
 
+    // ── api.open[#open]=true ─────────────────────────────────────
+
+    fun testApiOpenWithOpenTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val publicEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("public") == true
+        }
+        assertNotNull("Should find GET /yapi/public endpoint", publicEndpoint)
+        assertTrue(
+            "Endpoint with @open tag should have open=true",
+            publicEndpoint?.open == true
+        )
+    }
+
+    fun testApiOpenWithoutOpenTag() = runTest {
+        val psiClass = findClass("com.itangcent.yapi.YapiController")
+        assertNotNull("Should find YapiController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val privateEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("private") == true
+        }
+        assertNotNull("Should find GET /yapi/private endpoint", privateEndpoint)
+        assertFalse(
+            "Endpoint without @open tag should have open=false",
+            privateEndpoint?.open == true
+        )
+    }
+
     // ── field.mock=#mock ─────────────────────────────────────────
 
     fun testFieldMockWithMockTag() = runTest {

--- a/src/test/resources/api/yapi/DeprecatedController.java
+++ b/src/test/resources/api/yapi/DeprecatedController.java
@@ -1,0 +1,21 @@
+package com.itangcent.yapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Deprecated
+@RestController
+@RequestMapping("/deprecated")
+public class DeprecatedController {
+
+    /**
+     * Old method
+     *
+     * @return Returns old data
+     */
+    @GetMapping("/old")
+    public String oldMethod() {
+        return "old data";
+    }
+}

--- a/src/test/resources/api/yapi/DeprecatedDocController.java
+++ b/src/test/resources/api/yapi/DeprecatedDocController.java
@@ -1,0 +1,31 @@
+package com.itangcent.yapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/doc")
+public class DeprecatedDocController {
+
+    /**
+     * Old method using javadoc @deprecated
+     *
+     * @deprecated Use {@link #newMethod()} instead
+     * @return Returns old data
+     */
+    @GetMapping("/old")
+    public String oldMethod() {
+        return "old data";
+    }
+
+    /**
+     * New method
+     *
+     * @return Returns new data
+     */
+    @GetMapping("/new")
+    public String newMethod() {
+        return "new data";
+    }
+}

--- a/src/test/resources/api/yapi/ItemDTO.java
+++ b/src/test/resources/api/yapi/ItemDTO.java
@@ -1,0 +1,47 @@
+package com.itangcent.yapi;
+
+public class ItemDTO {
+
+    /**
+     * Item id
+     *
+     * @mock 123
+     */
+    private Long id;
+
+    /**
+     * Item name
+     *
+     * @mock test-item
+     */
+    private String name;
+
+    /**
+     * Item description
+     */
+    private String description;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/test/resources/api/yapi/KotlinController.kt
+++ b/src/test/resources/api/yapi/KotlinController.kt
@@ -1,0 +1,37 @@
+package com.itangcent.yapi
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Deprecated("Use NewKotlinController instead")
+@RestController
+@RequestMapping("/kotlin/deprecated")
+class DeprecatedKotlinController {
+
+    /**
+     * Old method
+     *
+     * @return Returns old data
+     */
+    @GetMapping("/old")
+    fun oldMethod(): String {
+        return "old data"
+    }
+}
+
+@RestController
+@RequestMapping("/kotlin/new")
+class NewKotlinController {
+
+    /**
+     * New method
+     *
+     * @open
+     * @return Returns new data
+     */
+    @GetMapping("/new")
+    fun newMethod(): String {
+        return "new data"
+    }
+}

--- a/src/test/resources/api/yapi/YapiController.java
+++ b/src/test/resources/api/yapi/YapiController.java
@@ -1,0 +1,71 @@
+package com.itangcent.yapi;
+
+import com.itangcent.yapi.ItemDTO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RestController
+@RequestMapping("/yapi")
+public class YapiController {
+
+    /**
+     * Get public info
+     *
+     * @open
+     * @return Returns public information
+     */
+    @GetMapping("/public")
+    public String getPublicInfo() {
+        return "public info";
+    }
+
+    /**
+     * Get private info
+     *
+     * @return Returns private information
+     */
+    @GetMapping("/private")
+    public String getPrivateInfo() {
+        return "private info";
+    }
+
+    /**
+     * Create item
+     *
+     * @undone
+     * @param item the item to create
+     * @return Created item
+     */
+    @PostMapping("/create")
+    public ItemDTO createItem(@RequestBody ItemDTO item) {
+        return item;
+    }
+
+    /**
+     * Update item
+     *
+     * @todo
+     * @param item the item to update
+     * @return Updated item
+     */
+    @PostMapping("/update")
+    public ItemDTO updateItem(@RequestBody ItemDTO item) {
+        return item;
+    }
+
+    /**
+     * Delete item
+     *
+     * @open
+     * @undone
+     * @param id the item id
+     * @return Success message
+     */
+    @GetMapping("/delete/{id}")
+    public String deleteItem(Long id) {
+        return "deleted";
+    }
+}


### PR DESCRIPTION
## Changes

Fix 3 failing tests in `YapiConfigIntegrationTest`:

- **`testFieldMockWithMockTag`** / **`testFieldMockWithoutMockTag`**: Added explicit `import com.itangcent.yapi.ItemDTO` in `YapiController.java` so the PSI type resolver can find the class in the light test fixture (same-package resolution fails when file paths don't match the package structure).

- **`testApiTagWithJavaDeprecatedAnnotation`**: Load a `java.lang.Deprecated` annotation stub in the test setup so the `@Deprecated` annotation's `qualifiedName` resolves correctly, enabling the groovy rule `it.containingClass().hasAnn("java.lang.Deprecated")` to match.