### PR TITLE
refactor: remove enum mapping extensions and related configs

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
@@ -75,7 +75,7 @@ object ExtensionConfigRegistry : IdeaLog {
                         "swagger", "swagger3", "jackson", "gson", "spring", 
                         "spring-validations", "spring-webflux", "spring-configuration", "spring-properties",
                         "module", "ignore", "deprecated", "jakarta-validation", "javax-validation", "converts",
-                        "field-utils", "enum-use-by-type", "enum-use-name", "enum-use-ordinal",
+                        "field-utils",
                         "field-order-alphabetically", "field-order-alphabetically-desc",
                         "field-order-child-first", "field-order-parent-first",
                         "jakarta-validation-strict", "javax-validation-strict"

--- a/src/main/resources/extensions/enum-use-by-type.config
+++ b/src/main/resources/extensions/enum-use-by-type.config
@@ -1,8 +1,0 @@
----
-code: enum-use-by-type
-description: Auto map enum to a type matched field in it
-default-enabled: false
----
-
-enum.use.by.type=true
-json.rule.enum.convert=~#name()

--- a/src/main/resources/extensions/enum-use-name.config
+++ b/src/main/resources/extensions/enum-use-name.config
@@ -1,8 +1,0 @@
----
-code: enum-use-name
-description: Map enum to its name
-default-enabled: false
----
-
-enum.use.name=true
-json.rule.enum.convert=~#name()

--- a/src/main/resources/extensions/enum-use-ordinal.config
+++ b/src/main/resources/extensions/enum-use-ordinal.config
@@ -1,8 +1,0 @@
----
-code: enum-use-ordinal
-description: Map enum to its ordinal
-default-enabled: false
----
-
-enum.use.ordinal=true
-json.rule.enum.convert=~#ordinal()

--- a/src/test/resources/result/com.itangcent.idea.plugin.config.EnhancedConfigReaderTest.SimpleEnhancedConfigReaderTest.foreach.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.config.EnhancedConfigReaderTest.SimpleEnhancedConfigReaderTest.foreach.txt
@@ -29,8 +29,6 @@ constant.field.ignore=groovy:it.name()=="serialVersionUID"
 properties.prefix=@org.springframework.boot.context.properties.ConfigurationProperties
 properties.prefix=@org.springframework.boot.context.properties.ConfigurationProperties#prefix
 field.name=@com.alibaba.fastjson.annotation.JSONField#value
-enum.use.by.type=true
-json.rule.enum.convert=~#name()
 ignored.classes_or_packages=java.lang.Class,java.lang.ClassLoader,java.lang.Module,java.lang.module,java.lang.annotation,
 java.lang.security,java.lang.invoke,java.lang.reflect,jdk.internal,java.util.jar,java.util.function,
 java.util.stream,java.util.logging,java.util.regex,java.util.zip,java.util.concurrent.locks,

--- a/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigLoaderTest.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigLoaderTest.txt
@@ -45,9 +45,6 @@ properties.prefix=@org.springframework.boot.context.properties.ConfigurationProp
 properties.prefix=@org.springframework.boot.context.properties.ConfigurationProperties#prefix
 #Support for Fastjson annotations
 field.name=@com.alibaba.fastjson.annotation.JSONField#value
-#Auto map enum to a type matched field in it
-enum.use.by.type=true
-json.rule.enum.convert=~#name()
 #ignore some common classes
 ignored.classes_or_packages=```
     java.lang.Class,java.lang.ClassLoader,java.lang.Module,java.lang.module,java.lang.annotation,

--- a/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigSettingsHelperTest.txt
+++ b/src/test/resources/result/com.itangcent.idea.plugin.settings.helper.RecommendConfigSettingsHelperTest.txt
@@ -45,9 +45,6 @@ properties.prefix=@org.springframework.boot.context.properties.ConfigurationProp
 properties.prefix=@org.springframework.boot.context.properties.ConfigurationProperties#prefix
 #Support for Fastjson annotations
 field.name=@com.alibaba.fastjson.annotation.JSONField#value
-#Auto map enum to a type matched field in it
-enum.use.by.type=true
-json.rule.enum.convert=~#name()
 #ignore some common classes
 ignored.classes_or_packages=```
     java.lang.Class,java.lang.ClassLoader,java.lang.Module,java.lang.module,java.lang.annotation,


### PR DESCRIPTION
Clean up unused enum mapping configuration files and references in the codebase. Remove enum-related settings from test results and registry.