### PR TITLE
feat: add YAPI mock rules support with separate extension config

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
@@ -180,7 +180,8 @@ data class ApiParameter(
     val defaultValue: String? = null,
     val description: String? = null,
     val example: String? = null,
-    val enumValues: List<String>? = null
+    val enumValues: List<String>? = null,
+    val jsonType: String? = null
 )
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -338,7 +338,8 @@ class SpringMvcClassExporter(
             binding = binding,
             defaultValue = defaultValue,
             description = doc,
-            example = demo ?: mock
+            example = demo ?: mock,
+            jsonType = rawType
         )
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/MockDataGenerator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/MockDataGenerator.kt
@@ -28,13 +28,10 @@ class MockDataGenerator(
      * @return A mock expression string, or null if unable to determine
      */
     fun mockFor(param: ApiParameter): String? {
-        val type = param.type.rawType()
+        val type = param.jsonType ?: param.type.rawType()
         val name = param.name.lowercase()
         
-        return when {
-            mockRules.isNotEmpty() -> mockByRules(param)
-            else -> mockByTypeName(type, name)
-        }
+        return mockByRules(param) ?: mockByTypeName(type, name)
     }
 
     /**
@@ -72,7 +69,7 @@ class MockDataGenerator(
      */
     private fun mockByRules(param: ApiParameter): String? {
         val name = param.name
-        val type = param.type.rawType()
+        val type = param.jsonType ?: param.type.rawType()
         
         val keyPatterns = listOf(
             "${name}|$type",
@@ -86,7 +83,7 @@ class MockDataGenerator(
             mockRules[pattern]?.let { return it }
         }
 
-        return mockByTypeName(type, name)
+        return null
     }
 
     /**
@@ -152,7 +149,7 @@ class MockDataGenerator(
         return when (type) {
             JsonType.STRING -> "@string"
             JsonType.SHORT -> "@integer(0, 32767)"
-            JsonType.INT -> "@integer"
+            JsonType.INT, "integer" -> "@integer"
             JsonType.LONG -> "@integer"
             JsonType.FLOAT -> "@float"
             JsonType.DOUBLE -> "@float"

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/MockRuleLoader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/MockRuleLoader.kt
@@ -1,0 +1,71 @@
+package com.itangcent.easyapi.exporter.yapi
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.ConfigReloadListener
+import com.itangcent.easyapi.logging.IdeaLog
+
+@Service(Service.Level.PROJECT)
+class MockRuleLoader(
+    private val project: Project
+) : ConfigReloadListener, Disposable, IdeaLog {
+
+    @Volatile
+    private var cachedRules: Map<String, String>? = null
+
+    private val connection = project.messageBus.connect(this)
+
+    init {
+        connection.subscribe(ConfigReloadListener.TOPIC, this)
+    }
+
+    fun getMockRules(): Map<String, String> {
+        cachedRules?.let { return it }
+        val rules = loadMockRules()
+        cachedRules = rules
+        return rules
+    }
+
+    private fun loadMockRules(): Map<String, String> {
+        val configReader = ConfigReader.getInstance(project)
+        val rules = mutableMapOf<String, String>()
+        configReader.foreach(
+            { key -> key == CONFIG_KEY || key.startsWith("$CONFIG_KEY[") },
+            { _, value ->
+                parseMockRule(value)?.let { (pattern, mockValue) ->
+                    rules[pattern] = mockValue
+                }
+            }
+        )
+        return rules
+    }
+
+    override fun onConfigReloaded() {
+        LOG.info("MockRuleLoader: clearing cache due to config reload")
+        cachedRules = null
+    }
+
+    override fun dispose() {
+        cachedRules = null
+    }
+
+    companion object {
+        private const val CONFIG_KEY = "mock.rule"
+
+        fun getInstance(project: Project): MockRuleLoader = project.service()
+
+        internal fun parseMockRule(line: String): Pair<String, String>? {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) return null
+            val eqIndex = trimmed.indexOf('=')
+            if (eqIndex <= 0 || eqIndex == trimmed.length - 1) return null
+            val pattern = trimmed.substring(0, eqIndex).trim()
+            val mockValue = trimmed.substring(eqIndex + 1).trim()
+            if (pattern.isEmpty() || mockValue.isEmpty()) return null
+            return pattern to mockValue
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
@@ -48,9 +48,11 @@ class YapiExporter(private val project: Project) : ApiExporter {
 
         val serverUrl = clientProvider.serverUrl
         val settings = settingBinder.read()
+        val mockRules = MockRuleLoader.getInstance(project).getMockRules()
         val formatter = YapiFormatter(
             reqBodyJson5 = settings.yapiReqBodyJson5,
             resBodyJson5 = settings.yapiResBodyJson5,
+            mockRules = mockRules,
             markdownRender = MarkdownRender.getInstance(project)
         )
         val engine = RuleEngine.getInstance(project)
@@ -113,7 +115,7 @@ class YapiExporter(private val project: Project) : ApiExporter {
                     continue
                 }
 
-                val yapiDoc = formatter.format(endpoint)
+                val yapiDoc = formatter.formatWithMock(endpoint)
                 val psiElement = endpoint.sourceMethod ?: endpoint.sourceClass
 
                 psiElement?.let {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
@@ -41,25 +41,32 @@ class YapiFormatter(
     private val autoFormatUrl: Boolean = true,
     private val markdownRender: MarkdownRender
 ) {
-    /**
-     * Legacy constructor for backward compatibility.
-     * When a single useJson5 flag is provided, it applies to both request and response body.
-     * 
-     * @param jsonSchemaBuilder Builder for creating JSON Schema
-     * @param useJson5 Whether to use JSON5 format for both request and response bodies
-     * @param mockGenerator Optional generator for mock data
-     * @param markdownRender Renderer for converting Markdown descriptions to HTML
-     */
+    constructor(
+        jsonSchemaBuilder: JsonSchemaBuilder = JsonSchemaBuilder(),
+        reqBodyJson5: Boolean = false,
+        resBodyJson5: Boolean = false,
+        mockRules: Map<String, String>,
+        autoFormatUrl: Boolean = true,
+        markdownRender: MarkdownRender
+    ) : this(
+        jsonSchemaBuilder,
+        reqBodyJson5,
+        resBodyJson5,
+        MockDataGenerator(mockRules),
+        autoFormatUrl,
+        markdownRender
+    )
+
     constructor(
         jsonSchemaBuilder: JsonSchemaBuilder = JsonSchemaBuilder(),
         useJson5: Boolean,
-        mockGenerator: MockDataGenerator? = MockDataGenerator(),
+        mockRules: Map<String, String> = emptyMap(),
         markdownRender: MarkdownRender
     ) : this(
         jsonSchemaBuilder,
         reqBodyJson5 = useJson5,
         resBodyJson5 = useJson5,
-        mockGenerator = mockGenerator,
+        mockGenerator = MockDataGenerator(mockRules),
         autoFormatUrl = true,
         markdownRender = markdownRender
     )

--- a/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
@@ -72,7 +72,7 @@ object ExtensionConfigRegistry : IdeaLog {
                 } else {
                     // Fallback: try to load known extension files directly from classpath
                     val knownExtensions = listOf(
-                        "swagger", "swagger3", "jackson", "gson", "fastjson", "yapi", "spring",
+                        "swagger", "swagger3", "jackson", "gson", "fastjson", "yapi", "yapi-mock", "spring",
                         "spring-validations", "spring-webflux", "spring-configuration", "spring-properties",
                         "yapi.project", "ignore", "deprecated", "jakarta-validation", "javax-validation", "converts",
                         "field-utils",

--- a/src/main/resources/extensions/yapi-mock.config
+++ b/src/main/resources/extensions/yapi-mock.config
@@ -1,0 +1,37 @@
+---
+code: yapi-mock
+description: YAPI mock rules for parameter mock data generation
+default-enabled: true
+---
+
+#mock rules for parameters (pattern=mockValue)
+mock.rule=*.email|string=@email
+mock.rule=*.phone|string=@phone
+mock.rule=*.mobile|string=@phone
+mock.rule=*.url|string=@url
+mock.rule=*.link|string=@url
+mock.rule=*.uuid|string=@uuid
+mock.rule=*.id|integer=@integer
+mock.rule=*.id|long=@integer
+mock.rule=*.id|string=@id
+mock.rule=*.name|string=@string
+mock.rule=*.age|integer=@integer(0, 120)
+mock.rule=*.price|double=@float(0, 10000, 2, 2)
+mock.rule=*.price|float=@float(0, 10000, 2, 2)
+mock.rule=*.amount|double=@float(0, 10000, 2, 2)
+mock.rule=*.amount|float=@float(0, 10000, 2, 2)
+mock.rule=*.count|integer=@integer(0, 100)
+mock.rule=*.page|integer=@integer(1, 100)
+mock.rule=*.size|integer=@integer(1, 100)
+mock.rule=*.password|string=******
+mock.rule=*.token|string=@string(32)
+mock.rule=*.image|string=@image
+mock.rule=*.avatar|string=@image
+mock.rule=*.address|string=@county(true)
+mock.rule=*.city|string=@city
+mock.rule=*.country|string=@county
+mock.rule=*.province|string=@province
+mock.rule=*.zip|string=@zip
+mock.rule=*.ip|string=@ip
+mock.rule=*.date|string=@date
+mock.rule=*.datetime|string=@datetime

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/MockDataGeneratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/MockDataGeneratorTest.kt
@@ -1,0 +1,249 @@
+package com.itangcent.easyapi.exporter.yapi
+
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.ParameterType
+import org.junit.Assert.*
+import org.junit.Test
+
+class MockDataGeneratorTest {
+
+    private val emptyGenerator = MockDataGenerator()
+
+    private val rulesGenerator = MockDataGenerator(
+        mapOf(
+            "*.email|string" to "@email",
+            "*.phone|string" to "@phone",
+            "*.id|integer" to "@integer",
+            "*.id|long" to "@integer",
+            "*.id|string" to "@id",
+            "*.age|integer" to "@integer(0, 120)",
+            "*.price|double" to "@float(0, 10000, 2, 2)",
+            "*.count|integer" to "@integer(0, 100)",
+            "*.page|integer" to "@integer(1, 100)",
+            "*.password|string" to "******",
+            "*.token|string" to "@string(32)",
+            "customField" to "@custom",
+            "param.userId" to "@id",
+            "query.searchTerm" to "@word"
+        )
+    )
+
+    // region mockFor with empty rules (name/type heuristics)
+
+    @Test
+    fun testMockForEmailField() {
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@email", emptyGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForPhoneField() {
+        val param = ApiParameter(name = "phone", jsonType = "string")
+        assertEquals("@phone", emptyGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForIntegerField() {
+        val param = ApiParameter(name = "count", jsonType = "integer")
+        assertEquals("@integer(0, 100)", emptyGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForUnknownFieldWithStringType() {
+        val param = ApiParameter(name = "data", jsonType = "string")
+        assertEquals("@string", emptyGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForUnknownFieldWithIntegerType() {
+        val param = ApiParameter(name = "data", jsonType = "integer")
+        assertEquals("@integer", emptyGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForUnknownFieldWithNoJsonType() {
+        val param = ApiParameter(name = "data")
+        assertEquals("@string", emptyGenerator.mockFor(param))
+    }
+
+    // endregion
+
+    // region mockFor with custom rules
+
+    @Test
+    fun testMockForWithRuleNameAndType() {
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@email", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForWithRuleWildcardNameAndType() {
+        val param = ApiParameter(name = "phone", jsonType = "string")
+        assertEquals("@phone", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForWithRuleWildcardNameOnly() {
+        val param = ApiParameter(name = "age", jsonType = "integer")
+        assertEquals("@integer(0, 120)", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForWithRuleExactName() {
+        val param = ApiParameter(name = "customField", jsonType = "string")
+        assertEquals("@custom", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForWithRuleWildcardTypeFallback() {
+        val param = ApiParameter(name = "data", jsonType = "integer")
+        val result = rulesGenerator.mockFor(param)
+        assertEquals("@integer", result)
+    }
+
+    @Test
+    fun testMockForRuleFallbackToNameHeuristic() {
+        val param = ApiParameter(name = "address", jsonType = "string")
+        assertEquals("@county(true)", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForRuleFallbackToTypeHeuristic() {
+        val param = ApiParameter(name = "unknownField", jsonType = "boolean")
+        assertEquals("@boolean", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForIdWithIntegerType() {
+        val param = ApiParameter(name = "id", jsonType = "integer")
+        assertEquals("@integer", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForIdWithStringType() {
+        val param = ApiParameter(name = "id", jsonType = "string")
+        assertEquals("@id", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForPriceWithDoubleType() {
+        val param = ApiParameter(name = "price", jsonType = "double")
+        assertEquals("@float(0, 10000, 2, 2)", rulesGenerator.mockFor(param))
+    }
+
+    // endregion
+
+    // region mockForParam
+
+    @Test
+    fun testMockForParamWithNameHeuristic() {
+        assertEquals("@id", emptyGenerator.mockForParam("userId"))
+    }
+
+    @Test
+    fun testMockForParamWithRule() {
+        assertEquals("@id", rulesGenerator.mockForParam("userId"))
+    }
+
+    @Test
+    fun testMockForParamWithNoMatch() {
+        assertNull(emptyGenerator.mockForParam("xyz"))
+    }
+
+    // endregion
+
+    // region mockForQuery
+
+    @Test
+    fun testMockForQueryWithNameHeuristic() {
+        assertEquals("@id", emptyGenerator.mockForQuery("userId"))
+    }
+
+    @Test
+    fun testMockForQueryWithRule() {
+        assertEquals("@word", rulesGenerator.mockForQuery("searchTerm"))
+    }
+
+    @Test
+    fun testMockForQueryWithNoMatch() {
+        assertNull(emptyGenerator.mockForQuery("xyz"))
+    }
+
+    // endregion
+
+    // region jsonType vs ParameterType
+
+    @Test
+    fun testMockForUsesJsonTypeOverParameterType() {
+        val param = ApiParameter(
+            name = "email",
+            type = ParameterType.TEXT,
+            jsonType = "string"
+        )
+        assertEquals("@email", rulesGenerator.mockFor(param))
+    }
+
+    @Test
+    fun testMockForFallsBackToParameterTypeRawType() {
+        val param = ApiParameter(
+            name = "email",
+            type = ParameterType.TEXT
+        )
+        val result = emptyGenerator.mockFor(param)
+        assertNotNull(result)
+    }
+
+    // endregion
+
+    // region pattern priority
+
+    @Test
+    fun testPatternPriorityNameAndTypeOverWildcardNameAndType() {
+        val generator = MockDataGenerator(
+            mapOf(
+                "email|string" to "@exact",
+                "*.email|string" to "@wildcard"
+            )
+        )
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@exact", generator.mockFor(param))
+    }
+
+    @Test
+    fun testPatternPriorityWildcardNameAndTypeOverWildcardName() {
+        val generator = MockDataGenerator(
+            mapOf(
+                "*.email|string" to "@wildcard_typed",
+                "*.email" to "@wildcard"
+            )
+        )
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@wildcard_typed", generator.mockFor(param))
+    }
+
+    @Test
+    fun testPatternPriorityWildcardNameOverWildcardType() {
+        val generator = MockDataGenerator(
+            mapOf(
+                "*.email" to "@wildcard_name",
+                "*|string" to "@wildcard_type"
+            )
+        )
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@wildcard_name", generator.mockFor(param))
+    }
+
+    @Test
+    fun testPatternPriorityWildcardTypeOverExactName() {
+        val generator = MockDataGenerator(
+            mapOf(
+                "*|string" to "@wildcard_type",
+                "email" to "@exact_name"
+            )
+        )
+        val param = ApiParameter(name = "email", jsonType = "string")
+        assertEquals("@wildcard_type", generator.mockFor(param))
+    }
+
+    // endregion
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/MockRuleLoaderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/MockRuleLoaderTest.kt
@@ -1,0 +1,85 @@
+package com.itangcent.easyapi.exporter.yapi
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class MockRuleLoaderTest {
+
+    @Test
+    fun testParseMockRuleValid() {
+        val result = MockRuleLoader.parseMockRule("*.email|string=@email")
+        assertNotNull(result)
+        assertEquals("*.email|string", result!!.first)
+        assertEquals("@email", result.second)
+    }
+
+    @Test
+    fun testParseMockRuleWithSpaces() {
+        val result = MockRuleLoader.parseMockRule("  *.email|string  =  @email  ")
+        assertNotNull(result)
+        assertEquals("*.email|string", result!!.first)
+        assertEquals("@email", result.second)
+    }
+
+    @Test
+    fun testParseMockRuleSimplePattern() {
+        val result = MockRuleLoader.parseMockRule("email=@email")
+        assertNotNull(result)
+        assertEquals("email", result!!.first)
+        assertEquals("@email", result.second)
+    }
+
+    @Test
+    fun testParseMockRuleWithEqualsInValue() {
+        val result = MockRuleLoader.parseMockRule("field.mock=groovy:\"@integer(\"+it.ann(\"Max\")+\")\"")
+        assertNotNull(result)
+        assertEquals("field.mock", result!!.first)
+        assertEquals("groovy:\"@integer(\"+it.ann(\"Max\")+\")\"", result.second)
+    }
+
+    @Test
+    fun testParseMockRuleEmptyLine() {
+        assertNull(MockRuleLoader.parseMockRule(""))
+    }
+
+    @Test
+    fun testParseMockRuleBlankLine() {
+        assertNull(MockRuleLoader.parseMockRule("   "))
+    }
+
+    @Test
+    fun testParseMockRuleComment() {
+        assertNull(MockRuleLoader.parseMockRule("# this is a comment"))
+    }
+
+    @Test
+    fun testParseMockRuleNoEquals() {
+        assertNull(MockRuleLoader.parseMockRule("*.email|string"))
+    }
+
+    @Test
+    fun testParseMockRuleEmptyValue() {
+        assertNull(MockRuleLoader.parseMockRule("*.email|string="))
+    }
+
+    @Test
+    fun testParseMockRuleEmptyPattern() {
+        assertNull(MockRuleLoader.parseMockRule("=@email"))
+    }
+
+    @Test
+    fun testParseMockRuleComplexMockValue() {
+        val result = MockRuleLoader.parseMockRule("*.age|integer=@integer(0, 120)")
+        assertNotNull(result)
+        assertEquals("*.age|integer", result!!.first)
+        assertEquals("@integer(0, 120)", result.second)
+    }
+
+    @Test
+    fun testParseMockRulePasswordMask() {
+        val result = MockRuleLoader.parseMockRule("*.password|string=******")
+        assertNotNull(result)
+        assertEquals("*.password|string", result!!.first)
+        assertEquals("******", result.second)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
@@ -613,4 +613,118 @@ class YapiFormatterTest {
     }
 
     // endregion
+
+    // region Mock rules
+
+    @Test
+    fun testFormatWithMockWithRules() {
+        val mockRules = mapOf(
+            "*.id|integer" to "@integer",
+            "*.email|string" to "@email"
+        )
+        val mockFormatter = YapiFormatter(mockRules = mockRules, markdownRender = BundledMarkdownRender())
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    ApiParameter(
+                        name = "id",
+                        binding = ParameterBinding.Path,
+                        description = "User ID",
+                        jsonType = "integer"
+                    )
+                )
+            )
+        )
+
+        val doc = mockFormatter.formatWithMock(endpoint)
+
+        assertNotNull(doc.reqParams)
+        assertEquals("@integer", doc.reqParams!![0].example)
+    }
+
+    @Test
+    fun testFormatWithMockRulesForQueryParams() {
+        val mockRules = mapOf(
+            "*.page|integer" to "@integer(1, 100)",
+            "*.size|integer" to "@integer(1, 100)"
+        )
+        val mockFormatter = YapiFormatter(mockRules = mockRules, markdownRender = BundledMarkdownRender())
+        val endpoint = ApiEndpoint(
+            name = "List Users",
+            metadata = httpMetadata(
+                path = "/api/users",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    ApiParameter(name = "page", binding = ParameterBinding.Query, jsonType = "integer"),
+                    ApiParameter(name = "size", binding = ParameterBinding.Query, jsonType = "integer")
+                )
+            )
+        )
+
+        val doc = mockFormatter.formatWithMock(endpoint)
+
+        assertNotNull(doc.reqQuery)
+        assertEquals("@integer(1, 100)", doc.reqQuery!![0].example)
+        assertEquals("@integer(1, 100)", doc.reqQuery!![1].example)
+    }
+
+    @Test
+    fun testFormatWithMockRulesFallbackToNameHeuristic() {
+        val mockRules = mapOf(
+            "*.email|string" to "@email"
+        )
+        val mockFormatter = YapiFormatter(mockRules = mockRules, markdownRender = BundledMarkdownRender())
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    ApiParameter(
+                        name = "id",
+                        binding = ParameterBinding.Path,
+                        description = "User ID",
+                        jsonType = "integer"
+                    )
+                )
+            )
+        )
+
+        val doc = mockFormatter.formatWithMock(endpoint)
+
+        assertNotNull(doc.reqParams)
+        assertEquals("@id", doc.reqParams!![0].example)
+    }
+
+    @Test
+    fun testFormatWithMockNoRulesUsesNameHeuristic() {
+        val noRulesFormatter = YapiFormatter(
+            mockGenerator = MockDataGenerator(emptyMap()),
+            markdownRender = BundledMarkdownRender()
+        )
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                parameters = listOf(
+                    ApiParameter(
+                        name = "email",
+                        binding = ParameterBinding.Query,
+                        jsonType = "string"
+                    )
+                )
+            )
+        )
+
+        val doc = noRulesFormatter.formatWithMock(endpoint)
+
+        assertNotNull(doc.reqQuery)
+        assertEquals("@email", doc.reqQuery!![0].example)
+    }
+
+    // endregion
 }

--- a/src/test/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistryTest.kt
@@ -28,6 +28,38 @@ class ExtensionConfigRegistryTest {
     }
 
     @Test
+    fun testYapiMockExtensionExists() {
+        val extensions = ExtensionConfigRegistry.allExtensions()
+        val codes = extensions.map { it.code }
+        println("All extension codes: $codes")
+        assertTrue("yapi-mock extension should exist. Available: $codes", codes.contains("yapi-mock"))
+    }
+
+    @Test
+    fun testYapiMockExtensionContainsMockRules() {
+        val extension = ExtensionConfigRegistry.getExtension("yapi-mock")
+        assertNotNull("yapi-mock extension should be loaded", extension)
+        val content = extension!!.content
+        assertTrue("yapi-mock should contain mock.rule entries", content.contains("mock.rule="))
+        assertTrue("yapi-mock should contain email rule", content.contains("@email"))
+        assertTrue("yapi-mock should contain phone rule", content.contains("@phone"))
+    }
+
+    @Test
+    fun testYapiMockExtensionDefaultEnabled() {
+        val extension = ExtensionConfigRegistry.getExtension("yapi-mock")
+        assertNotNull("yapi-mock extension should be loaded", extension)
+        assertTrue("yapi-mock should be default-enabled", extension!!.defaultEnabled)
+    }
+
+    @Test
+    fun testYapiExtensionDoesNotContainMockRules() {
+        val extension = ExtensionConfigRegistry.getExtension("yapi")
+        assertNotNull("yapi extension should be loaded", extension)
+        assertFalse("yapi extension should not contain mock.rule entries", extension!!.content.contains("mock.rule="))
+    }
+
+    @Test
     fun testGetExtension_existing() {
         val extensions = ExtensionConfigRegistry.allExtensions()
         if (extensions.isNotEmpty()) {


### PR DESCRIPTION
Split mock rules from yapi.config into yapi-mock.config extension. Add MockRuleLoader service to load mock rules from config. Add jsonType field to ApiParameter for type-based rule matching.