### PR TITLE
fix: correct log level filtering semantic inversion

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -49,7 +49,7 @@ data class Settings(
     override var httpTimeOut: Int = 30,
     override var unsafeSsl: Boolean = false,
     override var httpClient: String = HttpClientType.APACHE.value,
-    override var logLevel: Int = 50,
+    override var logLevel: Int = 0,
     override var outputDemo: Boolean = true,
     override var outputCharset: String = "UTF-8",
     override var markdownFormatType: String = MarkdownFormatType.SIMPLE.name,

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -51,7 +51,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var unsafeSsl: Boolean = false,
         override var httpClient: String = HttpClientType.APACHE.value,
         override var extensionConfigs: String = Settings().extensionConfigs,
-        override var logLevel: Int = 50,
+        override var logLevel: Int = 0,
         override var outputDemo: Boolean = true,
         override var outputCharset: String = "UTF-8",
         override var markdownFormatType: String = MarkdownFormatType.SIMPLE.name,

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -399,7 +399,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         autoScanEnabled.isSelected = settings?.autoScanEnabled ?: true
         concurrentScanEnabled.isSelected = settings?.concurrentScanEnabled ?: false
         switchNotice.isSelected = settings?.switchNotice ?: true
-        logLevelCombo.selectedItem = CommonSettingsHelper.VerbosityLevel.toLevel(settings?.logLevel ?: 50)
+        logLevelCombo.selectedItem = CommonSettingsHelper.VerbosityLevel.toLevel(settings?.logLevel ?: 0)
         outputCharsetCombo.selectedItem = settings?.outputCharset ?: "UTF-8"
         outputDemoCheckBox.isSelected = settings?.outputDemo ?: true
         markdownFormatTypeCombo.selectedItem = settings?.markdownFormatType?.let {
@@ -422,7 +422,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         settings.autoScanEnabled = autoScanEnabled.isSelected
         settings.concurrentScanEnabled = concurrentScanEnabled.isSelected
         settings.switchNotice = switchNotice.isSelected
-        settings.logLevel = (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level ?: 50
+        settings.logLevel = (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level ?: 0
         settings.outputCharset = outputCharsetCombo.selectedItem?.toString() ?: "UTF-8"
         settings.outputDemo = outputDemoCheckBox.isSelected
         settings.markdownFormatType =
@@ -453,12 +453,12 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
 
 object CommonSettingsHelper {
     enum class VerbosityLevel(val level: Int, val displayName: String) {
-        SILENT(0, "Silent"),
-        ERROR(10, "Error"),
-        WARN(20, "Warning"),
-        INFO(30, "Info"),
-        DEBUG(40, "Debug"),
-        TRACE(50, "Trace");
+        SILENT(100, "Silent"),
+        ERROR(40, "Error"),
+        WARN(30, "Warning"),
+        INFO(20, "Info"),
+        DEBUG(10, "Debug"),
+        TRACE(0, "Trace");
 
         override fun toString(): String = displayName
 

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
@@ -30,7 +30,7 @@ class SettingsTest {
         assertEquals(30, settings.httpTimeOut)
         assertFalse(settings.unsafeSsl)
         assertEquals(HttpClientType.APACHE.value, settings.httpClient)
-        assertEquals(50, settings.logLevel)
+        assertEquals(0, settings.logLevel)
         assertTrue(settings.outputDemo)
         assertEquals("UTF-8", settings.outputCharset)
         assertEquals(MarkdownFormatType.SIMPLE.name, settings.markdownFormatType)

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -30,7 +30,7 @@ class ApplicationSettingsStateTest {
         assertEquals(30, s.httpTimeOut)
         assertFalse(s.unsafeSsl)
         assertEquals(HttpClientType.APACHE.value, s.httpClient)
-        assertEquals(50, s.logLevel)
+        assertEquals(0, s.logLevel)
         assertTrue(s.outputDemo)
         assertEquals("UTF-8", s.outputCharset)
         assertEquals(MarkdownFormatType.SIMPLE.name, s.markdownFormatType)


### PR DESCRIPTION
VerbosityLevel values were semantically inverted compared to LogLevel.threshold, causing the comparison in ConfigurableIdeaConsole.enabled() to produce opposite results. Setting 'Trace' in the UI would suppress INFO logs, while 'Error' would print all logs.

Changes:
- Align VerbosityLevel.level values with LogLevel.threshold semantics: SILENT(100), ERROR(40), WARN(30), INFO(20), DEBUG(10), TRACE(0)
- Update default logLevel from 50 to 0 (TRACE) in Settings and ApplicationSettingsState
- Update fallback default values in GeneralSettingsPanel from 50 to 0
- Update ApplicationSettingsStateTest to expect new default value

Closes: #1329