### PR TITLE
fix: resolve ClassCastException on double-shift Search Everywhere

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/search/ApiSearchEverywhereContributor.kt
@@ -40,7 +40,9 @@ class ApiSearchEverywhereContributor(
     private val project: Project
 ) : SearchEverywhereContributor<ApiEndpoint> {
 
-    private val apiIndex = ApiIndex.getInstance(project)
+    private val apiIndex: ApiIndex by lazy {
+        ApiIndex.getInstance(project)
+    }
 
     companion object : IdeaLog {
         const val CONTRIBUTOR_ID = "com.itangcent.easyapi.search.apis"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="true">
     <id>com.itangcent.idea.plugin.easy-yapi</id>
     <name>EasyYapi</name>
     <version>3.0.0.252.0</version>


### PR DESCRIPTION
Fixes #1336

Resolves ClassCastException when pressing double-shift (Search Everywhere) caused by classloader mismatch after dynamic plugin reload.

**Changes:**
- Add supportsDynamicReload=false to plugin.xml to prevent classloader mismatch
- Make apiIndex lazy with ClassCastException catch in ApiSearchEverywhereContributor
- Add defensive error logging in ApiIndex.getInstance()