### PR TITLE
feat: add setting to enable/disable API method gutter icon

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
@@ -4,28 +4,24 @@ import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.itangcent.easyapi.cache.ApiIndex
 import com.itangcent.easyapi.cache.ApiIndexManager
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiDashboardService
 import com.itangcent.easyapi.exporter.core.MetaAnnotationResolver
 import com.itangcent.easyapi.exporter.grpc.GrpcMethodResolver
 import com.itangcent.easyapi.exporter.grpc.GrpcServiceRecognizer
-import com.itangcent.easyapi.core.threading.IdeDispatchers
-import com.itangcent.easyapi.core.threading.backgroundAsync
-import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.runBlocking
 import java.awt.event.MouseEvent
 
@@ -54,6 +50,8 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
         if (element !is PsiIdentifier) return null
         val parent = element.parent as? PsiMethod ?: return null
 
+        if (!isGutterIconEnabled(element.project)) return null
+
         if (!isApiMethod(parent) && !isIndexedMethod(parent)) return null
 
         return LineMarkerInfo(
@@ -69,6 +67,10 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
 
     private fun isIndexedMethod(method: PsiMethod): Boolean {
         return ApiIndex.getInstance(method.project).containsMethod(method)
+    }
+
+    private fun isGutterIconEnabled(project: Project): Boolean {
+        return SettingBinder.getInstance(project).read().gutterIconEnabled
     }
 
     private fun isApiMethod(method: PsiMethod): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -61,6 +61,7 @@ data class Settings(
     override var grpcCallEnabled: Boolean = false,
     override var grpcRepositories: Array<String> = emptyArray(),
     override var concurrentScanEnabled: Boolean = false,
+    override var gutterIconEnabled: Boolean = true,
     override var projectEnvironments: String = "",
     override var globalEnvironments: String = ""
 ) : ProjectSettingsSupport, ApplicationSettingsSupport {
@@ -116,6 +117,7 @@ data class Settings(
         if (grpcCallEnabled != other.grpcCallEnabled) return false
         if (!grpcRepositories.contentEquals(other.grpcRepositories)) return false
         if (concurrentScanEnabled != other.concurrentScanEnabled) return false
+        if (gutterIconEnabled != other.gutterIconEnabled) return false
         if (projectEnvironments != other.projectEnvironments) return false
         if (globalEnvironments != other.globalEnvironments) return false
 
@@ -162,6 +164,7 @@ data class Settings(
         result = 31 * result + grpcCallEnabled.hashCode()
         result = 31 * result + grpcRepositories.contentHashCode()
         result = 31 * result + concurrentScanEnabled.hashCode()
+        result = 31 * result + gutterIconEnabled.hashCode()
         result = 31 * result + projectEnvironments.hashCode()
         result = 31 * result + globalEnvironments.hashCode()
         return result

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -63,6 +63,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var grpcCallEnabled: Boolean = false,
         override var grpcRepositories: Array<String> = emptyArray(),
         override var concurrentScanEnabled: Boolean = false,
+        override var gutterIconEnabled: Boolean = true,
         override var globalEnvironments: String = ""
     ) : ApplicationSettingsSupport {
         override fun equals(other: Any?): Boolean {
@@ -106,6 +107,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (grpcCallEnabled != other.grpcCallEnabled) return false
             if (!grpcRepositories.contentEquals(other.grpcRepositories)) return false
             if (concurrentScanEnabled != other.concurrentScanEnabled) return false
+            if (gutterIconEnabled != other.gutterIconEnabled) return false
             if (globalEnvironments != other.globalEnvironments) return false
 
             return true
@@ -147,6 +149,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + grpcCallEnabled.hashCode()
             result = 31 * result + grpcRepositories.contentHashCode()
             result = 31 * result + concurrentScanEnabled.hashCode()
+            result = 31 * result + gutterIconEnabled.hashCode()
             result = 31 * result + globalEnvironments.hashCode()
             return result
         }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
@@ -73,6 +73,8 @@ interface ApplicationSettingsSupport {
     var grpcRepositories: Array<String>
     /** Enable concurrent API scanning for better performance */
     var concurrentScanEnabled: Boolean
+    /** When true, show gutter icon on API methods for opening in API Dashboard */
+    var gutterIconEnabled: Boolean
     var globalEnvironments: String
 
     fun copyTo(newSetting: ApplicationSettingsSupport) {
@@ -111,6 +113,7 @@ interface ApplicationSettingsSupport {
         newSetting.grpcCallEnabled = this.grpcCallEnabled
         newSetting.grpcRepositories = this.grpcRepositories
         newSetting.concurrentScanEnabled = this.concurrentScanEnabled
+        newSetting.gutterIconEnabled = this.gutterIconEnabled
         newSetting.globalEnvironments = this.globalEnvironments
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -95,6 +95,9 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
     private val concurrentScanEnabled = JBCheckBox("Enable concurrent API scanning (experimental)", false).apply {
         toolTipText = "Use multiple threads for API scanning (may improve performance but is experimental)"
     }
+    private val gutterIconEnabled = JBCheckBox("Show gutter icon on API methods", true).apply {
+        toolTipText = "Show a gutter icon on API methods for quick navigation to the API Dashboard. Disable if it conflicts with other plugins."
+    }
     private val switchNotice = JBCheckBox("Show notification on settings switch", true).apply {
         toolTipText = "Show a notification when switching between different setting profiles"
     }
@@ -382,6 +385,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         )
         .addComponent(autoScanEnabled)
         .addComponent(concurrentScanEnabled)
+        .addComponent(gutterIconEnabled)
         .addComponent(switchNotice)
         .addLabeledComponent("Log Level:", logLevelCombo)
         .addLabeledComponent("Output Charset:", outputCharsetCombo)
@@ -398,6 +402,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         actuatorEnable.isSelected = settings?.actuatorEnable ?: false
         autoScanEnabled.isSelected = settings?.autoScanEnabled ?: true
         concurrentScanEnabled.isSelected = settings?.concurrentScanEnabled ?: false
+        gutterIconEnabled.isSelected = settings?.gutterIconEnabled ?: true
         switchNotice.isSelected = settings?.switchNotice ?: true
         logLevelCombo.selectedItem = CommonSettingsHelper.VerbosityLevel.toLevel(settings?.logLevel ?: 0)
         outputCharsetCombo.selectedItem = settings?.outputCharset ?: "UTF-8"
@@ -421,6 +426,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         settings.actuatorEnable = actuatorEnable.isSelected
         settings.autoScanEnabled = autoScanEnabled.isSelected
         settings.concurrentScanEnabled = concurrentScanEnabled.isSelected
+        settings.gutterIconEnabled = gutterIconEnabled.isSelected
         settings.switchNotice = switchNotice.isSelected
         settings.logLevel = (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level ?: 0
         settings.outputCharset = outputCharsetCombo.selectedItem?.toString() ?: "UTF-8"
@@ -440,6 +446,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
                 actuatorEnable.isSelected != s.actuatorEnable ||
                 autoScanEnabled.isSelected != s.autoScanEnabled ||
                 concurrentScanEnabled.isSelected != s.concurrentScanEnabled ||
+                gutterIconEnabled.isSelected != s.gutterIconEnabled ||
                 switchNotice.isSelected != s.switchNotice ||
                 (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level != s.logLevel ||
                 outputCharsetCombo.selectedItem?.toString() != s.outputCharset ||

--- a/src/test/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProviderTest.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.ide.linemarker
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.PsiTreeUtil
+import com.itangcent.easyapi.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
@@ -99,6 +100,58 @@ class ApiMethodLineMarkerProviderTest : EasyApiLightCodeInsightFixtureTestCase()
         assertTrue(
             "Available annotations should be subset of all annotations",
             availableAnnotations.size < allApiAnnotations.size
+        )
+    }
+
+    fun testNoLineMarkerWhenGutterIconDisabled() = runTest {
+        settingBinder.update {
+            gutterIconEnabled = false
+        }
+
+        val file = myFixture.configureByFile("api/UserCtrl.java")
+        val classes = PsiTreeUtil.getChildrenOfType(file, PsiClass::class.java) ?: emptyArray()
+        assertTrue("Should have classes in test file", classes.isNotEmpty())
+
+        val methods = classes.flatMap { it.methods.toList() }
+        assertTrue("Should have methods in test file", methods.isNotEmpty())
+
+        methods.forEach { method ->
+            val identifier = method.nameIdentifier
+            if (identifier != null) {
+                val marker = lineMarkerProvider.getLineMarkerInfo(identifier)
+                assertNull(
+                    "Should not show gutter icon when gutterIconEnabled is false",
+                    marker
+                )
+            }
+        }
+    }
+
+    fun testLineMarkerWhenGutterIconEnabled() = runTest {
+        settingBinder.update {
+            gutterIconEnabled = true
+        }
+
+        val file = myFixture.configureByFile("api/UserCtrl.java")
+        val classes = PsiTreeUtil.getChildrenOfType(file, PsiClass::class.java) ?: emptyArray()
+        assertTrue("Should have classes in test file", classes.isNotEmpty())
+
+        val methods = classes.flatMap { it.methods.toList() }
+        assertTrue("Should have methods in test file", methods.isNotEmpty())
+
+        var foundMarker = false
+        methods.forEach { method ->
+            val identifier = method.nameIdentifier
+            if (identifier != null) {
+                val marker = lineMarkerProvider.getLineMarkerInfo(identifier)
+                if (marker != null) {
+                    foundMarker = true
+                }
+            }
+        }
+        assertTrue(
+            "Should show gutter icon on at least one API method when gutterIconEnabled is true",
+            foundMarker
         )
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
@@ -45,4 +45,30 @@ class SettingsDefaultsTest {
         val settings = Settings()
         assertEquals(HttpClientType.APACHE.value, settings.httpClient)
     }
+
+    @Test
+    fun `test Settings default gutterIconEnabled is true`() {
+        val settings = Settings()
+        assertTrue("gutterIconEnabled should default to true", settings.gutterIconEnabled)
+    }
+
+    @Test
+    fun `test ApplicationSettingsState State default gutterIconEnabled is true`() {
+        val state = ApplicationSettingsState.State()
+        assertTrue(
+            "ApplicationSettingsState default gutterIconEnabled should be true",
+            state.gutterIconEnabled
+        )
+    }
+
+    @Test
+    fun `test Settings and ApplicationSettingsState have matching gutterIconEnabled defaults`() {
+        val settings = Settings()
+        val appState = ApplicationSettingsState.State()
+        assertEquals(
+            "gutterIconEnabled defaults should match between Settings and ApplicationSettingsState",
+            settings.gutterIconEnabled,
+            appState.gutterIconEnabled
+        )
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
@@ -44,6 +44,12 @@ class SettingsTest {
     }
 
     @Test
+    fun testDefaultGutterIconEnabled() {
+        val settings = Settings()
+        assertTrue("gutterIconEnabled should default to true", settings.gutterIconEnabled)
+    }
+
+    @Test
     fun testCustomValues() {
         val settings = Settings(
             feignEnable = true,
@@ -74,6 +80,13 @@ class SettingsTest {
     }
 
     @Test
+    fun testEquality_differentGutterIconEnabled() {
+        val s1 = Settings(gutterIconEnabled = true)
+        val s2 = Settings(gutterIconEnabled = false)
+        assertNotEquals(s1, s2)
+    }
+
+    @Test
     fun testEquality_withArrays() {
         val s1 = Settings(remoteConfig = arrayOf("http://example.com"))
         val s2 = Settings(remoteConfig = arrayOf("http://example.com"))
@@ -87,6 +100,15 @@ class SettingsTest {
         (source as ApplicationSettingsSupport).copyTo(target)
         assertTrue("feignEnable should be copied", target.feignEnable)
         assertEquals("httpTimeOut should be copied", 10, target.httpTimeOut)
+    }
+
+    @Test
+    fun testSettingsCopyToApplicationSettings_gutterIconEnabled() {
+        val source = Settings(gutterIconEnabled = false)
+        val target = Settings()
+        assertTrue("target gutterIconEnabled should default to true", target.gutterIconEnabled)
+        (source as ApplicationSettingsSupport).copyTo(target)
+        assertFalse("gutterIconEnabled should be copied as false", target.gutterIconEnabled)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -37,6 +37,7 @@ class ApplicationSettingsStateTest {
         assertNull(s.builtInConfig)
         assertArrayEquals(emptyArray(), s.remoteConfig)
         assertTrue(s.autoScanEnabled)
+        assertTrue(s.gutterIconEnabled)
     }
 
     @Test
@@ -78,6 +79,13 @@ class ApplicationSettingsStateTest {
     }
 
     @Test
+    fun testState_inequality_gutterIconEnabled() {
+        val s1 = ApplicationSettingsState.State(gutterIconEnabled = true)
+        val s2 = ApplicationSettingsState.State(gutterIconEnabled = false)
+        assertNotEquals(s1, s2)
+    }
+
+    @Test
     fun testState_equalityWithArrays() {
         val s1 = ApplicationSettingsState.State(remoteConfig = arrayOf("http://a.com"))
         val s2 = ApplicationSettingsState.State(remoteConfig = arrayOf("http://a.com"))
@@ -105,6 +113,15 @@ class ApplicationSettingsStateTest {
         assertEquals(30, target.httpTimeOut)
         assertEquals(100, target.logLevel)
         assertEquals("ISO-8859-1", target.outputCharset)
+    }
+
+    @Test
+    fun testState_copyTo_gutterIconEnabled() {
+        val source = ApplicationSettingsState.State(gutterIconEnabled = false)
+        val target = ApplicationSettingsState.State()
+        assertTrue("target gutterIconEnabled should default to true", target.gutterIconEnabled)
+        source.copyTo(target)
+        assertFalse("gutterIconEnabled should be copied as false", target.gutterIconEnabled)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/SettingsSupportKtTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/SettingsSupportKtTest.kt
@@ -94,4 +94,13 @@ class SettingsSupportKtTest {
         assertEquals(100, target.logLevel)
         assertEquals("ISO-8859-1", target.outputCharset)
     }
+
+    @Test
+    fun testApplicationSettingsSupport_copyTo_gutterIconEnabled() {
+        val source = Settings(gutterIconEnabled = false)
+        val target = Settings()
+        assertTrue("target gutterIconEnabled should default to true", target.gutterIconEnabled)
+        source.copyTo(target as ApplicationSettingsSupport)
+        assertFalse("gutterIconEnabled should be copied as false", target.gutterIconEnabled)
+    }
 }


### PR DESCRIPTION
Resolves #1339

Adds a configuration option (gutterIconEnabled) to enable/disable the gutter icon on API methods, resolving the conflict with JetBrains IDEA built-in HTTP client.

**Changes:**
- Add gutterIconEnabled to ApplicationSettingsSupport interface, Settings, and ApplicationSettingsState.State
- Add checkbox UI in General Settings panel (defaults to enabled)
- ApiMethodLineMarkerProvider checks the setting before rendering gutter icons
- Test cases added for all new functionality