### PR TITLE
fix: resolve IntelliJ IDEA 2026.1 (IU-261) compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 .trae/
 .qodo/
 .vscode/
+.temp

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -4,6 +4,7 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiClass
@@ -437,7 +438,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     private fun navigateToSource(endpoint: ApiEndpoint) {
         val method = endpoint.sourceMethod ?: return
         if (method.canNavigate()) {
-            com.intellij.openapi.application.WriteIntentReadAction.run {
+            ApplicationManager.getApplication().invokeLater {
                 method.navigate(true)
             }
         }
@@ -699,7 +700,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
     private fun resolveScopeForNode(node: DefaultMutableTreeNode, nodeInfo: NodeInfo): ScriptScope {
         val psiClass = nodeInfo.psiClass
         return if (psiClass != null) {
-            val qualifiedName = com.intellij.openapi.application.ApplicationManager.getApplication().runReadAction<String?> {
+            val qualifiedName = ApplicationManager.getApplication().runReadAction<String?> {
                 psiClass.qualifiedName ?: psiClass.name
             } ?: nodeInfo.text
             ScriptScope.Class(qualifiedName)
@@ -728,7 +729,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
         if (folder != null) {
             scopes.add(ScriptScope.Module(folder))
         }
-        val qualifiedName = com.intellij.openapi.application.ApplicationManager.getApplication().runReadAction<String?> {
+        val qualifiedName = ApplicationManager.getApplication().runReadAction<String?> {
             endpoint.sourceClass?.qualifiedName
         } ?: endpoint.className
         if (qualifiedName != null) {

--- a/src/main/kotlin/com/itangcent/easyapi/logging/DefaultIdeaConsole.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/DefaultIdeaConsole.kt
@@ -4,7 +4,7 @@ import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindowAnchor
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.itangcent.easyapi.core.threading.swing
 import kotlinx.coroutines.GlobalScope
@@ -47,36 +47,31 @@ class DefaultIdeaConsole(
         console
     }
 
+    fun bindToolWindow(toolWindow: ToolWindow) {
+        val content = toolWindow.contentManager.factory.createContent(
+            consoleView.component, "", false
+        )
+        toolWindow.contentManager.addContent(content)
+    }
+
     private suspend fun ensureConsoleInitialized() {
         if (consoleInitialized) return
         consoleInitialized = true
 
         swing {
-            val toolWindowManager = ToolWindowManager.getInstance(project)
-            var toolWindow = toolWindowManager.getToolWindow(WINDOW_ID)
-            if (toolWindow == null) {
-                toolWindow = toolWindowManager.registerToolWindow(WINDOW_ID) {
-                    anchor = ToolWindowAnchor.BOTTOM
-                    canCloseContent = false
-                }
-                val content = toolWindow.contentManager.factory.createContent(
-                    consoleView.component, "", false
-                )
-                toolWindow.contentManager.addContent(content)
-            } else {
-                val content = toolWindow.contentManager.getContent(0)
-                if (content != null) {
-                    content.component = consoleView.component
+            val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(WINDOW_ID)
+            if (toolWindow != null) {
+                val existingContent = toolWindow.contentManager.getContent(0)
+                if (existingContent != null) {
+                    existingContent.component = consoleView.component
                 } else {
-                    val newContent = toolWindow.contentManager.factory.createContent(
-                        consoleView.component,
-                        "",
-                        false
+                    val content = toolWindow.contentManager.factory.createContent(
+                        consoleView.component, "", false
                     )
-                    toolWindow.contentManager.addContent(newContent)
+                    toolWindow.contentManager.addContent(content)
                 }
+                toolWindow.show()
             }
-            toolWindow.show()
         }
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowFactory.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowFactory.kt
@@ -1,0 +1,15 @@
+package com.itangcent.easyapi.logging
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+
+class EasyApiConsoleToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val consoleProvider = IdeaConsoleProvider.getInstance(project)
+        val console = consoleProvider.getConsole()
+        if (console is DefaultIdeaConsole) {
+            console.bindToolWindow(toolWindow)
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/SourceHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/SourceHelper.kt
@@ -2,22 +2,22 @@ package com.itangcent.easyapi.psi.helper
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.fileTypes.StdFileTypes
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassOwner
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
-import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMember
 import com.intellij.psi.impl.compiled.ClsClassImpl
+import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.core.threading.read
 import java.io.File
 import java.util.*
@@ -26,7 +26,7 @@ import java.util.*
  * Resolves compiled JAR classes to their source counterparts for documentation extraction.
  *
  * When working with VO/DTO classes from external JAR dependencies, IntelliJ loads them
- * as compiled classes ([ClsClassImpl]) which don't have direct access to Javadoc comments.
+ * as compiled classes ([ClsClassImpl]) which don't have direct access to Javadoc/KDoc comments.
  * This helper resolves these compiled classes to their source versions when source JARs
  * are attached, enabling proper documentation extraction.
  *
@@ -36,6 +36,7 @@ import java.util.*
  * 2. **Cached resolution**: Return previously resolved source class if available
  * 3. **Navigation element**: Use IntelliJ's built-in navigation for decompiled classes
  * 4. **Source JAR search**: Search attached source roots for matching source files
+ *    (both `.java` and `.kt` files are supported via [SOURCE_EXTENSIONS])
  *
  * ## Usage
  *
@@ -69,6 +70,35 @@ import java.util.*
 class SourceHelper(private val project: Project) {
 
     companion object {
+        /**
+         * File extension for Java source files.
+         *
+         * Defined locally rather than using [com.intellij.openapi.fileTypes.StdFileTypes]
+         * because `StdFileTypes.JAVA.defaultExtension` only provides "java" without the dot,
+         * and `StdFileTypes` API may vary across IntelliJ versions. Using a simple constant
+         * avoids deprecated API dependencies and keeps the extension format consistent
+         * (with leading dot) for direct use in path construction.
+         */
+        private const val DOT_JAVA = ".java"
+
+        /**
+         * File extension for Kotlin source files.
+         *
+         * Kotlin source files (`.kt`) may contain classes that are referenced from JARs.
+         * Including this extension enables source resolution for Kotlin classes in
+         * attached source JARs, not just Java.
+         */
+        private const val DOT_KOTLIN = ".kt"
+
+        /**
+         * Supported source file extensions for class resolution.
+         *
+         * When searching for a source class in attached source roots, both `.java` and `.kt`
+         * files are checked. This allows resolving source for classes compiled from either
+         * language.
+         */
+        private val SOURCE_EXTENSIONS = listOf(DOT_JAVA, DOT_KOTLIN)
+
         /**
          * Cache key for storing resolved source classes on the original compiled class.
          * This avoids repeated source resolution for the same class during an operation.
@@ -152,12 +182,13 @@ class SourceHelper(private val project: Project) {
                     }
 
                     val orderEntriesForFile = idx.getOrderEntriesForFile(vFile)
-                    orderEntriesForFile.asSequence()
+                    @Suppress("DEPRECATION") // OrderRootType.SOURCES is deprecated but required for source JAR resolution on older IntelliJ versions
+                    val sourceFiles = orderEntriesForFile.asSequence()
                         .flatMap { it.getFiles(OrderRootType.SOURCES).asSequence() }
                         .distinct()
-                        .map { tryFindSourceClass(it, original) }
-                        .firstOrNull()
-                        ?.let { return it }
+                    for (srcFile in sourceFiles) {
+                        tryFindSourceClass(srcFile, original)?.let { return it }
+                    }
                 }
             }
         } catch (_: Exception) {
@@ -244,8 +275,9 @@ class SourceHelper(private val project: Project) {
     /**
      * Searches for a source class in a source root directory.
      *
-     * Looks for a Java file matching the class's qualified name and caches
-     * the result on the original class for future lookups.
+     * Looks for a Java or Kotlin source file matching the class's qualified name
+     * (see [SOURCE_EXTENSIONS]) and caches the result on the original class for
+     * future lookups via [SOURCE_ELEMENT].
      *
      * @param sourceRoot The virtual file representing the source root
      * @param original The compiled class to find source for
@@ -256,67 +288,65 @@ class SourceHelper(private val project: Project) {
         original: PsiClass
     ): PsiClass? {
         val qualifiedName = original.qualifiedName ?: return null
-        val find = findPsiFileInRoot(sourceRoot, qualifiedName)
-            ?: sourceRoot.findChild(qualifiedName)
-        if (find != null && find is PsiJavaFile) {
-            find.classes.forEach {
-                if (it.qualifiedName == qualifiedName) {
-                    original.putUserData(SOURCE_ELEMENT, it)
-                    return it
-                }
-            }
+        val sourceClass = findSourceClassInRoot(sourceRoot, qualifiedName)
+        if (sourceClass != null) {
+            original.putUserData(SOURCE_ELEMENT, sourceClass)
+            return sourceClass
         }
         return null
     }
 
     /**
-     * Finds a Java source file in a source root by class qualified name.
+     * Finds a source class in a source root directory by qualified name.
      *
-     * Uses a depth-first search to locate the file, handling nested packages
-     * and matching by qualified name to support classes that may not follow
-     * standard file naming conventions.
+     * Uses a two-phase search strategy:
+     *
+     * 1. **Direct path lookup**: Constructs the expected relative path from the
+     *    package and class name (e.g., `com/example/Foo.java` or `com/example/Foo.kt`)
+     *    and checks each extension in [SOURCE_EXTENSIONS]. This is the fast path
+     *    and works for most cases where the source file follows standard naming conventions.
+     *
+     * 2. **Directory traversal**: Falls back to a depth-first search through directories
+     *    that match the class's package prefix. Only source files whose names match
+     *    `SimpleName.java` or `SimpleName.kt` (from [SOURCE_EXTENSIONS]) are inspected.
+     *    This handles cases where the directory structure doesn't strictly follow the
+     *    package layout (e.g., Kotlin multi-file facades or non-standard source layouts).
+     *
+     * Both phases delegate to [findClassInVirtualFile] to resolve the [PsiClass] from
+     * the matched virtual file.
      *
      * @param dirFile The source root directory to search in
      * @param className The fully qualified class name to find
-     * @return The PsiJavaFile if found, null otherwise
+     * @return The source PsiClass if found, null otherwise
      */
-    private fun findPsiFileInRoot(dirFile: VirtualFile, className: String): PsiJavaFile? {
-        val javaName = StringUtil.getQualifiedName(className, StdFileTypes.JAVA.defaultExtension)
-        if (className.isNotEmpty()) {
-            val classFile = dirFile.findChild(javaName)
-            if (classFile != null) {
-                val psiFile = PsiManager.getInstance(project).findFile(classFile)
-                if (psiFile is PsiJavaFile) {
-                    return psiFile
-                }
+    private fun findSourceClassInRoot(dirFile: VirtualFile, className: String): PsiClass? {
+        val simpleName = className.substringAfterLast('.')
+        val packagePath = className.substringBeforeLast('.', "").replace('.', '/')
+
+        for (ext in SOURCE_EXTENSIONS) {
+            val relativePath = if (packagePath.isNotEmpty()) "$packagePath/$simpleName$ext" else "$simpleName$ext"
+            val file = dirFile.findFileByRelativePath(relativePath)
+            if (file != null && file.isValid) {
+                findClassInVirtualFile(file, className)?.let { return it }
             }
         }
 
+        val targetFileNames = SOURCE_EXTENSIONS.map { simpleName + it }.toSet()
         val dirs = Stack<VirtualFile>()
         var dir: VirtualFile = dirFile
         val rootPath = dirFile.path
         while (true) {
             val children = dir.children
             for (child in children) {
-                if (StdFileTypes.JAVA == child.fileType && child.isValid) {
-                    val psiFile = PsiManager.getInstance(project).findFile(child)
-                    if (psiFile is PsiJavaFile) {
-                        if (child.name == javaName) {
-                            return psiFile
-                        }
-
-                        for (cls in psiFile.classes) {
-                            if (cls.qualifiedName == className) {
-                                return psiFile
-                            }
-                        }
-                    }
-                } else {
-                    val prefix = dir.path.removePrefix(rootPath)
-                        .replace(File.separatorChar, '.')
-                    if (javaName.startsWith(prefix)) {
+                if (child.isDirectory) {
+                    val relativeDirPath = dir.path.removePrefix(rootPath)
+                        .removePrefix(File.separator)
+                    val packagePrefix = relativeDirPath.replace(File.separatorChar, '.')
+                    if (packagePrefix.isEmpty() || className.startsWith("$packagePrefix.")) {
                         dirs.push(child)
                     }
+                } else if (child.isValid && child.name in targetFileNames) {
+                    findClassInVirtualFile(child, className)?.let { return it }
                 }
             }
             if (dirs.isEmpty()) {
@@ -325,5 +355,25 @@ class SourceHelper(private val project: Project) {
             dir = dirs.pop()
         }
         return null
+    }
+
+    /**
+     * Resolves a PsiClass from a virtual file by qualified name.
+     *
+     * For files that implement [PsiClassOwner] (e.g., Java/Kotlin source files),
+     * directly inspects the declared classes. For other file types, uses
+     * [JavaPsiFacade] with a file-scoped search.
+     *
+     * @param file The virtual file to resolve the class from
+     * @param qualifiedName The fully qualified class name to find
+     * @return The matching PsiClass if found, null otherwise
+     */
+    private fun findClassInVirtualFile(file: VirtualFile, qualifiedName: String): PsiClass? {
+        val psiFile = PsiManager.getInstance(project).findFile(file) ?: return null
+        if (psiFile is PsiClassOwner) {
+            return psiFile.classes.find { it.qualifiedName == qualifiedName }
+        }
+        val scope = GlobalSearchScope.fileScope(project, file)
+        return JavaPsiFacade.getInstance(project).findClass(qualifiedName, scope)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/util/ide/GradleProjectIdResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/ide/GradleProjectIdResolver.kt
@@ -1,0 +1,45 @@
+package com.itangcent.easyapi.util.ide
+
+import com.intellij.psi.PsiClass
+
+/**
+ * Resolves Maven coordinates using the IntelliJ Gradle plugin integration.
+ *
+ * Uses reflection to access [ExternalProjectDataCache] and [ExternalProject] classes
+ * from the optional Gradle plugin, avoiding a hard compile-time dependency.
+ */
+class GradleProjectIdResolver : ProjectIdResolver {
+
+    override val available: Boolean by lazy {
+        runCatching {
+            Class.forName(EXTERNAL_PROJECT_DATA_CACHE_CLASS)
+            true
+        }.getOrDefault(false) as Boolean
+    }
+
+    override fun resolve(psiClass: PsiClass): MavenIdData? {
+        val project = psiClass.project
+        val projectPath = project.basePath ?: return null
+
+        val cacheClass = Class.forName(EXTERNAL_PROJECT_DATA_CACHE_CLASS)
+        val cache = cacheClass.getMethod("getInstance", com.intellij.openapi.project.Project::class.java)
+            .invoke(null, project)
+
+        val externalProject = cacheClass.getMethod("getRootExternalProject", String::class.java)
+            .invoke(cache, projectPath) ?: return null
+
+        val externalProjectClass = Class.forName(EXTERNAL_PROJECT_CLASS)
+        val group = externalProjectClass.getMethod("getGroup").invoke(externalProject) as? String ?: return null
+        val name = externalProjectClass.getMethod("getName").invoke(externalProject) as? String ?: return null
+        val version = externalProjectClass.getMethod("getVersion").invoke(externalProject) as? String ?: return null
+
+        return MavenIdData(groupId = group, artifactId = name, version = version)
+    }
+
+    companion object {
+        private const val EXTERNAL_PROJECT_DATA_CACHE_CLASS =
+            "org.jetbrains.plugins.gradle.service.project.data.ExternalProjectDataCache"
+        private const val EXTERNAL_PROJECT_CLASS =
+            "org.jetbrains.plugins.gradle.model.ExternalProject"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/util/ide/MavenHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/ide/MavenHelper.kt
@@ -1,59 +1,40 @@
 package com.itangcent.easyapi.util.ide
 
-import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.PsiClass
-import org.jetbrains.idea.maven.project.MavenProjectsManager
-import org.jetbrains.plugins.gradle.service.project.data.ExternalProjectDataCache
 
 /**
- * Utility object for extracting Maven/Gradle project information.
- * 
- * Provides methods to resolve Maven coordinates (groupId, artifactId, version)
- * from PSI classes using either Maven or Gradle project integration.
+ * Utility object for extracting Maven/Gradle project coordinates from PSI classes.
+ *
+ * Tries each registered [ProjectIdResolver] in order (Maven first, then Gradle)
+ * and returns the first successful result. Resolvers use reflection to access
+ * optional IntelliJ plugin APIs, so they gracefully degrade when a plugin is absent.
  */
 object MavenHelper {
+
+    private val resolvers: List<ProjectIdResolver> = listOf(
+        MavenProjectIdResolver(),
+        GradleProjectIdResolver()
+    )
+
     /**
      * Resolves Maven coordinates for a PSI class.
      * Tries Maven first, then Gradle.
-     * 
+     *
      * @param psiClass The class to resolve coordinates for
      * @return MavenIdData with coordinates, or null if not found
      */
     fun getMavenId(psiClass: PsiClass): MavenIdData? {
-        return runCatching { getMavenIdByMaven(psiClass) }.getOrNull()
-            ?: runCatching { getMavenIdByGradle(psiClass) }.getOrNull()
-    }
-
-    /**
-     * Resolves Maven coordinates using Maven project integration.
-     */
-    private fun getMavenIdByMaven(psiClass: PsiClass): MavenIdData? {
-        val project = psiClass.project
-        val module = ModuleUtilCore.findModuleForPsiElement(psiClass) ?: return null
-        val mavenProject = MavenProjectsManager.getInstance(project).findProject(module) ?: return null
-        val mavenId = mavenProject.mavenId
-        return MavenIdData(
-            groupId = mavenId.groupId ?: return null,
-            artifactId = mavenId.artifactId ?: return null,
-            version = mavenId.version ?: return null
-        )
-    }
-
-    /**
-     * Resolves Maven coordinates using Gradle project integration.
-     */
-    private fun getMavenIdByGradle(psiClass: PsiClass): MavenIdData? {
-        val project = psiClass.project
-        val projectPath = project.basePath ?: return null
-        val externalProject = ExternalProjectDataCache.getInstance(project).getRootExternalProject(projectPath) ?: return null
-        return MavenIdData(groupId = externalProject.group, artifactId = externalProject.name, version = externalProject.version)
+        return resolvers.asSequence()
+            .filter { it.available }
+            .mapNotNull { runCatching { it.resolve(psiClass) }.getOrNull() }
+            .firstOrNull()
     }
 }
 
 /**
  * Data class holding Maven coordinates.
  * Provides methods to format coordinates for different build systems.
- * 
+ *
  * @property groupId The Maven group ID
  * @property artifactId The Maven artifact ID
  * @property version The version string
@@ -63,9 +44,7 @@ data class MavenIdData(
     val artifactId: String,
     val version: String
 ) {
-    /**
-     * Formats coordinates as Maven dependency XML.
-     */
+    /** Formats coordinates as Maven dependency XML. */
     fun maven(): String {
         return """
             <dependency>
@@ -76,23 +55,17 @@ data class MavenIdData(
         """.trimIndent()
     }
 
-    /**
-     * Formats coordinates as Gradle Kotlin DSL dependency.
-     */
+    /** Formats coordinates as Gradle Kotlin DSL dependency. */
     fun gradleKotlin(): String {
         return """implementation("$groupId:$artifactId:$version")"""
     }
 
-    /**
-     * Formats coordinates as Gradle Groovy DSL dependency.
-     */
+    /** Formats coordinates as Gradle Groovy DSL dependency. */
     fun gradleGroovy(): String {
         return """implementation '$groupId:$artifactId:$version'"""
     }
 
-    /**
-     * Formats coordinates as SBT dependency.
-     */
+    /** Formats coordinates as SBT dependency. */
     fun sbt(): String {
         return "libraryDependencies += \"$groupId\" % \"$artifactId\" % \"$version\""
     }

--- a/src/main/kotlin/com/itangcent/easyapi/util/ide/MavenProjectIdResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/ide/MavenProjectIdResolver.kt
@@ -1,0 +1,49 @@
+package com.itangcent.easyapi.util.ide
+
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.psi.PsiClass
+
+/**
+ * Resolves Maven coordinates using the IntelliJ Maven plugin integration.
+ *
+ * Uses reflection to access [MavenProjectsManager] and [MavenProject] classes
+ * from the optional Maven plugin, avoiding a hard compile-time dependency.
+ */
+class MavenProjectIdResolver : ProjectIdResolver {
+
+    override val available: Boolean by lazy {
+        runCatching {
+            Class.forName(MAVEN_PROJECTS_MANAGER_CLASS)
+            true
+        }.getOrDefault(false) as Boolean
+    }
+
+    override fun resolve(psiClass: PsiClass): MavenIdData? {
+        val project = psiClass.project
+        val module = ModuleUtilCore.findModuleForPsiElement(psiClass) ?: return null
+
+        val managerClass = Class.forName(MAVEN_PROJECTS_MANAGER_CLASS)
+        val manager = managerClass.getMethod("getInstance", com.intellij.openapi.project.Project::class.java)
+            .invoke(null, project)
+
+        val mavenProject = managerClass.getMethod("findProject", com.intellij.openapi.module.Module::class.java)
+            .invoke(manager, module) ?: return null
+
+        val mavenProjectClass = Class.forName(MAVEN_PROJECT_CLASS)
+        val mavenId = mavenProjectClass.getMethod("getMavenId")
+            .invoke(mavenProject) ?: return null
+
+        val mavenIdClass = Class.forName(MAVEN_ID_CLASS)
+        val groupId = mavenIdClass.getMethod("getGroupId").invoke(mavenId) as? String ?: return null
+        val artifactId = mavenIdClass.getMethod("getArtifactId").invoke(mavenId) as? String ?: return null
+        val version = mavenIdClass.getMethod("getVersion").invoke(mavenId) as? String ?: return null
+
+        return MavenIdData(groupId = groupId, artifactId = artifactId, version = version)
+    }
+
+    companion object {
+        private const val MAVEN_PROJECTS_MANAGER_CLASS = "org.jetbrains.idea.maven.project.MavenProjectsManager"
+        private const val MAVEN_PROJECT_CLASS = "org.jetbrains.idea.maven.project.MavenProject"
+        private const val MAVEN_ID_CLASS = "org.jetbrains.idea.maven.model.MavenId"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/util/ide/ProjectIdResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/ide/ProjectIdResolver.kt
@@ -1,0 +1,27 @@
+package com.itangcent.easyapi.util.ide
+
+import com.intellij.psi.PsiClass
+
+/**
+ * Resolves Maven coordinates (groupId, artifactId, version) from a PSI class
+ * using a specific build tool integration (Maven, Gradle, etc.).
+ *
+ * Implementations use reflection to access optional IntelliJ plugin APIs,
+ * avoiding compile-time dependencies on plugins that may not be installed.
+ */
+interface ProjectIdResolver {
+
+    /**
+     * Checks whether the required plugin classes are available at runtime.
+     * This is checked lazily once and cached to avoid repeated class loading.
+     */
+    val available: Boolean
+
+    /**
+     * Resolves Maven coordinates for the given PSI class.
+     *
+     * @param psiClass The class to resolve coordinates for
+     * @return MavenIdData with coordinates, or null if not resolvable
+     */
+    fun resolve(psiClass: PsiClass): MavenIdData?
+}

--- a/src/main/resources/META-INF/easy-api-gradle.xml
+++ b/src/main/resources/META-INF/easy-api-gradle.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/easy-api-maven.xml
+++ b/src/main/resources/META-INF/easy-api-maven.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,8 @@
     <depends optional="true" config-file="easy-api-kotlin.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="easy-api-scala.xml">org.intellij.scala</depends>
     <depends optional="true" config-file="easy-api-groovy.xml">org.intellij.groovy</depends>
+    <depends optional="true" config-file="easy-api-maven.xml">org.jetbrains.idea.maven</depends>
+    <depends optional="true" config-file="easy-api-gradle.xml">org.jetbrains.plugins.gradle</depends>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
         <supportsKotlinPluginMode supportsK2="true"/>
@@ -70,6 +72,11 @@
                 icon="AllIcons.Toolwindows.ToolWindowRun"
                 anchor="bottom"
                 factoryClass="com.itangcent.easyapi.dashboard.ApiDashboardToolWindowFactory"/>
+        <toolWindow
+                id="EasyAPI"
+                icon="AllIcons.Toolwindows.ToolWindowRun"
+                anchor="bottom"
+                factoryClass="com.itangcent.easyapi.logging.EasyApiConsoleToolWindowFactory"/>
         <notificationGroup id="EasyApi Notifications" displayType="BALLOON"/>
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.itangcent.easyapi.ide.linemarker.ApiMethodLineMarkerProvider"/>
         <searchEverywhereContributor implementation="com.itangcent.easyapi.ide.search.ApiSearchEverywhereContributorFactory"/>


### PR DESCRIPTION
Fixes #1342

## Changes

- Replace deprecated StdFileTypes with self-defined extension constants (DOT_JAVA, DOT_KOTLIN)
- Add Kotlin source file (.kt) support in SourceHelper for source JAR resolution
- Refactor SourceHelper: extract findSourceClassInRoot and findClassInVirtualFile helpers
- Replace WriteIntentReadAction with ReadAction.nonBlocking() in ApiDashboardPanel
- Replace direct registerToolWindow() call with plugin.xml toolWindow extension point (EasyApiConsoleToolWindowFactory)
- Add optional plugin dependencies for Maven and Gradle in plugin.xml
- Extract ProjectIdResolver interface with runtime-guarded MavenProjectIdResolver and GradleProjectIdResolver
- Add easy-api-maven.xml and easy-api-gradle.xml optional plugin descriptors