### PR TITLE
fix: wrap PsiAnnotation.owner access in read action in JaxRsClassExporter

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -86,9 +86,11 @@ class JaxRsClassExporter(
         val endpoints = ArrayList<ApiEndpoint>()
         try {
             for (resolvedMethod in resolvedMethods) {
-                val httpMethodAnn = read { resolvedMethod.searchAnnotation(JAXRS_HTTP_METHOD_ANNOTATIONS) }
-                    ?: continue
-                val annotatedMethod = (httpMethodAnn.owner as? PsiMethod) ?: resolvedMethod.psiMethod
+                val annotatedMethod = read {
+                    val httpMethodAnn = resolvedMethod.searchAnnotation(JAXRS_HTTP_METHOD_ANNOTATIONS)
+                        ?: return@read null
+                    (httpMethodAnn.owner as? PsiMethod) ?: resolvedMethod.psiMethod
+                } ?: continue
                 endpoints.addAll(exportMethod(psiClass, annotatedMethod, resolvedMethod))
             }
         } finally {


### PR DESCRIPTION
Fixes #1349 - Read access is allowed from inside read-action only error when opening a new project. The httpMethodAnn.owner call accesses the PSI tree and must be within a read action, but was previously called outside the read block that produced the annotation.