### PR TITLE
fix: inherited methods from parent class not scanned

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -89,7 +89,7 @@ class FeignClassExporter(
         val basePath = normalizePath(info.path ?: "")
 
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethods = read { classType.methods() }
+        val resolvedMethods = read { classType.suitableMethods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
             for (resolvedMethod in resolvedMethods) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -82,7 +82,7 @@ class JaxRsClassExporter(
         }
 
         val resolvedType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethods = read { resolvedType.methods() }
+        val resolvedMethods = read { resolvedType.suitableMethods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
             for (resolvedMethod in resolvedMethods) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -83,7 +83,7 @@ class SpringMvcClassExporter(
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
         val resolvedType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethods = read { resolvedType.methods() }
+        val resolvedMethods = read { resolvedType.suitableMethods() }
         val endpoints = ArrayList<ApiEndpoint>()
         try {
             for (resolvedMethod in resolvedMethods) {

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypes.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypes.kt
@@ -113,69 +113,149 @@ sealed class ResolvedType {
         }
 
         /**
-         * Returns deduplicated, generics-resolved methods.
-         * Deduplicates by name#paramCount, preferring the override from [psiClass].
+         * Returns methods declared directly in this class (not inherited).
+         * Excludes constructors.
          * Each [ResolvedMethod] gets [ResolvedMethod.ownerClassType] = this.
-         *
-         * Uses per-level generic context propagation: each method's types are resolved
-         * using the context of its declaring class, not a flat merged context.
          */
-        fun methods(): List<ResolvedMethod> {
-            // Collect all non-constructor, non-Object methods
-            val allMethods = psiClass.allMethods.filter { method ->
-                !method.isConstructor &&
-                method.containingClass?.qualifiedName != "java.lang.Object"
-            }
-
-            // Group by name + param count to detect generic erasure duplicates
-            // (e.g., interface save(Req) and impl save(UserInfo) have same param count)
-            val result = LinkedHashMap<String, PsiMethod>()
-            for (method in allMethods) {
-                val fullKey = methodSignatureKey(method)
-                val countKey = "${method.name}#${method.parameterList.parametersCount}"
-
-                // Check if there's already a method with the same full signature
-                if (fullKey in result) {
-                    // Same exact signature — prefer concrete class over interface
-                    val existing = result[fullKey]!!
-                    if (shouldPrefer(method, existing, psiClass)) {
-                        result[fullKey] = method
-                    }
-                    continue
-                }
-
-                // Check if there's a method with same name+paramCount but different types
-                // (could be a generic erasure duplicate or a true overload)
-                val sameCountKey = result.entries.find { (k, v) ->
-                    "${v.name}#${v.parameterList.parametersCount}" == countKey
-                }
-
-                if (sameCountKey != null) {
-                    val existing = sameCountKey.value
-                    // If one is from an interface and the other from a class, it's generic erasure
-                    val existingIsInterface = existing.containingClass?.isInterface == true
-                    val newIsInterface = method.containingClass?.isInterface == true
-                    if (existingIsInterface != newIsInterface) {
-                        // Generic erasure: prefer the concrete class method
-                        if (!newIsInterface) {
-                            result.remove(sameCountKey.key)
-                            result[fullKey] = method
-                        }
-                        // else: existing is already the concrete one, skip
-                        continue
-                    }
-                    // Both from same kind (both interface or both class) — true overload, keep both
-                }
-
-                result[fullKey] = method
-            }
-            return result.values.map { method ->
+        fun declaredMethods(): List<ResolvedMethod> {
+            return psiClass.methods.filter { !it.isConstructor }.map { method ->
                 ResolvedMethod(
                     name = method.name,
                     psiMethod = method,
                     containClass = psiClass,
                     ownerClassType = this
                 )
+            }
+        }
+
+        /**
+         * Returns fields declared directly in this class (not inherited).
+         */
+        fun declaredFields(): List<ResolvedField> {
+            return psiClass.fields.map { field ->
+                ResolvedField(
+                    name = field.name,
+                    psiField = field,
+                    annotations = field.annotations.toList(),
+                    containClass = psiClass,
+                    ownerClassType = this
+                )
+            }
+        }
+
+        /**
+         * Returns all methods from this class and its superclasses, without deduplication.
+         * Excludes constructors and methods from java.lang.Object.
+         * Each [ResolvedMethod] gets [ResolvedMethod.ownerClassType] = this.
+         *
+         * Note: if a subclass overrides a superclass method, both versions will appear
+         * in the result. Use [suitableMethods] for a deduplicated view.
+         */
+        fun allMethods(): List<ResolvedMethod> {
+            return psiClass.allMethods.filter { method ->
+                !method.isConstructor &&
+                        method.containingClass?.qualifiedName != "java.lang.Object"
+            }.map { method ->
+                ResolvedMethod(
+                    name = method.name,
+                    psiMethod = method,
+                    containClass = psiClass,
+                    ownerClassType = this
+                )
+            }
+        }
+
+        /**
+         * Returns all fields from this class and its superclasses, without deduplication.
+         * Each field's type is resolved using the context of its declaring class.
+         *
+         * Note: if a subclass declares a field with the same name as a superclass field,
+         * both will appear in the result. Use [suitableFields] for a deduplicated view.
+         */
+        fun allFields(): List<ResolvedField> = fieldsSequence(deduplicate = false).toList()
+
+        /**
+         * Returns deduplicated methods from this class and its superclasses.
+         * If a method is overridden in a subclass, only the subclass version is kept.
+         * Handles generic erasure by preferring concrete class methods over interface methods.
+         * Each [ResolvedMethod] gets [ResolvedMethod.ownerClassType] = this.
+         *
+         * Uses per-level generic context propagation: each method's types are resolved
+         * using the context of its declaring class, not a flat merged context.
+         */
+        fun suitableMethods(): List<ResolvedMethod> {
+            val allMethods = psiClass.allMethods.filter { method ->
+                !method.isConstructor &&
+                        method.containingClass?.qualifiedName != "java.lang.Object"
+            }
+
+            val supersOf = mutableMapOf<PsiMethod, Set<PsiMethod>>()
+            for (method in allMethods) {
+                supersOf[method] = method.findSuperMethods().toSet()
+            }
+
+            val removed = mutableSetOf<PsiMethod>()
+            for (method in allMethods) {
+                val superMethods = supersOf[method] ?: emptySet()
+                for (superMethod in superMethods) {
+                    if (superMethod in removed) continue
+                    if (allMethods.any { it == superMethod }) {
+                        removed.add(superMethod)
+                    }
+                }
+            }
+
+            return allMethods.filter { it !in removed }.map { method ->
+                ResolvedMethod(
+                    name = method.name,
+                    psiMethod = method,
+                    containClass = psiClass,
+                    ownerClassType = this
+                )
+            }
+        }
+
+        /**
+         * Returns deduplicated fields from this class and its superclasses.
+         * If a subclass declares a field with the same name as a superclass field,
+         * only the subclass version is kept.
+         * Each field's type is resolved using the context of its declaring class.
+         */
+        fun suitableFields(): List<ResolvedField> = fieldsSequence(deduplicate = true).toList()
+
+        private fun fieldsSequence(deduplicate: Boolean): Sequence<ResolvedField> = sequence {
+            val seen: (PsiField) -> Boolean
+            when {
+                deduplicate -> {
+                    val set = mutableSetOf<String>()
+                    seen = { set.add(it.name) }
+                }
+
+                else -> {
+                    seen = { true }
+                }
+            }
+            yieldAll(fieldsFromClass(this@ClassType, seen))
+        }
+
+        private fun fieldsFromClass(
+            classType: ClassType,
+            filter: (PsiField) -> Boolean
+        ): Sequence<ResolvedField> = sequence {
+            for (field in classType.psiClass.fields) {
+                if (!filter(field)) continue
+                yield(
+                    ResolvedField(
+                        name = field.name,
+                        psiField = field,
+                        annotations = field.annotations.toList(),
+                        containClass = psiClass,
+                        ownerClassType = classType
+                    )
+                )
+            }
+            for (superClassType in classType.superClasses()) {
+                yieldAll(fieldsFromClass(superClassType, filter))
             }
         }
 
@@ -195,21 +275,6 @@ sealed class ResolvedType {
                 }
                 yield(ClassType(superClass, args))
             }
-        }
-
-        /**
-         * Returns all fields from this class and its superclasses, with types resolved
-         * using per-level generic context propagation.
-         *
-         * Each field's type is resolved using the context of its declaring class,
-         * ensuring that type parameter `T` in `Layer1<T>` gets the correct binding
-         * even when multiple levels reuse the same name.
-         */
-        fun fields(): List<ResolvedField> {
-            val result = mutableListOf<ResolvedField>()
-            val fieldNames = mutableSetOf<String>()
-            collectFieldsPerLevel(this, result, fieldNames)
-            return result
         }
 
         fun annotations(): List<PsiAnnotation> = psiClass.annotations.toList()
@@ -270,6 +335,7 @@ sealed class ResolvedType {
             lower != null -> "? super " + lower.qualifiedName()
             else -> "?"
         }
+
         override fun simpleName(): String = "?"
         override fun contextElement(): PsiElement? = upper?.contextElement() ?: lower?.contextElement()
     }
@@ -428,38 +494,6 @@ class ResolvedParam internal constructor(
     override fun toString(): String = "ResolvedParam(name=$name)"
 }
 
-/**
- * Collects fields per-level by walking the hierarchy via [ResolvedType.ClassType.superClasses].
- * Each level's fields are resolved using that level's own generic context.
- * Super fields come first (depth-first), then this class's own declared fields.
- *
- * @param rootClass The root class being queried (used as containClass for all fields)
- */
-private fun collectFieldsPerLevel(
-    classType: ResolvedType.ClassType,
-    result: MutableList<ResolvedField>,
-    fieldNames: MutableSet<String>,
-    rootClass: PsiClass = classType.psiClass
-) {
-    // Recurse into supertypes first (depth-first so base fields come first)
-    for (superClassType in classType.superClasses()) {
-        collectFieldsPerLevel(superClassType, result, fieldNames, rootClass)
-    }
-    // Then this class's own declared fields (not allFields — just this level)
-    for (field in classType.psiClass.fields) {
-        if (fieldNames.add(field.name)) {
-            result.add(
-                ResolvedField(
-                    name = field.name,
-                    psiField = field,
-                    annotations = field.annotations.toList(),
-                    containClass = rootClass,
-                    ownerClassType = classType
-                )
-            )
-        }
-    }
-}
 
 /**
  * Walks the supertype hierarchy from [root] to find the per-level generic context
@@ -754,7 +788,7 @@ object TypeResolver {
         val facade = JavaPsiFacade.getInstance(project)
         val scope = GlobalSearchScope.allScope(project)
         val sourceHelper = com.itangcent.easyapi.psi.helper.SourceHelper.getInstance(project)
-        
+
         // Fully qualified name
         facade.findClass(className, scope)?.let { return sourceHelper.getSourceClassSync(it) }
 
@@ -795,13 +829,20 @@ object TypeResolver {
         val current = StringBuilder()
         for (ch in typeArgsText) {
             when {
-                ch == '<' -> { depth++; current.append(ch) }
-                ch == '>' -> { depth--; current.append(ch) }
+                ch == '<' -> {
+                    depth++; current.append(ch)
+                }
+
+                ch == '>' -> {
+                    depth--; current.append(ch)
+                }
+
                 ch == ',' && depth == 0 -> {
                     val arg = current.toString().trim()
                     if (arg.isNotEmpty()) result.add(arg)
                     current.clear()
                 }
+
                 else -> current.append(ch)
             }
         }
@@ -985,29 +1026,6 @@ object TypeResolver {
     }
 
     private fun canonicalNameOf(type: ResolvedType): String = type.qualifiedName()
-}
-
-/**
- * Builds a signature key for method deduplication that includes parameter types,
- * correctly distinguishing overloaded methods like `add(UserInfo, MultipartFile)`
- * from `add(UserInfo, MultipartFile[])`.
- */
-private fun methodSignatureKey(method: PsiMethod): String {
-    val params = method.parameterList.parameters.joinToString(",") { it.type.canonicalText }
-    return "${method.name}($params)"
-}
-
-/**
- * Returns true if [candidate] should replace [existing] in the deduplication map.
- * Prefers methods from the concrete [psiClass] over inherited ones,
- * and concrete class methods over interface methods.
- */
-private fun shouldPrefer(candidate: PsiMethod, existing: PsiMethod, psiClass: PsiClass): Boolean {
-    if (candidate.containingClass == psiClass) return true
-    if (existing.containingClass == psiClass) return false
-    val existingIsInterface = existing.containingClass?.isInterface == true
-    val candidateIsClass = candidate.containingClass?.isInterface == false
-    return existingIsInterface && candidateIsClass
 }
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
@@ -480,13 +480,13 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
 
     fun methods(): Array<ScriptPsiMethodContext> = readSync {
         val classType = resolvedType as? ResolvedType.ClassType ?: return@readSync emptyArray()
-        val methods = classType.methods()
+        val methods = classType.suitableMethods()
         Array(methods.size) { i -> ScriptResolvedMethodContext(context, methods[i]) }
     }
 
     fun fields(): Array<ScriptPsiFieldContext> = readSync {
         val classType = resolvedType as? ResolvedType.ClassType ?: return@readSync emptyArray()
-        val fields = classType.fields()
+        val fields = classType.suitableFields()
         Array(fields.size) { i -> ScriptResolvedFieldContext(context, fields[i]) }
     }
 
@@ -636,12 +636,12 @@ class ScriptResolvedClassContext(
 ) : ScriptPsiClassContext(context.withElement(classType.psiClass)) {
 
     override fun methods(): Array<ScriptPsiMethodContext> = readSync {
-        val methods = classType.methods()
+        val methods = classType.suitableMethods()
         Array(methods.size) { i -> ScriptResolvedMethodContext(context, methods[i]) }
     }
 
     override fun fields(): Array<ScriptPsiFieldContext> = readSync {
-        val fields = classType.fields()
+        val fields = classType.suitableFields()
         Array(fields.size) { i -> ScriptResolvedFieldContext(context, fields[i]) }
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignAnnotationInheritanceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/feign/FeignAnnotationInheritanceTest.kt
@@ -31,7 +31,7 @@ class FeignAnnotationInheritanceTest : EasyApiLightCodeInsightFixtureTestCase() 
     fun testOverrideMethodInheritsGetMappingFromSuperInterface() = runTest {
         val psiClass = findClass("com.itangcent.api.feign.UserFeignClient")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val getUserById = classType.methods().first { it.name == "getUserById" }
+        val getUserById = classType.suitableMethods().first { it.name == "getUserById" }
 
         // searchAnnotation walks super methods — the correct way to check inherited annotations
         val ann = getUserById.searchAnnotation("org.springframework.web.bind.annotation.GetMapping")

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedControllerExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedControllerExportTest.kt
@@ -214,4 +214,38 @@ class InheritedControllerExportTest : EasyApiLightCodeInsightFixtureTestCase() {
             body
         )
     }
+
+    // ========== Issue #1352: Non-overridden parent methods not exported ==========
+
+    fun testIssue1352_ParentMethodsWithoutOverride_Exported() = runTest {
+        loadFile("api/inherit/AbstractBaseController.java")
+        loadFile("api/inherit/ChildController.java")
+        val psiClass = findClass("com.itangcent.api.inherit.ChildController")!!
+        val endpoints = exporter.export(psiClass)
+
+        assertTrue("Should export endpoints from both parent and child", endpoints.isNotEmpty())
+
+        val getItem = endpoints.find { it.path.contains("item") && it.httpMetadata?.method == HttpMethod.GET }
+        assertNotNull("Should export GET /base/item inherited from AbstractBaseController", getItem)
+
+        val postItem = endpoints.find { it.path.contains("item") && it.httpMetadata?.method == HttpMethod.POST }
+        assertNotNull("Should export POST /base/item inherited from AbstractBaseController", postItem)
+
+        val getOwn = endpoints.find { it.path.contains("own") && it.httpMetadata?.method == HttpMethod.GET }
+        assertNotNull("Should export GET /own from ChildController", getOwn)
+    }
+
+    fun testIssue1352_ParentMethodPathPrefix() = runTest {
+        loadFile("api/inherit/AbstractBaseController.java")
+        loadFile("api/inherit/ChildController.java")
+        val psiClass = findClass("com.itangcent.api.inherit.ChildController")!!
+        val endpoints = exporter.export(psiClass)
+
+        val getItem = endpoints.find { it.path.contains("item") && it.httpMetadata?.method == HttpMethod.GET }
+        assertNotNull(getItem)
+        assertTrue(
+            "Path should include /base prefix from AbstractBaseController @RequestMapping, got: ${getItem!!.path}",
+            getItem.path.contains("base")
+        )
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedMethodDebugTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/InheritedMethodDebugTest.kt
@@ -1,0 +1,95 @@
+package com.itangcent.easyapi.exporter.springmvc
+
+import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+class InheritedMethodDebugTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PutMapping.java")
+        loadFile("spring/DeleteMapping.java")
+        loadFile("spring/PatchMapping.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/RequestHeader.java")
+        loadFile("spring/ModelAttribute.java")
+        loadFile("spring/RestController.java")
+        loadFile("spring/Controller.java")
+        loadFile("model/Result.java")
+        loadFile("model/IResult.java")
+        loadFile("model/UserInfo.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.empty(project)
+
+    fun testDebug_ParentClassResolved() = runTest {
+        loadFile("api/inherit/AbstractBaseController.java")
+        loadFile("api/inherit/ChildController.java")
+
+        val parentClass = findClass("com.itangcent.api.inherit.AbstractBaseController")
+        println("=== Parent class found: ${parentClass != null} ===")
+        if (parentClass != null) {
+            val parentMethods = read { parentClass.methods.toList() }
+            println("=== Parent class declared methods ===")
+            for (m in parentMethods) {
+                val name = read { m.name }
+                println("  $name")
+            }
+        }
+
+        val childClass = findClass("com.itangcent.api.inherit.ChildController")!!
+        val superTypes = read { childClass.superTypes.toList() }
+        println("=== Child class super types ===")
+        for (st in superTypes) {
+            val resolved = read { st.resolve() }
+            println("  ${st.canonicalText} -> resolved: ${resolved?.qualifiedName}")
+        }
+
+        val supers = read { childClass.supers.toList() }
+        println("=== Child class supers ===")
+        for (s in supers) {
+            val name = read { s.qualifiedName }
+            println("  $name")
+        }
+
+        val allMethods = read { childClass.allMethods.toList() }
+        println("=== Child class allMethods ===")
+        for (m in allMethods) {
+            val name = read { m.name }
+            val cc = read { m.containingClass?.qualifiedName }
+            val isCtor = read { m.isConstructor }
+            println("  $name -> containingClass: $cc, isCtor: $isCtor")
+        }
+    }
+
+    fun testDebug_CompareWithWorkingCase() = runTest {
+        loadFile("api/inherit/AnnotatedBaseCtrl.java")
+        loadFile("api/inherit/PlainSubCtrl.java")
+
+        val parentClass = findClass("com.itangcent.api.inherit.AnnotatedBaseCtrl")!!
+        val childClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
+
+        val parentMethods = read { parentClass.methods.toList() }
+        println("=== AnnotatedBaseCtrl declared methods ===")
+        for (m in parentMethods) {
+            val name = read { m.name }
+            println("  $name")
+        }
+
+        val allMethods = read { childClass.allMethods.toList() }
+        println("=== PlainSubCtrl allMethods ===")
+        for (m in allMethods) {
+            val name = read { m.name }
+            val cc = read { m.containingClass?.qualifiedName }
+            val isCtor = read { m.isConstructor }
+            println("  $name -> containingClass: $cc, isCtor: $isCtor")
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/RequestMappingResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/springmvc/RequestMappingResolverTest.kt
@@ -37,7 +37,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testResolveSimpleGetMapping() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "get" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "get" }
 
         val mappings = resolver.resolve(resolvedMethod)
         assertEquals(1, mappings.size)
@@ -50,7 +50,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testResolveGetMappingWithPathVariable() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "get" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "get" }
 
         val mappings = resolver.resolve(resolvedMethod)
         assertEquals(1, mappings.size)
@@ -63,7 +63,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testResolvePostMappingWithMultiplePaths() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "create" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "create" }
 
         val mappings = resolver.resolve(resolvedMethod)
         assertEquals(2, mappings.size)
@@ -77,7 +77,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testResolvePutMapping() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "update" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "update" }
 
         val mappings = resolver.resolve(resolvedMethod)
         assertEquals(1, mappings.size)
@@ -90,7 +90,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testResolveNestedController() = runTest {
         val psiClass = findClass("com.itangcent.api.UserCtrl.ProfileApi")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "getProfileSettings" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "getProfileSettings" }
 
         val mappings = resolver.resolve(resolvedMethod)
         
@@ -118,7 +118,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val psiClass = findClass("com.itangcent.api.inherit.PlainBaseCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "getItem" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "getItem" }
 
         // PlainBaseCtrl.getItem has no mapping annotation, and no super with one either
         val mappings = resolver.resolve(resolvedMethod)
@@ -138,7 +138,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "getItem" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "getItem" }
 
         // PlainSubCtrl.getItem has no @GetMapping, but AnnotatedBaseCtrl.getItem does
         // Class-level @RequestMapping("/annotated-base") is on AnnotatedBaseCtrl
@@ -159,7 +159,7 @@ class RequestMappingResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val psiClass = findClass("com.itangcent.api.inherit.OrderController")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "createOrder" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "createOrder" }
 
         // OrderController.createOrder has @SendAuditLog (not a mapping annotation)
         // OrderApi.createOrder has @PostMapping

--- a/src/test/kotlin/com/itangcent/easyapi/property/PsiAndExporterPropertyTests.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/property/PsiAndExporterPropertyTests.kt
@@ -78,7 +78,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         )
         val psiClass = findClass("demo.Ctrl")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "x" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "x" }
         val engine = RuleEngine.getInstance(project)
         val resolver = RequestMappingResolver(UnifiedAnnotationHelper(), engine)
         val mappings = resolver.resolve(resolvedMethod)
@@ -104,7 +104,7 @@ class PsiAndExporterPropertyTests : EasyApiLightCodeInsightFixtureTestCase() {
         )
         val psiClass = findClass("demo.Ctrl2")!!
         val classType = ResolvedType.ClassType(psiClass, emptyList())
-        val resolvedMethod = classType.methods().first { it.name == "x" }
+        val resolvedMethod = classType.suitableMethods().first { it.name == "x" }
         val engine = RuleEngine.getInstance(project)
         val resolver = RequestMappingResolver(UnifiedAnnotationHelper(), engine)
         val mappings = resolver.resolve(resolvedMethod)

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/ClassTypeMethodsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/ClassTypeMethodsTest.kt
@@ -33,7 +33,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testCase1_NoDuplicates() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val names = methods.map { it.name }
         assertTrue("list" in names)
         assertTrue("create" in names)
@@ -45,7 +45,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
         val ct = ResolvedType.ClassType(psiClass, emptyList())
-        val methods = ct.methods()
+        val methods = ct.suitableMethods()
         for (m in methods) {
             assertNotNull(m.ownerClassType)
             assertEquals(psiClass, m.ownerClassType?.psiClass)
@@ -55,7 +55,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testCase1_SuperMethodIsNull() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         for (m in methods) {
             assertNull("Simple method '${m.name}' should have no superMethod", m.superMethod())
         }
@@ -67,7 +67,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         assertEquals(1, methods.count { it.name == "getItem" })
         assertEquals(1, methods.count { it.name == "saveItem" })
     }
@@ -76,7 +76,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         // The method from methods() should be the override (from PlainSubCtrl)
@@ -92,7 +92,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         // PlainSubCtrl.getItem has no @GetMapping, but AnnotatedBaseCtrl.getItem does
@@ -106,7 +106,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/PlainBaseCtrl.java")
         loadFile("api/inherit/AnnotatedSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.AnnotatedSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         // AnnotatedSubCtrl.getItem has @GetMapping directly
@@ -118,7 +118,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/PlainBaseCtrl.java")
         loadFile("api/inherit/AnnotatedSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.AnnotatedSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         assertEquals("AnnotatedSubCtrl", getItem.psiMethod.containingClass?.name)
@@ -133,7 +133,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/GenericBaseCtrl.java")
         loadFile("api/generic/StringCtrl.java")
         val psiClass = findClass("com.itangcent.api.generic.StringCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val names = methods.map { it.name }
         assertTrue("getItem" in names)
         assertTrue("createItem" in names)
@@ -143,7 +143,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/GenericBaseCtrl.java")
         loadFile("api/generic/StringCtrl.java")
         val psiClass = findClass("com.itangcent.api.generic.StringCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val rt = getItem.returnType as ResolvedType.ClassType
         assertEquals("Result", rt.psiClass.name)
@@ -156,7 +156,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/MiddleCtrl.java")
         loadFile("api/generic/ConcreteCtrl.java")
         val psiClass = findClass("com.itangcent.api.generic.ConcreteCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val query = methods.first { it.name == "query" }
         val rt = query.returnType as ResolvedType.ClassType
         assertEquals("Result", rt.psiClass.name)
@@ -170,7 +170,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/GenericIface.java")
         loadFile("api/inherit/GenericIfaceImpl.java")
         val psiClass = findClass("com.itangcent.api.inherit.GenericIfaceImpl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val names = methods.map { it.name }
         assertTrue("query" in names)
         assertTrue("save" in names)
@@ -180,7 +180,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/GenericIface.java")
         loadFile("api/inherit/GenericIfaceImpl.java")
         val psiClass = findClass("com.itangcent.api.inherit.GenericIfaceImpl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         assertEquals(1, methods.count { it.name == "query" })
         assertEquals(1, methods.count { it.name == "save" })
     }
@@ -189,7 +189,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/GenericIface.java")
         loadFile("api/inherit/GenericIfaceImpl.java")
         val psiClass = findClass("com.itangcent.api.inherit.GenericIfaceImpl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val query = methods.first { it.name == "query" }
 
         // GenericIfaceImpl.query has no @GetMapping, but GenericIface.query does
@@ -205,7 +205,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/GenericBaseCtrl.java")
         loadFile("api/generic/StringCtrl.java")
         val psiClass = findClass("com.itangcent.api.generic.StringCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         // searchAnnotation should find @GetMapping on the inherited method
@@ -237,7 +237,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val keys = methods.map { "${it.name}#${it.params.size}" }
         assertEquals(keys.size, keys.toSet().size)
     }
@@ -250,7 +250,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/SameParamNameBase.java")
         loadFile("api/inherit/SameParamNameSub.java")
         val psiClass = findClass("com.itangcent.api.inherit.SameParamNameSub")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val rt = getItem.returnType as ResolvedType.ClassType
         assertEquals("Result", rt.psiClass.name)
@@ -268,7 +268,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/SameParamNameBase.java")
         loadFile("api/inherit/SameParamNameSub.java")
         val psiClass = findClass("com.itangcent.api.inherit.SameParamNameSub")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val sup = getItem.superMethod()
         assertNotNull("Should find superMethod in SameParamNameBase", sup)
@@ -288,14 +288,14 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testExcludesConstructors() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         for (m in methods) assertFalse(m.psiMethod.isConstructor)
     }
 
     fun testExcludesObjectMethods() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         for (m in methods) {
             assertFalse(m.psiMethod.containingClass?.qualifiedName == "java.lang.Object")
         }
@@ -307,7 +307,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("org/springframework/web/multipart/MultipartFile.java")
         loadFile("api/inherit/OverloadedCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.OverloadedCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val addMethods = methods.filter { it.name == "add" }
         assertEquals(
             "Both overloaded add() methods should be exported",
@@ -319,7 +319,7 @@ class ClassTypeMethodsTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("org/springframework/web/multipart/MultipartFile.java")
         loadFile("api/inherit/OverloadedCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.OverloadedCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val addMethods = methods.filter { it.name == "add" }
 
         // One has MultipartFile, the other has MultipartFile[]

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/ResolvedMethodTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/ResolvedMethodTest.kt
@@ -23,7 +23,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val sup = getItem.superMethod()
         assertNotNull(sup)
@@ -33,7 +33,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testSuperMethod_NoSuper() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val list = methods.first { it.name == "list" }
         assertNull(list.superMethod())
     }
@@ -42,7 +42,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/PlainBaseCtrl.java")
         loadFile("api/inherit/AnnotatedSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.AnnotatedSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val chain = getItem.superMethods().toList()
         assertTrue("Should have at least 1 super method", chain.isNotEmpty())
@@ -53,7 +53,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/PlainBaseCtrl.java")
         loadFile("api/inherit/AnnotatedSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.AnnotatedSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val saveItem = methods.first { it.name == "saveItem" }
         val ann = saveItem.searchAnnotation("org.springframework.web.bind.annotation.PostMapping")
         assertNotNull(ann)
@@ -63,7 +63,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val ann = getItem.searchAnnotation("org.springframework.web.bind.annotation.GetMapping")
         assertNotNull(ann)
@@ -72,7 +72,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testSearchAnnotation_NotFound() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val list = methods.first { it.name == "list" }
         val ann = list.searchAnnotation("org.springframework.web.bind.annotation.DeleteMapping")
         assertNull(ann)
@@ -82,7 +82,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
         val springAnns = setOf(
             "org.springframework.web.bind.annotation.GetMapping",
@@ -109,7 +109,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/generic/GenericBaseCtrl.java")
         loadFile("api/generic/StringCtrl.java")
         val psiClass = findClass("com.itangcent.api.generic.StringCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val getItem = methods.first { it.name == "getItem" }
 
         // StringCtrl has no override, so psiMethod is from GenericBaseCtrl
@@ -131,7 +131,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testSearchParameterAnnotation_FindsOnSelf() = runTest {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.AnnotatedBaseCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val saveItem = methods.first { it.name == "saveItem" }
         // saveItem has @RequestBody on parameter at index 0
         val ann = saveItem.searchParameterAnnotation(0, "org.springframework.web.bind.annotation.RequestBody")
@@ -142,7 +142,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val saveItem = methods.first { it.name == "saveItem" }
         // PlainSubCtrl.saveItem has no @RequestBody, but AnnotatedBaseCtrl.saveItem does
         val ann = saveItem.searchParameterAnnotation(0, "org.springframework.web.bind.annotation.RequestBody")
@@ -153,7 +153,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/IUserApi.java")
         loadFile("api/UserApiImpl.java")
         val psiClass = findClass("com.itangcent.api.UserApiImpl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val loginAuth = methods.first { it.name == "loginAuth" }
         // UserApiImpl.loginAuth has no @RequestBody, but IUserApi.loginAuth does
         val ann = loginAuth.searchParameterAnnotation(0, "org.springframework.web.bind.annotation.RequestBody")
@@ -163,7 +163,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testSearchParameterAnnotation_NotFound() = runTest {
         loadFile("api/inherit/SimpleCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.SimpleCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val list = methods.first { it.name == "list" }
         val ann = list.searchParameterAnnotation(0, "org.springframework.web.bind.annotation.RequestBody")
         assertNull("Should not find @RequestBody when not present", ann)
@@ -173,7 +173,7 @@ class ResolvedMethodTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadFile("api/inherit/AnnotatedBaseCtrl.java")
         loadFile("api/inherit/PlainSubCtrl.java")
         val psiClass = findClass("com.itangcent.api.inherit.PlainSubCtrl")!!
-        val methods = ResolvedType.ClassType(psiClass, emptyList()).methods()
+        val methods = ResolvedType.ClassType(psiClass, emptyList()).suitableMethods()
         val saveItem = methods.first { it.name == "saveItem" }
         val springAnns = setOf(
             "org.springframework.web.bind.annotation.RequestBody",

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypeTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/ResolvedTypeTest.kt
@@ -714,7 +714,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testClassTypeFields_GenericResolution() = runTest {
         val psiClass = findClass("com.itangcent.model.generic.StringChild")!!
         val ct = ResolvedType.ClassType(psiClass, emptyList())
-        val fields = ct.fields()
+        val fields = ct.suitableFields()
         val dataField = fields.firstOrNull { it.name == "data" }
         assertNotNull("Should have 'data' field", dataField)
         // StringChild extends GenericBase<String>, so data: T should resolve
@@ -729,7 +729,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testClassTypeFields_MultiLevelGenericResolution() = runTest {
         val psiClass = findClass("com.itangcent.model.generic.ConcreteLeaf")!!
         val ct = ResolvedType.ClassType(psiClass, emptyList())
-        val fields = ct.fields()
+        val fields = ct.suitableFields()
 
         val firstField = fields.firstOrNull { it.name == "first" }
         assertNotNull("Should have 'first' field", firstField)
@@ -929,7 +929,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     // ==================== Per-level generic context propagation via ClassType ====================
     //
-    // These tests verify that ResolvedType.ClassType.fields(), .genericContext,
+    // These tests verify that ResolvedType.ClassType.suitableFields(), .genericContext,
     // .contextForDeclaringClass(), and .superClasses() correctly propagate generic
     // bindings through inheritance hierarchies with inverted/swapped type parameters.
     //
@@ -1045,7 +1045,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     /**
-     * Verify ClassType.fields() resolves all fields correctly through the inverse hierarchy.
+     * Verify ClassType.suitableFields() resolves all fields correctly through the inverse hierarchy.
      *
      * InverseC extends InverseB<String, Integer>
      * B<X=String, Y=Integer> extends A<Y, X> = A<Integer, String>
@@ -1061,7 +1061,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val inverseCClass = findClass("com.itangcent.model.generic.InverseC")!!
         val cType = ResolvedType.ClassType(inverseCClass, emptyList())
-        val fields = cType.fields()
+        val fields = cType.suitableFields()
         val fieldMap = fields.associateBy { it.name }
 
         // B's own fields: x=String, y=Integer
@@ -1214,7 +1214,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     /**
-     * Verify ClassType.fields() for the double-inversion chain.
+     * Verify ClassType.suitableFields() for the double-inversion chain.
      */
     fun testClassTypeFields_DoubleInversion() = runTest {
         loadFile("model/generic/InverseA.java")
@@ -1224,7 +1224,7 @@ class ResolvedTypeTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         val psiClass = findClass("com.itangcent.model.generic.ConcreteInverseE")!!
         val cType = ResolvedType.ClassType(psiClass, emptyList())
-        val fields = cType.fields()
+        val fields = cType.suitableFields()
         val fieldMap = fields.associateBy { it.name }
 
         // A level: t=Long, r=Boolean

--- a/src/test/resources/api/inherit/AbstractBaseController.java
+++ b/src/test/resources/api/inherit/AbstractBaseController.java
@@ -1,0 +1,22 @@
+package com.itangcent.api.inherit;
+
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/base")
+public class AbstractBaseController {
+
+    @GetMapping("/item")
+    public Result<UserInfo> getItem() {
+        return null;
+    }
+
+    @PostMapping("/item")
+    public Result<UserInfo> saveItem(@RequestBody UserInfo item) {
+        return null;
+    }
+}

--- a/src/test/resources/api/inherit/ChildController.java
+++ b/src/test/resources/api/inherit/ChildController.java
@@ -1,0 +1,16 @@
+package com.itangcent.api.inherit;
+
+import com.itangcent.api.inherit.AbstractBaseController;
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ChildController extends AbstractBaseController {
+
+    @GetMapping("/own")
+    public Result<UserInfo> getOwn() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Problem

ClassType did not correctly handle inherited methods and fields:
- `collectFieldsPerLevel` collected parent class fields before current class fields, causing incorrect priority
- `suitableMethods` used manual signature comparison for override detection, which failed with generic erasure and complex inheritance

Resolves #1352

## Changes

- Refactor `collectFieldsPerLevel` to return `Sequence` instead of `MutableList`
- Collect fields from current class first before super classes (child fields take priority)
- Improve `suitableMethods` to use `PsiMethod.findSuperMethods()` for accurate override detection
- Add 6 explicit methods on `ClassType`: `declaredMethods`, `declaredFields`, `allMethods`, `allFields`, `suitableMethods`, `suitableFields`
- Migrate all callers (`SpringMvcClassExporter`, `JaxRsClassExporter`, `FeignClassExporter`, `ScriptPsiContexts`) to use appropriate new methods
- Remove obsolete `methodSignatureKey` and `shouldPrefer` helpers
