### PR TITLE
fix: handle IndexNotReadyException during IDEA Dumb Mode export

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/DumbModeHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/DumbModeHelper.kt
@@ -3,8 +3,14 @@ package com.itangcent.easyapi.ide
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.ide.support.NotificationUtils
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Helper utilities for working with IntelliJ's dumb mode.
@@ -15,8 +21,14 @@ import kotlin.coroutines.resume
  *
  * ## Usage
  * ```kotlin
- * // Suspend until smart mode
+ * // Suspend until smart mode (unbounded)
  * DumbModeHelper.waitForSmartMode(project)
+ *
+ * // Suspend until smart mode with a timeout
+ * DumbModeHelper.waitForSmartMode(project, timeout = 2.minutes)
+ *
+ * // Wait with a short timeout for user-triggered actions; shows a notification on timeout
+ * if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return
  *
  * // Run action when smart
  * DumbModeHelper.runWhenSmart(project) {
@@ -38,8 +50,12 @@ object DumbModeHelper {
      * In test mode, returns immediately without waiting.
      *
      * @param project The project to wait for
+     * @param timeout Optional maximum time to wait. If the timeout elapses before smart mode
+     *   is reached, a [TimeoutCancellationException] is thrown, which propagates as a normal
+     *   coroutine cancellation and aborts the calling operation cleanly.
+     *   Defaults to [DEFAULT_WAIT_TIMEOUT].
      */
-    suspend fun waitForSmartMode(project: Project) {
+    suspend fun waitForSmartMode(project: Project, timeout: Duration = DEFAULT_WAIT_TIMEOUT) {
         if (ApplicationManager.getApplication().isUnitTestMode) {
             return
         }
@@ -49,10 +65,66 @@ object DumbModeHelper {
             return
         }
 
-        suspendCancellableCoroutine { continuation ->
-            dumbService.runWhenSmart {
-                continuation.resume(Unit)
+        withTimeout(timeout) {
+            suspendCancellableCoroutine { continuation ->
+                dumbService.runWhenSmart {
+                    continuation.resume(Unit)
+                }
             }
+        }
+    }
+
+    /**
+     * Waits up to [timeout] for smart mode, intended for user-triggered actions.
+     *
+     * If smart mode is reached in time, returns `true` and the caller may proceed.
+     * If the timeout elapses while still in dumb mode, fires a warning notification
+     * and returns `false` — the caller should abort the action.
+     *
+     * This gives a brief grace period (e.g. indexing is nearly done) without leaving
+     * the user wondering why nothing happened after clicking.
+     *
+     * ## Usage
+     * ```kotlin
+     * backgroundAsync {
+     *     if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return@backgroundAsync
+     *     // proceed with index-dependent work
+     * }
+     * ```
+     *
+     * @param project The project to check
+     * @param timeout Maximum time to wait before notifying. Defaults to [USER_ACTION_WAIT_TIMEOUT].
+     * @return `true` if smart mode was reached, `false` if timed out
+     */
+    suspend fun waitForSmartModeOrNotify(
+        project: Project,
+        timeout: Duration = USER_ACTION_WAIT_TIMEOUT
+    ): Boolean {
+        if (ApplicationManager.getApplication().isUnitTestMode) {
+            return true
+        }
+
+        val dumbService = DumbService.getInstance(project)
+        if (!dumbService.isDumb) {
+            return true
+        }
+
+        return try {
+            withTimeout(timeout) {
+                suspendCancellableCoroutine { continuation ->
+                    dumbService.runWhenSmart {
+                        continuation.resume(Unit)
+                    }
+                }
+            }
+            true
+        } catch (_: TimeoutCancellationException) {
+            NotificationUtils.notifyWarning(
+                project,
+                "Indexing in Progress",
+                "EasyAPI export was cancelled because IDEA is still indexing. Please try again once indexing is complete."
+            )
+            false
         }
     }
 
@@ -93,4 +165,16 @@ object DumbModeHelper {
     fun isDumb(project: Project): Boolean {
         return DumbService.getInstance(project).isDumb
     }
+
+    /**
+     * Maximum wait time for background operations (e.g. auto-scan on startup).
+     * These can afford to wait longer since they run silently in the background.
+     */
+    val DEFAULT_WAIT_TIMEOUT: Duration = 5.minutes
+
+    /**
+     * Maximum wait time for user-triggered actions before showing a notification.
+     * Short enough that the user gets immediate feedback if indexing is still running.
+     */
+    val USER_ACTION_WAIT_TIMEOUT: Duration = 5.seconds
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
@@ -8,6 +8,7 @@ import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
 import com.itangcent.easyapi.exporter.ExportOrchestrator
+import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.ide.support.SelectedHelper
 import com.itangcent.easyapi.ide.support.runWithProgress
 import com.itangcent.easyapi.logging.IdeaLog
@@ -30,6 +31,8 @@ class ChannelExportAction(
         val selection = SelectedHelper.resolveSelection(e)
 
         backgroundAsync {
+            if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return@backgroundAsync
+
             val scanner = ApiScanner.getInstance(project)
             val apiIndex = ApiIndex.getInstance(project)
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.itangcent.easyapi.exporter.ExportOrchestrator
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.ide.dialog.ExportDialog
 import com.itangcent.easyapi.ide.dialog.ExportDialogResult
 import com.itangcent.easyapi.ide.support.SelectedHelper
@@ -26,6 +27,8 @@ class ExportApiAction : AnAction(), IdeaLog {
         val selection = SelectedHelper.resolveSelection(e)
 
         backgroundAsync {
+            if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return@backgroundAsync
+
             val apiIndex = ApiIndex.getInstance(project)
             val scanner = ApiScanner.getInstance(project)
             val endpoints = if (selection != null) {


### PR DESCRIPTION
Closes #1353

When IDEA is in Dumb Mode (indexes not ready), easy-yapi still attempted to export Controller classes, accessing StubIndex and causing IndexNotReadyException.

Changes:
- DumbModeHelper: Added waitForSmartModeOrNotify() that waits up to 5 seconds for smart mode, then shows a warning notification if still indexing
- ExportApiAction: Added dumb mode check before export
- ChannelExportAction: Added dumb mode check before export