### PR TITLE
chore: use org.jetbrains.changelog plugin for proper HTML rendering in marketplace

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,19 @@
 plugins {
     kotlin("jvm") version "2.1.0"
     id("org.jetbrains.intellij.platform") version "2.11.0"
+    id("org.jetbrains.changelog")
     id("com.google.protobuf") version "0.9.4"
     jacoco
 }
 
 group = "com.itangcent"
 version = "3.1.5.252.0"
+
+changelog {
+    val v = project.version.toString()
+    // version is like "3.1.5.252.0", changelog uses semver "3.1.5"
+    version.set(v.substringBeforeLast(".0").substringBeforeLast("."))
+}
 
 repositories {
     mavenCentral()
@@ -106,13 +113,10 @@ intellijPlatform {
         version = project.version.toString()
         description = file("src/main/resources/pluginDescription.html").readText()
         changeNotes = provider {
-            val lines = file("CHANGELOG.md").readLines()
-            val start = lines.indexOfFirst { it.startsWith("## [") }
-            val end = lines.drop(start + 1).indexOfFirst { it.startsWith("## [") }
-            val section = if (end >= 0) lines.subList(start, start + 1 + end) else lines.drop(start)
-            section.joinToString("<br/>")
-                .replace("### ", "<h3>")
-                .replace("<br/>- ", "<br/>• ")
+            changelog.renderItem(
+                changelog.getLatest(),
+                org.jetbrains.changelog.Changelog.OutputType.HTML
+            )
         }
         ideaVersion {
             sinceBuild = "252"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,4 +5,7 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    plugins {
+        id("org.jetbrains.changelog") version "2.5.0"
+    }
 }


### PR DESCRIPTION
Replace manual markdown-to-HTML conversion with the org.jetbrains.changelog Gradle plugin (v2.5.0), which uses CommonMark to properly convert CHANGELOG.md entries to HTML for correct display in the JetBrains Marketplace and IDE Plugin Manager.