### PR TITLE
fix: annotation array attributes are stringified instead of expanded

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/rule/parser/AnnotationExpressionParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/parser/AnnotationExpressionParser.kt
@@ -29,6 +29,6 @@ class AnnotationExpressionParser : RuleParser {
         if (attr.isNullOrBlank()) {
             return helper.hasAnn(element, annFqn)
         }
-        return helper.findAttrAsString(element, annFqn, attr)
+        return helper.findAttr(element, annFqn, attr)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/Swagger3ConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/Swagger3ConfigIntegrationTest.kt
@@ -97,6 +97,10 @@ class Swagger3ConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
             "Tags should be extracted from @Operation#tags",
             createEndpoint?.tags?.contains("order") == true
         )
+        assertTrue(
+            "Multiple tags should be extracted from @Operation#tags array",
+            createEndpoint?.tags?.contains("create") == true
+        )
     }
 
     // ── @Tag: api.tag, class.doc ─────────────────────────────────

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
@@ -102,6 +102,27 @@ class SwaggerConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
+    fun testApiOperationExtractsMultipleTags() = runTest {
+        val psiClass = findClass("com.itangcent.swagger.ProductController")
+        assertNotNull("Should find ProductController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+
+        val searchEndpoint = endpoints.find {
+            it.httpMetadata?.method == HttpMethod.GET &&
+            it.httpMetadata?.path?.contains("search") == true
+        }
+        assertNotNull("Should find GET /product/search endpoint", searchEndpoint)
+        assertTrue(
+            "Tags should contain 'product' from @ApiOperation#tags array",
+            searchEndpoint?.tags?.contains("product") == true
+        )
+        assertTrue(
+            "Tags should contain 'search' from @ApiOperation#tags array",
+            searchEndpoint?.tags?.contains("search") == true
+        )
+    }
+
     // ── @ApiParam: param.doc, param.default.value, param.required, param.ignore ──
 
     fun testApiParamExtractsDescription() = runTest {

--- a/src/test/resources/api/swagger/ProductController.java
+++ b/src/test/resources/api/swagger/ProductController.java
@@ -29,6 +29,13 @@ public class ProductController {
         return product;
     }
 
+    @ApiOperation(value = "Search products", tags = {"product", "search"})
+    @GetMapping("/search")
+    public java.util.List<ProductDTO> searchProducts(
+            @ApiParam(value = "keyword") String keyword) {
+        return java.util.Collections.emptyList();
+    }
+
     @GetMapping("/list")
     public java.util.List<ProductDTO> listProducts(
             @ApiParam(value = "page number", defaultValue = "1") Integer page,

--- a/src/test/resources/api/swagger3/OrderController.java
+++ b/src/test/resources/api/swagger3/OrderController.java
@@ -26,7 +26,7 @@ public class OrderController {
         return new OrderDTO();
     }
 
-    @Operation(summary = "Create a new order", tags = "order")
+    @Operation(summary = "Create a new order", tags = {"order", "create"})
     @PostMapping("/create")
     public OrderDTO createOrder(@RequestBody OrderDTO order) {
         return order;


### PR DESCRIPTION
## Problem

Closes #1363

When rule expressions like `api.tag=@io.swagger.annotations.ApiOperation#tags` reference array annotation attributes, the values were converted to their string representation (e.g. `"[]"`) instead of being properly expanded as individual elements. This caused tags to appear as literal `"[]"` in the generated API docs.

## Root Cause

`AnnotationExpressionParser.parse()` called `helper.findAttrAsString()` which always converted annotation attribute values to strings. When the attribute is an array (like `String[] tags`), `findAttr` returns a `List<Any?>`, but `findAttrAsString` converted it to `"[value1, value2]"` or `"[]"`.

The `RuleEngine.emitStringValues()` already had logic to expand arrays/collections into individual elements, but it never received an array because `findAttrAsString` had already stringified it.

## Fix

Changed `AnnotationExpressionParser` to use `helper.findAttr()` instead of `helper.findAttrAsString()`, so array attributes are returned as `List<Any?>` and properly expanded by `emitStringValues()`.

## Changes

- `AnnotationExpressionParser.kt`: Use `findAttr()` instead of `findAttrAsString()`
- Added test for multi-tag extraction in Swagger 2 and Swagger 3 integration tests