### PR TITLE
chore: upgrade codecov-action from v5 to v7

### DIFF
--- a/.github/workflows/co.yml
+++ b/.github/workflows/co.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Generate coverage report
         run: ./gradlew test jacocoTestReport --stacktrace
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/jacoco/report.xml


### PR DESCRIPTION
## Changes

- chore: upgrade codecov-action from v5 to v7

Fix GPG signature verification failure (`gpg: no valid OpenPGP data found` / `Can't check signature: No public key`) by upgrading to the latest codecov-action which uses the new Codecov CLI.