### PR TITLE
Yapi response wrapper

### DIFF
--- a/docs/superpowers/specs/2026-06-08-yapi-response-wrapper-design.md
+++ b/docs/superpowers/specs/2026-06-08-yapi-response-wrapper-design.md
@@ -185,15 +185,17 @@ Add settings coverage:
 
 ## Verification
 
-This repository is a single Gradle module. Do not use the project `gradlew` script.
+This repository is a Gradle project. Do not use the project `gradlew` script for any Gradle operation.
 
-Run syntax verification from the project root with the global Gradle installation:
+This repository is currently a single-module project, so run syntax verification from the project root with the system Gradle installation:
 
 ```bash
-JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home \
+env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home \
 GRADLE_HOME=/Users/advance/Documents/work/gradle-4.10.3 \
 GRADLE_OPTS=-Dorg.gradle.native=false \
 gradle classes
 ```
 
 Do not add `--no-daemon`.
+
+If this work is later moved into a multi-module layout, verify only changed subprojects with `gradle :<sub-module>:classes` after confirming the exact subproject name, while keeping the same `JAVA_HOME`, `GRADLE_HOME`, and `GRADLE_OPTS` environment settings.

--- a/docs/superpowers/specs/2026-06-08-yapi-response-wrapper-design.md
+++ b/docs/superpowers/specs/2026-06-08-yapi-response-wrapper-design.md
@@ -1,0 +1,199 @@
+# Yapi Response Wrapper Design
+
+## Goal
+
+Add a Yapi-only export option that wraps each controller method response in a configurable response object. The main use case is exporting a response such as:
+
+```json
+{"code":0,"msg":"","data":"$response"}
+```
+
+where `"$response"` is replaced by the schema or example for the original controller return value.
+
+## Scope
+
+This feature applies only to Yapi export. It must not change the shared API model, response inference, Postman export, Markdown export, HTTP client export, or API Dashboard behavior.
+
+The feature is configured in the EasyApi settings page under the existing Yapi tab.
+
+## Settings
+
+Add two application-level Yapi settings:
+
+- `yapiResponseWrapperEnabled: Boolean`
+- `yapiResponseWrapperTemplate: String`
+
+The Yapi settings UI adds:
+
+- `Enable response wrapper`
+- `Response wrapper template`
+
+When the wrapper is enabled and the template is blank, EasyYapi uses this default template:
+
+```json
+{"code":0,"msg":"","data":"$response"}
+```
+
+## Template Contract
+
+The response wrapper template must be a JSON object.
+
+The exact string value `"$response"` marks where the original controller return value is inserted. The field name is not special. For example, all of these are valid:
+
+```json
+{"code":0,"msg":"","data":"$response"}
+```
+
+```json
+{"success":true,"message":"","result":"$response"}
+```
+
+Multiple `"$response"` values are allowed. Each occurrence is replaced with the original response schema or example.
+
+If the template is invalid or does not contain `"$response"`, Yapi export falls back to the original response body and logs a warning. Export should continue.
+
+## JSON Schema Output
+
+When `Response body JSON5` is disabled, Yapi export emits JSON Schema as it does today.
+
+The wrapper converts normal JSON template values into schema nodes:
+
+- JSON string -> `{ "type": "string" }`
+- JSON integer -> `{ "type": "integer" }`
+- JSON decimal -> `{ "type": "number" }`
+- JSON boolean -> `{ "type": "boolean" }`
+- JSON object -> `{ "type": "object", "properties": ... }`
+- JSON array -> `{ "type": "array", "items": ... }`
+- JSON null -> `{ "type": "object" }`
+
+The `"$response"` value is replaced by the existing response schema map built from the original `ObjectModel`.
+
+The final schema keeps the root draft-04 `$schema` header already used by `JsonSchemaBuilder`.
+
+Example template:
+
+```json
+{"code":0,"msg":"","data":"$response"}
+```
+
+Example schema output shape:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "code": { "type": "integer" },
+    "msg": { "type": "string" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "name": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+## JSON5 Output
+
+When `Response body JSON5` is enabled, the wrapper still applies.
+
+The same JSON template is used, but output is an example JSON5 body. The `"$response"` value is replaced with the original response JSON5 example generated from the existing `ObjectModelJsonConverter` behavior.
+
+Example output shape:
+
+```json5
+{
+  code: 0,
+  msg: "",
+  data: {
+    id: 0,
+    name: ""
+  }
+}
+```
+
+The template input remains strict JSON even when JSON5 response output is enabled. This keeps settings parsing predictable.
+
+## Type Support
+
+The wrapper must support all response shapes that the current Yapi response generation supports:
+
+- primitive values such as `String`, `Int`, `Long`, `Boolean`
+- arrays and collections
+- maps
+- VO/object models
+- missing or unresolved response bodies
+
+For missing or unresolved response bodies, the placeholder is replaced with an empty object schema or empty object example.
+
+## Implementation Shape
+
+Add a small Yapi-specific wrapper component, for example `YapiResponseWrapper`.
+
+Responsibilities:
+
+- resolve the effective template, including the default template
+- parse the template as a JSON object
+- detect whether at least one `"$response"` placeholder exists
+- build a wrapped JSON Schema body
+- build a wrapped JSON5 example body
+- return a failure result when the template is invalid, so callers can fall back
+
+`YapiFormatter` stays responsible for converting `ApiEndpoint` to `YapiApiDoc`. It receives the wrapper settings from `YapiExporter` and delegates only the response-body wrapping work to `YapiResponseWrapper`.
+
+`YapiExporter` reads the new settings through `SettingBinder` and passes them to `YapiFormatter` along with the existing `yapiReqBodyJson5` and `yapiResBodyJson5` options.
+
+## Error Handling
+
+Yapi export must not fail only because the response wrapper template is invalid.
+
+Fallback cases:
+
+- template is not valid JSON
+- template root is not a JSON object
+- template has no `"$response"` placeholder
+- wrapper conversion fails unexpectedly
+
+In those cases, `YapiFormatter` uses the original unwrapped response body and logs a warning.
+
+## Tests
+
+Add unit coverage for the wrapper component:
+
+- schema mode wraps a VO response
+- schema mode wraps primitive, array, and map responses
+- JSON5 mode wraps a VO response
+- blank template uses the default template
+- invalid template falls back
+- template without `"$response"` falls back
+- multiple `"$response"` placeholders are all replaced
+- missing response body produces an empty object at the placeholder
+
+Add focused `YapiFormatterTest` coverage:
+
+- wrapper disabled keeps current output behavior
+- wrapper enabled wraps `resBody` in schema mode
+- wrapper enabled wraps `resBody` when `resBodyJson5 = true`
+
+Add settings coverage:
+
+- reset/apply/isModified includes the new Yapi settings fields
+- application settings state copy, equality, and hash code include the new fields
+
+## Verification
+
+This repository is a single Gradle module. Do not use the project `gradlew` script.
+
+Run syntax verification from the project root with the global Gradle installation:
+
+```bash
+JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home \
+GRADLE_HOME=/Users/advance/Documents/work/gradle-4.10.3 \
+GRADLE_OPTS=-Dorg.gradle.native=false \
+gradle classes
+```
+
+Do not add `--no-daemon`.

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
@@ -38,6 +38,8 @@ class YapiExporter(private val project: Project) {
             reqBodyJson5 = settings.yapiReqBodyJson5,
             resBodyJson5 = settings.yapiResBodyJson5,
             mockRules = mockRules,
+            responseWrapperEnabled = settings.yapiResponseWrapperEnabled,
+            responseWrapperTemplate = settings.yapiResponseWrapperTemplate,
             markdownRender = MarkdownRender.getInstance(project)
         )
         val engine = RuleEngine.getInstance(project)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
@@ -39,6 +39,9 @@ class YapiFormatter(
     private val resBodyJson5: Boolean = false,
     private val mockGenerator: MockDataGenerator? = MockDataGenerator(),
     private val autoFormatUrl: Boolean = true,
+    private val responseWrapperEnabled: Boolean = false,
+    private val responseWrapperTemplate: String? = null,
+    private val responseWrapper: YapiResponseWrapper = YapiResponseWrapper(jsonSchemaBuilder),
     private val markdownRender: MarkdownRender
 ) {
     constructor(
@@ -47,6 +50,9 @@ class YapiFormatter(
         resBodyJson5: Boolean = false,
         mockRules: Map<String, String>,
         autoFormatUrl: Boolean = true,
+        responseWrapperEnabled: Boolean = false,
+        responseWrapperTemplate: String? = null,
+        responseWrapper: YapiResponseWrapper = YapiResponseWrapper(jsonSchemaBuilder),
         markdownRender: MarkdownRender
     ) : this(
         jsonSchemaBuilder,
@@ -54,6 +60,9 @@ class YapiFormatter(
         resBodyJson5,
         MockDataGenerator(mockRules),
         autoFormatUrl,
+        responseWrapperEnabled,
+        responseWrapperTemplate,
+        responseWrapper,
         markdownRender
     )
 
@@ -68,6 +77,9 @@ class YapiFormatter(
         resBodyJson5 = useJson5,
         mockGenerator = MockDataGenerator(mockRules),
         autoFormatUrl = true,
+        responseWrapperEnabled = false,
+        responseWrapperTemplate = null,
+        responseWrapper = YapiResponseWrapper(jsonSchemaBuilder),
         markdownRender = markdownRender
     )
 
@@ -157,18 +169,19 @@ class YapiFormatter(
         val reqBodyIsJsonSchema = hasJsonBody && !reqBodyJson5
 
         val responseBody = httpMeta?.responseBody
-        val resBody = if (responseBody != null) {
-            if (resBodyJson5) {
-                formatAsJson5(responseBody)
+        val resBody = if (responseWrapperEnabled) {
+            val wrapped = if (resBodyJson5) {
+                responseWrapper.wrapJson5(responseWrapperTemplate, responseBody)
             } else {
-                jsonSchemaBuilder.build(responseBody)
+                responseWrapper.wrapSchema(responseWrapperTemplate, responseBody)
             }
+            wrapped ?: buildOriginalResponseBody(responseBody)
         } else {
-            null
+            buildOriginalResponseBody(responseBody)
         }
 
         // res_body_is_json_schema: true when we use JSON schema (not JSON5) for response body
-        val resBodyIsJsonSchema = responseBody != null && !resBodyJson5
+        val resBodyIsJsonSchema = resBody != null && !resBodyJson5
 
         return YapiApiDoc(
             title = endpoint.name ?: "${httpMeta?.method?.name ?: "UNKNOWN"} ${endpoint.path}",
@@ -186,7 +199,7 @@ class YapiFormatter(
             reqBodyType = reqBodyType,
             reqBodyIsJsonSchema = reqBodyIsJsonSchema,
             resBody = resBody,
-            resBodyType = if (responseBody != null) "json" else null,
+            resBodyType = if (resBody != null) "json" else null,
             resBodyIsJsonSchema = resBodyIsJsonSchema,
             tags = endpoint.tags.ifEmpty { null },
             open = if (endpoint.open) true else null
@@ -288,12 +301,22 @@ class YapiFormatter(
     /**
      * Formats an object model as JSON5 string.
      * JSON5 is a more readable JSON format with comments and trailing commas.
-     * 
+     *
      * @param model The object model to format
      * @return A JSON5 formatted string
      */
     private fun formatAsJson5(model: ObjectModel): String {
         return ObjectModelJsonConverter.toJson5(model)
+    }
+
+    private fun buildOriginalResponseBody(responseBody: ObjectModel?): String? {
+        return responseBody?.let {
+            if (resBodyJson5) {
+                formatAsJson5(it)
+            } else {
+                jsonSchemaBuilder.build(it)
+            }
+        }
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -46,6 +46,8 @@ data class Settings(
     override var yapiExportMode: String = YapiExportMode.ALWAYS_UPDATE.name,
     override var yapiReqBodyJson5: Boolean = false,
     override var yapiResBodyJson5: Boolean = false,
+    override var yapiResponseWrapperEnabled: Boolean = false,
+    override var yapiResponseWrapperTemplate: String = "",
     override var httpTimeOut: Int = 30,
     override var unsafeSsl: Boolean = false,
     override var httpClient: String = HttpClientType.APACHE.value,
@@ -93,6 +95,8 @@ data class Settings(
         if (switchNotice != other.switchNotice) return false
         if (yapiReqBodyJson5 != other.yapiReqBodyJson5) return false
         if (yapiResBodyJson5 != other.yapiResBodyJson5) return false
+        if (yapiResponseWrapperEnabled != other.yapiResponseWrapperEnabled) return false
+        if (yapiResponseWrapperTemplate != other.yapiResponseWrapperTemplate) return false
         if (httpTimeOut != other.httpTimeOut) return false
         if (unsafeSsl != other.unsafeSsl) return false
         if (logLevel != other.logLevel) return false
@@ -140,6 +144,8 @@ data class Settings(
         result = 31 * result + switchNotice.hashCode()
         result = 31 * result + yapiReqBodyJson5.hashCode()
         result = 31 * result + yapiResBodyJson5.hashCode()
+        result = 31 * result + yapiResponseWrapperEnabled.hashCode()
+        result = 31 * result + yapiResponseWrapperTemplate.hashCode()
         result = 31 * result + httpTimeOut
         result = 31 * result + unsafeSsl.hashCode()
         result = 31 * result + logLevel

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -47,6 +47,8 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var yapiExportMode: String = YapiExportMode.ALWAYS_UPDATE.name,
         override var yapiReqBodyJson5: Boolean = false,
         override var yapiResBodyJson5: Boolean = false,
+        override var yapiResponseWrapperEnabled: Boolean = false,
+        override var yapiResponseWrapperTemplate: String = "",
         override var httpTimeOut: Int = 30,
         override var unsafeSsl: Boolean = false,
         override var httpClient: String = HttpClientType.APACHE.value,
@@ -86,6 +88,8 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (switchNotice != other.switchNotice) return false
             if (yapiReqBodyJson5 != other.yapiReqBodyJson5) return false
             if (yapiResBodyJson5 != other.yapiResBodyJson5) return false
+            if (yapiResponseWrapperEnabled != other.yapiResponseWrapperEnabled) return false
+            if (yapiResponseWrapperTemplate != other.yapiResponseWrapperTemplate) return false
             if (httpTimeOut != other.httpTimeOut) return false
             if (unsafeSsl != other.unsafeSsl) return false
             if (logLevel != other.logLevel) return false
@@ -128,6 +132,8 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + switchNotice.hashCode()
             result = 31 * result + yapiReqBodyJson5.hashCode()
             result = 31 * result + yapiResBodyJson5.hashCode()
+            result = 31 * result + yapiResponseWrapperEnabled.hashCode()
+            result = 31 * result + yapiResponseWrapperTemplate.hashCode()
             result = 31 * result + httpTimeOut
             result = 31 * result + unsafeSsl.hashCode()
             result = 31 * result + logLevel

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
@@ -52,6 +52,8 @@ interface ApplicationSettingsSupport {
     var yapiExportMode: String
     var yapiReqBodyJson5: Boolean
     var yapiResBodyJson5: Boolean
+    var yapiResponseWrapperEnabled: Boolean
+    var yapiResponseWrapperTemplate: String
     var httpTimeOut: Int
     var unsafeSsl: Boolean
     var httpClient: String
@@ -98,6 +100,8 @@ interface ApplicationSettingsSupport {
         newSetting.yapiExportMode = this.yapiExportMode
         newSetting.yapiReqBodyJson5 = this.yapiReqBodyJson5
         newSetting.yapiResBodyJson5 = this.yapiResBodyJson5
+        newSetting.yapiResponseWrapperEnabled = this.yapiResponseWrapperEnabled
+        newSetting.yapiResponseWrapperTemplate = this.yapiResponseWrapperTemplate
         newSetting.logLevel = this.logLevel
         newSetting.outputDemo = this.outputDemo
         newSetting.outputCharset = this.outputCharset

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -30,6 +30,7 @@ import com.itangcent.easyapi.settings.PostmanExportMode
 import com.itangcent.easyapi.settings.PostmanJson5FormatType
 import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.settings.YapiExportMode
+import com.itangcent.easyapi.exporter.yapi.YapiResponseWrapper
 import java.awt.*
 import java.io.File
 import javax.swing.*
@@ -684,6 +685,11 @@ class YapiSettingsPanel : SettingsPanel {
     private val yapiExportModeCombo = ComboBox(YapiExportMode.entries.toTypedArray())
     private val yapiReqBodyJson5 = JBCheckBox("Request body JSON5")
     private val yapiResBodyJson5 = JBCheckBox("Response body JSON5")
+    private val yapiResponseWrapperEnabled = JBCheckBox("Enable response wrapper")
+    private val yapiResponseWrapperTemplate = JBTextArea(4, 40).apply {
+        text = YapiResponseWrapper.DEFAULT_TEMPLATE
+        toolTipText = "Strict JSON object. Use \"\$response\" where the original response should be inserted."
+    }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
         .addLabeledComponent("Yapi Server:", yapiServer)
@@ -693,6 +699,8 @@ class YapiSettingsPanel : SettingsPanel {
         .addLabeledComponent("Export Mode:", yapiExportModeCombo)
         .addComponent(yapiReqBodyJson5)
         .addComponent(yapiResBodyJson5)
+        .addComponent(yapiResponseWrapperEnabled)
+        .addLabeledComponent("Response wrapper template:", JScrollPane(yapiResponseWrapperTemplate))
         .addComponentFillVertically(JPanel(), 0)
         .panel
 
@@ -706,6 +714,10 @@ class YapiSettingsPanel : SettingsPanel {
         } ?: YapiExportMode.ALWAYS_UPDATE
         yapiReqBodyJson5.isSelected = settings?.yapiReqBodyJson5 ?: false
         yapiResBodyJson5.isSelected = settings?.yapiResBodyJson5 ?: false
+        yapiResponseWrapperEnabled.isSelected = settings?.yapiResponseWrapperEnabled ?: false
+        yapiResponseWrapperTemplate.text = settings?.yapiResponseWrapperTemplate
+            ?.takeIf { it.isNotBlank() }
+            ?: YapiResponseWrapper.DEFAULT_TEMPLATE
     }
 
     override fun applyTo(settings: Settings) {
@@ -717,6 +729,8 @@ class YapiSettingsPanel : SettingsPanel {
             (yapiExportModeCombo.selectedItem as? YapiExportMode)?.name ?: YapiExportMode.ALWAYS_UPDATE.name
         settings.yapiReqBodyJson5 = yapiReqBodyJson5.isSelected
         settings.yapiResBodyJson5 = yapiResBodyJson5.isSelected
+        settings.yapiResponseWrapperEnabled = yapiResponseWrapperEnabled.isSelected
+        settings.yapiResponseWrapperTemplate = yapiResponseWrapperTemplate.text.trim()
     }
 
     override fun isModified(settings: Settings?): Boolean {
@@ -727,7 +741,10 @@ class YapiSettingsPanel : SettingsPanel {
                 switchNotice.isSelected != s.switchNotice ||
                 yapiExportModeCombo.selectedItem?.toString() != s.yapiExportMode ||
                 yapiReqBodyJson5.isSelected != s.yapiReqBodyJson5 ||
-                yapiResBodyJson5.isSelected != s.yapiResBodyJson5
+                yapiResBodyJson5.isSelected != s.yapiResBodyJson5 ||
+                yapiResponseWrapperEnabled.isSelected != s.yapiResponseWrapperEnabled ||
+                yapiResponseWrapperTemplate.text != ((s.yapiResponseWrapperTemplate).takeIf { it.isNotBlank() }
+                    ?: YapiResponseWrapper.DEFAULT_TEMPLATE)
     }
 }
 

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
@@ -727,4 +727,95 @@ class YapiFormatterTest {
     }
 
     // endregion
+
+    // region Response Wrapper
+
+    @Test
+    fun testResponseWrapperDisabledKeepsOriginalResponseSchema() {
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                        "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+                    )
+                )
+            )
+        )
+
+        val doc = formatter.format(endpoint)
+
+        assertNotNull(doc.resBody)
+        assertFalse("Unwrapped response should not contain wrapper code field", doc.resBody!!.contains("\"code\""))
+        assertTrue(doc.resBody!!.contains("\"id\""))
+        assertTrue(doc.resBody!!.contains("\"name\""))
+    }
+
+    @Test
+    fun testResponseWrapperWrapsSchemaResponseBody() {
+        val wrapperFormatter = YapiFormatter(
+            responseWrapperEnabled = true,
+            responseWrapperTemplate = """{"code":0,"msg":"","data":"${'$'}response"}""",
+            markdownRender = BundledMarkdownRender()
+        )
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                        "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+                    )
+                )
+            )
+        )
+
+        val doc = wrapperFormatter.format(endpoint)
+
+        assertNotNull(doc.resBody)
+        assertTrue(doc.resBody!!.contains("\"code\""))
+        assertTrue(doc.resBody!!.contains("\"msg\""))
+        assertTrue(doc.resBody!!.contains("\"data\""))
+        assertTrue(doc.resBody!!.contains("\"id\""))
+        assertTrue(doc.resBody!!.contains("\"name\""))
+        assertTrue(doc.resBodyIsJsonSchema)
+    }
+
+    @Test
+    fun testResponseWrapperWrapsJson5ResponseBody() {
+        val wrapperFormatter = YapiFormatter(
+            resBodyJson5 = true,
+            responseWrapperEnabled = true,
+            responseWrapperTemplate = """{"code":0,"msg":"","data":"${'$'}response"}""",
+            markdownRender = BundledMarkdownRender()
+        )
+        val endpoint = ApiEndpoint(
+            name = "Get User",
+            metadata = httpMetadata(
+                path = "/api/users/{id}",
+                method = HttpMethod.GET,
+                responseBody = ObjectModel.Object(
+                    mapOf(
+                        "id" to FieldModel(ObjectModel.Single(JsonType.INT)),
+                        "name" to FieldModel(ObjectModel.Single(JsonType.STRING))
+                    )
+                )
+            )
+        )
+
+        val doc = wrapperFormatter.format(endpoint)
+
+        assertNotNull(doc.resBody)
+        assertTrue(doc.resBody!!.contains("\"code\"") || doc.resBody!!.contains("code"))
+        assertTrue(doc.resBody!!.contains("\"data\"") || doc.resBody!!.contains("data"))
+        assertTrue(doc.resBody!!.contains("\"id\"") || doc.resBody!!.contains("id"))
+        assertFalse(doc.resBodyIsJsonSchema)
+    }
+
+    // endregion
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
@@ -71,4 +71,13 @@ class SettingsDefaultsTest {
             appState.gutterIconEnabled
         )
     }
+
+    @Test
+    fun `test Settings and ApplicationSettingsState have matching yapi response wrapper defaults`() {
+        val settings = Settings()
+        val appState = ApplicationSettingsState.State()
+
+        assertEquals(settings.yapiResponseWrapperEnabled, appState.yapiResponseWrapperEnabled)
+        assertEquals(settings.yapiResponseWrapperTemplate, appState.yapiResponseWrapperTemplate)
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -38,6 +38,8 @@ class ApplicationSettingsStateTest {
         assertArrayEquals(emptyArray(), s.remoteConfig)
         assertTrue(s.autoScanEnabled)
         assertTrue(s.gutterIconEnabled)
+        assertFalse(s.yapiResponseWrapperEnabled)
+        assertEquals("", s.yapiResponseWrapperTemplate)
     }
 
     @Test
@@ -122,6 +124,31 @@ class ApplicationSettingsStateTest {
         assertTrue("target gutterIconEnabled should default to true", target.gutterIconEnabled)
         source.copyTo(target)
         assertFalse("gutterIconEnabled should be copied as false", target.gutterIconEnabled)
+    }
+
+    @Test
+    fun testState_copyTo_yapiResponseWrapper() {
+        val source = ApplicationSettingsState.State(
+            yapiResponseWrapperEnabled = true,
+            yapiResponseWrapperTemplate = """{"code":0,"data":"${'$'}response"}"""
+        )
+        val target = ApplicationSettingsState.State()
+
+        source.copyTo(target)
+
+        assertTrue(target.yapiResponseWrapperEnabled)
+        assertEquals("""{"code":0,"data":"${'$'}response"}""", target.yapiResponseWrapperTemplate)
+    }
+
+    @Test
+    fun testState_inequality_yapiResponseWrapper() {
+        val enabled = ApplicationSettingsState.State(yapiResponseWrapperEnabled = true)
+        val disabled = ApplicationSettingsState.State(yapiResponseWrapperEnabled = false)
+        assertNotEquals(enabled, disabled)
+
+        val templateA = ApplicationSettingsState.State(yapiResponseWrapperTemplate = """{"data":"${'$'}response"}""")
+        val templateB = ApplicationSettingsState.State(yapiResponseWrapperTemplate = """{"result":"${'$'}response"}""")
+        assertNotEquals(templateA, templateB)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
@@ -41,4 +41,20 @@ class SettingsPanelsParityTest {
         assertFalse(builtIn.isModified(settings))
         builtIn.applyTo(settings)
     }
+
+    @Test
+    fun testYapiPanelResponseWrapperApplyReset() {
+        val settings = Settings().apply {
+            yapiResponseWrapperEnabled = true
+            yapiResponseWrapperTemplate = """{"code":0,"msg":"","data":"${'$'}response"}"""
+        }
+        val panel = YapiSettingsPanel()
+
+        panel.resetFrom(settings)
+
+        assertFalse(panel.isModified(settings))
+        panel.applyTo(settings)
+        assertTrue(settings.yapiResponseWrapperEnabled)
+        assertTrue(settings.yapiResponseWrapperTemplate.contains("${'$'}response"))
+    }
 }


### PR DESCRIPTION
# Summary

Adds configurable Yapi response wrapping so exported response bodies can be wrapped with a template such as:

```json
{
  "code": 0,
  "msg": "",
  "data": "$response"
}
```

The `$response` placeholder is replaced with the original controller return value in both JSON Schema and JSON5 response output modes.

# Changes

- Add `YapiResponseWrapper` to parse wrapper templates and generate wrapped response bodies.
- Support wrapping for primitive return values, arrays/collections, maps, VO/object responses, and missing or unresolved response bodies.
- Apply response wrapping in `YapiFormatter` when enabled.
- Pass wrapper settings from `YapiExporter`.
- Add Yapi settings:
  - Enable response wrapper
  - Response wrapper template
- Persist wrapper settings in application settings state.
- Add unit coverage for wrapper behavior, Yapi formatter integration, and settings defaults/state/UI flow.
- Add design and implementation plan docs under `docs/superpowers/`.

