### PR TITLE
fix: invalidate cache on settings/branch change to prevent occasional test failures

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
@@ -10,6 +10,7 @@ import com.itangcent.easyapi.exporter.jaxrs.JaxRsResourceRecognizer
 import com.itangcent.easyapi.exporter.springmvc.ActuatorEndpointRecognizer
 import com.itangcent.easyapi.exporter.springmvc.SpringControllerRecognizer
 import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.SettingsChangeListener
 
 /**
  * Composite recognizer that combines all framework-specific [ApiClassRecognizer]s.
@@ -21,9 +22,20 @@ import com.itangcent.easyapi.settings.SettingBinder
 @Service(Service.Level.PROJECT)
 class CompositeApiClassRecognizer(private val project: Project) {
 
-    private val recognizers: List<ApiClassRecognizer> by lazy {
+    @Volatile
+    private var cachedRecognizers: List<ApiClassRecognizer> = buildRecognizers()
+
+    init {
+        project.messageBus.connect().subscribe(SettingsChangeListener.TOPIC, object : SettingsChangeListener {
+            override fun settingsChanged() {
+                cachedRecognizers = buildRecognizers()
+            }
+        })
+    }
+
+    private fun buildRecognizers(): List<ApiClassRecognizer> {
         val settings = SettingBinder.getInstance(project).read()
-        buildList {
+        return buildList {
             add(SpringControllerRecognizer())
             if (settings.jaxrsEnable) {
                 add(JaxRsResourceRecognizer(enabled = true))
@@ -44,14 +56,14 @@ class CompositeApiClassRecognizer(private val project: Project) {
      * Returns true if [psiClass] is an API class for any enabled framework.
      */
     suspend fun isApiClass(psiClass: PsiClass): Boolean {
-        return recognizers.any { it.isApiClass(psiClass) }
+        return cachedRecognizers.any { it.isApiClass(psiClass) }
     }
 
     /**
      * Returns the names of frameworks that recognize [psiClass] as an API class.
      */
     suspend fun matchingFrameworks(psiClass: PsiClass): List<String> {
-        return recognizers.filter { it.isApiClass(psiClass) }.map { it.frameworkName }
+        return cachedRecognizers.filter { it.isApiClass(psiClass) }.map { it.frameworkName }
     }
 
     /**
@@ -59,7 +71,7 @@ class CompositeApiClassRecognizer(private val project: Project) {
      * Useful for [AnnotatedElementsSearch] in scanning.
      */
     val allTargetAnnotations: Set<String>
-        get() = recognizers.flatMap { it.targetAnnotations }.toSet()
+        get() = cachedRecognizers.flatMap { it.targetAnnotations }.toSet()
 
     companion object {
         fun getInstance(project: Project): CompositeApiClassRecognizer = project.service()

--- a/src/main/kotlin/com/itangcent/easyapi/util/ide/ProjectClassAvailabilityService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/ide/ProjectClassAvailabilityService.kt
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.seconds
 @Service(Service.Level.PROJECT)
 class ProjectClassAvailabilityService(
     private val project: Project
-) : Disposable, IdeaLog {
+) : Disposable {
 
     private val psiFacade: JavaPsiFacade = JavaPsiFacade.getInstance(project)
     private val searchScope: GlobalSearchScope = GlobalSearchScope.allScope(project)
@@ -62,27 +62,20 @@ class ProjectClassAvailabilityService(
     @Volatile
     private var messageBusConnection: MessageBusConnection? = null
 
-    private val branchChangeListener = object : BranchChangeListener {
-        override fun branchWillChange(branchName: String) {
-            // no-op
-        }
-
-        override fun branchHasChanged(branchName: String) {
-            LOG.info("Branch changed to '$branchName', clearing class availability cache")
-            clearCache()
-        }
-    }
-
-    private fun ensureConnected() {
-        if (messageBusConnection != null) return
-        if (project.isDisposed) return
-        synchronized(this) {
-            if (messageBusConnection != null) return
-            if (project.isDisposed) return
+    init {
+        if (!project.isDisposed) {
             val connection = project.messageBus.connect(this)
-            connection.subscribe(BranchChangeListener.VCS_BRANCH_CHANGED, branchChangeListener)
+            connection.subscribe(BranchChangeListener.VCS_BRANCH_CHANGED, object : BranchChangeListener {
+                override fun branchWillChange(branchName: String) {
+                    // no-op
+                }
+
+                override fun branchHasChanged(branchName: String) {
+                    LOG.info("Branch changed to '$branchName', clearing class availability cache")
+                    clearCache()
+                }
+            })
             messageBusConnection = connection
-            LOG.info("ProjectClassAvailabilityService connected to message bus")
         }
     }
 
@@ -99,8 +92,6 @@ class ProjectClassAvailabilityService(
      * @return true if the class exists in the project's dependencies, false otherwise
      */
     suspend fun hasClassInProject(qName: String): Boolean {
-        ensureConnected()
-
         val now = System.currentTimeMillis()
 
         val cached = cache[qName]
@@ -141,7 +132,7 @@ class ProjectClassAvailabilityService(
         clearCache()
     }
 
-    companion object {
+    companion object : IdeaLog {
         /**
          * Gets the service instance for the given project.
          */


### PR DESCRIPTION
## Changes

- Replace lazy-initialized `recognizers` in `CompositeApiClassRecognizer` with `@Volatile` cached list that refreshes on `SettingsChangeListener` events, ensuring cache is invalidated when settings change
- Move `ProjectClassAvailabilityService` message bus connection from lazy `ensureConnected()` to `init` block for eager registration, preventing race conditions where the listener wasn't registered before cache was accessed

## Why

The lazy initialization pattern caused occasional test failures because:
1. `CompositeApiClassRecognizer` cached recognizers via `lazy {}` but never invalidated when settings (e.g., JAX-RS enable/disable) changed
2. `ProjectClassAvailabilityService` used deferred `ensureConnected()` which could miss branch change events if the first `hasClassInProject()` call happened after a branch switch but before the listener was registered