### PR TITLE
feat: add toJson/toJson5 to script class context

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -5,9 +5,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.itangcent.easyapi.cache.json.JsonConstructionCache
 import com.itangcent.easyapi.config.ConfigReader
-import com.itangcent.easyapi.core.threading.read
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.DefaultPsiClassHelper.Companion.DEFAULT_MAX_DEEP
+import com.itangcent.easyapi.psi.DefaultPsiClassHelper.Companion.DEFAULT_MAX_ELEMENTS
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
@@ -102,34 +103,8 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
         psiClass: PsiClass,
         option: Int
     ): ObjectModel? {
-        val engine = RuleEngine.getInstance(project)
-        val elementCounter = ElementCounter(maxElements())
-        val maxDepth = maxDeep()
-
-        val converted = engine.evaluate(
-            RuleKeys.JSON_RULE_CONVERT,
-            com.intellij.psi.util.PsiTypesUtil.getClassType(psiClass),
-            psiClass
-        )
-        if (!converted.isNullOrBlank()) {
-            return buildObjectModelFromConvertedType(
-                convertedType = converted,
-                contextElement = psiClass,
-                option = option,
-                maxDepth = maxDepth,
-                genericContext = GenericContext.EMPTY,
-                elementCounter = elementCounter
-            )
-        }
-
-        val docHelper = UnifiedDocHelper.getInstance(project)
-        val cache = JsonConstructionCache()
-        val visited = HashSet<String>()
-        return buildTypeObject(
-            psiClass, engine, docHelper, cache,
-            option, maxDepth, depth = 0, visited = visited,
-            elementCounter = elementCounter
-        )
+        val resolvedType = ResolvedType.ClassType(psiClass)
+        return buildObjectModel(resolvedType, option)
     }
 
     override suspend fun buildObjectModel(

--- a/src/main/kotlin/com/itangcent/easyapi/psi/PsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/PsiClassHelper.kt
@@ -25,7 +25,21 @@ object JsonOption {
 }
 
 /**
- * Helper for building object models from PSI classes.
+ * Helper for building JSON models from PSI classes and resolved types.
+ *
+ * Supports all Java types — not just object classes, but also:
+ * - Primitive types (int, boolean, etc.)
+ * - Array types (String[], int[])
+ * - Collection types (List<T>, Set<T>)
+ * - Map types (Map<K, V>)
+ * - Enum types
+ * - Simple/wrapper types (String, Integer, etc.)
+ *
+ * The returned [ObjectModel] can be any variant:
+ * - [ObjectModel.Object] for class types → `{}`
+ * - [ObjectModel.Array] for collection/array types → `[]`
+ * - [ObjectModel.Single] for primitive/simple types → `0`, `""`, `true`
+ * - [ObjectModel.MapModel] for map types → `{"": ""}`
  *
  * ## Usage
  * ```kotlin
@@ -44,11 +58,15 @@ object JsonOption {
  */
 interface PsiClassHelper {
     /**
-     * Builds an object model from a PSI class.
+     * Builds a JSON model from a PSI class.
+     *
+     * Delegates to [buildObjectModel(ResolvedType)] internally, so the result
+     * may be any [ObjectModel] variant (Object, Array, Single, MapModel, etc.)
+     * depending on the actual type.
      *
      * @param psiClass The class to analyze
      * @param option Options for what to include (see JsonOption constants)
-     * @return The object model, or null if the class cannot be analyzed
+     * @return The JSON model, or null if the type cannot be analyzed (e.g., void)
      */
     suspend fun buildObjectModel(
         psiClass: PsiClass,
@@ -56,11 +74,21 @@ interface PsiClassHelper {
     ): ObjectModel?
 
     /**
-     * Builds an object model from an already-resolved type.
+     * Builds a JSON model from an already-resolved type.
      *
      * This is the preferred entry point when you have a [ResolvedType]
      * (e.g., from [ResolvedType.ClassType.fields] or [ResolvedType.ClassType.methods]).
      * No generic context is needed because the type is already fully resolved.
+     *
+     * Handles all [ResolvedType] variants:
+     * - [ResolvedType.PrimitiveType] → [ObjectModel.Single]
+     * - [ResolvedType.ArrayType] → [ObjectModel.Array]
+     * - [ResolvedType.ClassType] → depends on the class (Object, Array, Single, MapModel)
+     * - [ResolvedType.WildcardType] → resolved from upper bound
+     *
+     * @param resolvedType The resolved type to analyze
+     * @param option Options for what to include (see JsonOption constants)
+     * @return The JSON model, or null if the type cannot be analyzed (e.g., void)
      */
     suspend fun buildObjectModel(
         resolvedType: ResolvedType,

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
@@ -152,7 +152,7 @@ class RuleContext private constructor(
 
     fun wrapExt(key: String, value: Any?): Any? {
         if (value == null) return null
-        if (key == "fieldContext" && value is String) return ScriptFieldContext(value)
+        if (key == "fieldContext" && value is String) return ScriptFieldPathContext(value)
         if (value is PsiElement) return withElement(value).asScriptIt()
         if (value is ApiEndpoint) return ScriptApiEndpoint(value)
         return value

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptFieldPathContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptFieldPathContext.kt
@@ -9,7 +9,7 @@ package com.itangcent.easyapi.rule.context
  *
  * @param fieldPath The dot-separated JSON path of the current field
  */
-class ScriptFieldContext(private val fieldPath: String) {
+class ScriptFieldPathContext(private val fieldPath: String) {
 
     /** Returns the full JSON path of the current field. */
     fun path(): String = fieldPath

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
@@ -6,6 +6,9 @@ import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.psi.JsonOption
+import com.itangcent.easyapi.psi.PsiClassHelper
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
 import com.itangcent.easyapi.psi.type.InheritanceHelper
 import com.itangcent.easyapi.psi.type.ResolvedField
 import com.itangcent.easyapi.psi.type.ResolvedMethod
@@ -13,6 +16,125 @@ import com.itangcent.easyapi.psi.type.ResolvedParam
 import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 import com.itangcent.easyapi.psi.type.TypeResolver
+import kotlinx.coroutines.runBlocking
+
+//region Context Type Interfaces
+
+/**
+ * Interface defining the contract for contextType "class".
+ *
+ * Implemented by [ScriptPsiClassContext] and its subclasses.
+ * Provides class-specific operations for scripts including:
+ * - Method and field access
+ * - Type checking (isMap, isCollection, isArray, etc.)
+ * - Inheritance queries (extends, implements, superClass)
+ * - JSON serialization (toJson, toJson5)
+ */
+interface ClassContext {
+    fun methods(): Array<ScriptPsiMethodContext>
+    fun methodCnt(): Int
+    fun fields(): Array<ScriptPsiFieldContext>
+    fun fieldCnt(): Int
+    fun type(): ScriptTypeContext
+    fun isExtend(superClass: String): Boolean
+    fun isMap(): Boolean
+    fun isCollection(): Boolean
+    fun isArray(): Boolean
+    fun isInterface(): Boolean
+    fun isAnnotationType(): Boolean
+    fun isEnum(): Boolean
+    fun isPrimitive(): Boolean
+    fun isPrimitiveWrapper(): Boolean
+    fun isNormalType(): Boolean
+    fun qualifiedName(): String?
+    fun packageName(): String?
+    fun isPublic(): Boolean
+    fun isProtected(): Boolean
+    fun isPrivate(): Boolean
+    fun isPackagePrivate(): Boolean
+    fun isInnerClass(): Boolean
+    fun isStatic(): Boolean
+    fun outerClass(): ScriptPsiClassContext?
+    fun superClass(): ScriptPsiClassContext?
+    fun extends(): Array<ScriptPsiClassContext>?
+    fun implements(): Array<ScriptPsiClassContext>?
+    fun toJson(): String
+    fun toJson5(): String
+}
+
+/**
+ * Interface defining the contract for contextType "method".
+ *
+ * Implemented by [ScriptPsiMethodContext] and its subclasses.
+ * Provides method-specific operations for scripts including:
+ * - Return type and parameter access
+ * - Containing class access
+ * - Method modifier checks
+ */
+interface MethodContext {
+    fun returnType(): ScriptTypeContext?
+    fun type(): ScriptTypeContext?
+    fun isVarArgs(): Boolean
+    fun args(): Array<ScriptPsiParameterContext>
+    fun params(): Array<ScriptPsiParameterContext>
+    fun parameters(): Array<ScriptPsiParameterContext>
+    fun argTypes(): Array<ScriptTypeContext>
+    fun argCnt(): Int
+    fun paramCnt(): Int
+    fun containingClass(): ScriptPsiClassContext?
+    fun defineClass(): ScriptPsiClassContext?
+    fun isEnumField(): Boolean
+    fun isConstructor(): Boolean
+    fun isOverride(): Boolean
+    fun throwsExceptions(): Array<String>
+    fun isDefault(): Boolean
+    fun isAbstract(): Boolean
+    fun isSynchronized(): Boolean
+    fun isNative(): Boolean
+}
+
+/**
+ * Interface defining the contract for contextType "field".
+ *
+ * Implemented by [ScriptPsiFieldContext] and its subclasses.
+ * Provides field-specific operations for scripts including:
+ * - Type access
+ * - Containing class access
+ * - Field modifier checks
+ */
+interface FieldContext {
+    fun type(): ScriptTypeContext
+    fun jsonType(): ScriptTypeContext
+    fun containingClass(): ScriptPsiClassContext?
+    fun defineClass(): ScriptPsiClassContext?
+    fun isEnumField(): Boolean
+    fun asEnumField(): ScriptPsiEnumConstantContext?
+    fun isStatic(): Boolean
+    fun isFinal(): Boolean
+    fun isTransient(): Boolean
+    fun isVolatile(): Boolean
+    fun constantValue(): Any?
+}
+
+/**
+ * Interface defining the contract for contextType "param".
+ *
+ * Implemented by [ScriptPsiParameterContext] and its subclasses.
+ * Provides parameter-specific operations for scripts including:
+ * - Type access
+ * - Varargs detection
+ * - Declaring method access
+ */
+interface ParameterContext {
+    fun type(): ScriptTypeContext
+    fun jsonType(): ScriptTypeContext
+    fun isVarArgs(): Boolean
+    fun isFinal(): Boolean
+    fun method(): ScriptPsiMethodContext?
+    fun declaration(): ScriptItContext?
+}
+
+//endregion
 
 /**
  * Converts a [RuleContext] to a script-friendly context based on the element type.
@@ -68,11 +190,11 @@ fun RuleContext.asScriptIt(): Any {
  * if (it.isMap()) { ... }
  * ```
  */
-open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context) {
+open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context), ClassContext {
 
     private fun psiClass(): PsiClass = context.element as PsiClass
 
-    open fun methods(): Array<ScriptPsiMethodContext> = readSync {
+    override fun methods(): Array<ScriptPsiMethodContext> = readSync {
         val cls = psiClass()
         val methods = cls.allMethods
         Array(methods.size) { i ->
@@ -80,9 +202,9 @@ open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context
         }
     }
 
-    fun methodCnt(): Int = readSync { psiClass().allMethods.size }
+    override fun methodCnt(): Int = readSync { psiClass().allMethods.size }
 
-    open fun fields(): Array<ScriptPsiFieldContext> = readSync {
+    override fun fields(): Array<ScriptPsiFieldContext> = readSync {
         val cls = psiClass()
         val fields = cls.allFields
         Array(fields.size) { i ->
@@ -90,80 +212,96 @@ open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context
         }
     }
 
-    fun fieldCnt(): Int = readSync { psiClass().allFields.size }
+    override fun fieldCnt(): Int = readSync { psiClass().allFields.size }
 
-    open fun type(): ScriptTypeContext {
+    override fun type(): ScriptTypeContext {
         return ScriptTypeContext(context, ResolvedType.ClassType(psiClass()))
     }
 
-    fun isExtend(superClass: String): Boolean =
+    override fun isExtend(superClass: String): Boolean =
         InheritanceHelper.isInheritor(psiClass(), superClass)
 
-    fun isMap(): Boolean =
+    override fun isMap(): Boolean =
         InheritanceHelper.isMap(psiClass())
 
-    fun isCollection(): Boolean =
+    override fun isCollection(): Boolean =
         InheritanceHelper.isCollection(psiClass())
 
-    fun isArray(): Boolean = name().endsWith("[]")
+    override fun isArray(): Boolean = name().endsWith("[]")
 
-    fun isInterface(): Boolean = readSync { psiClass().isInterface }
+    override fun isInterface(): Boolean = readSync { psiClass().isInterface }
 
-    fun isAnnotationType(): Boolean = readSync { psiClass().isAnnotationType }
+    override fun isAnnotationType(): Boolean = readSync { psiClass().isAnnotationType }
 
-    fun isEnum(): Boolean = readSync { psiClass().isEnum }
+    override fun isEnum(): Boolean = readSync { psiClass().isEnum }
 
-    fun isPrimitive(): Boolean = SpecialTypeHandler.isPrimitive(name())
+    override fun isPrimitive(): Boolean = SpecialTypeHandler.isPrimitive(name())
 
-    fun isPrimitiveWrapper(): Boolean = SpecialTypeHandler.isPrimitiveWrapper(name())
+    override fun isPrimitiveWrapper(): Boolean = SpecialTypeHandler.isPrimitiveWrapper(name())
 
-    fun isNormalType(): Boolean {
+    override fun isNormalType(): Boolean {
         val n = name()
         return isPrimitive() || isPrimitiveWrapper() || n == "java.lang.String" || n == "java.lang.Object"
     }
 
-    fun qualifiedName(): String? = readSync { psiClass().qualifiedName }
+    override fun qualifiedName(): String? = readSync { psiClass().qualifiedName }
 
-    fun packageName(): String? = readSync { psiClass().qualifiedName?.substringBeforeLast('.', "") }
+    override fun packageName(): String? = readSync { psiClass().qualifiedName?.substringBeforeLast('.', "") }
 
-    fun isPublic(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PUBLIC) }
+    override fun isPublic(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PUBLIC) }
 
-    fun isProtected(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PROTECTED) }
+    override fun isProtected(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PROTECTED) }
 
-    fun isPrivate(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PRIVATE) }
+    override fun isPrivate(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.PRIVATE) }
 
-    fun isPackagePrivate(): Boolean = readSync {
+    override fun isPackagePrivate(): Boolean = readSync {
         val cls = psiClass()
         !cls.hasModifierProperty(com.intellij.psi.PsiModifier.PUBLIC) &&
                 !cls.hasModifierProperty(com.intellij.psi.PsiModifier.PROTECTED) &&
                 !cls.hasModifierProperty(com.intellij.psi.PsiModifier.PRIVATE)
     }
 
-    fun isInnerClass(): Boolean = readSync { psiClass().containingClass != null }
+    override fun isInnerClass(): Boolean = readSync { psiClass().containingClass != null }
 
-    fun isStatic(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.STATIC) }
+    override fun isStatic(): Boolean = readSync { psiClass().hasModifierProperty(com.intellij.psi.PsiModifier.STATIC) }
 
-    open fun outerClass(): ScriptPsiClassContext? = readSync {
+    override fun outerClass(): ScriptPsiClassContext? = readSync {
         psiClass().containingClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 
-    open fun superClass(): ScriptPsiClassContext? = readSync {
+    override fun superClass(): ScriptPsiClassContext? = readSync {
         val cls = psiClass()
         if (cls.isInterface || cls.isAnnotationType || cls.isEnum) return@readSync null
         extends()?.takeIf { it.isNotEmpty() }?.get(0)?.let { return@readSync it }
         cls.superClass?.let { ScriptPsiClassContext(context.withElement(it)) }
     }
 
-    open fun extends(): Array<ScriptPsiClassContext>? = readSync {
+    override fun extends(): Array<ScriptPsiClassContext>? = readSync {
         psiClass().extendsList?.referencedTypes?.mapNotNull { ref ->
             ref.resolve()?.let { ScriptPsiClassContext(context.withElement(it)) }
         }?.toTypedArray()
     }
 
-    open fun implements(): Array<ScriptPsiClassContext>? = readSync {
+    override fun implements(): Array<ScriptPsiClassContext>? = readSync {
         psiClass().implementsList?.referencedTypes?.mapNotNull { ref ->
             ref.resolve()?.let { ScriptPsiClassContext(context.withElement(it)) }
         }?.toTypedArray()
+    }
+
+    override fun toJson(): String {
+        val helper = PsiClassHelper.getInstance(context.project)
+        val model = runBlocking {
+            helper.buildObjectModel(ResolvedType.ClassType(psiClass()), JsonOption.READ_GETTER_OR_SETTER)
+        }
+        return ObjectModelJsonConverter.toJson(model)
+    }
+
+    override fun toJson5(): String {
+        val helper = PsiClassHelper.getInstance(context.project)
+        val model = runBlocking {
+            helper.buildObjectModel(ResolvedType.ClassType(psiClass()), JsonOption.ALL)
+        }
+        return ObjectModelJsonConverter.toJson5(model)
     }
 
     override fun canonicalText(): String = qualifiedName() ?: name()
@@ -194,67 +332,67 @@ open class ScriptPsiClassContext(context: RuleContext) : ScriptItContext(context
  * it.containingClass().name()
  * ```
  */
-open class ScriptPsiMethodContext(context: RuleContext) : ScriptItContext(context) {
+open class ScriptPsiMethodContext(context: RuleContext) : ScriptItContext(context), MethodContext {
 
     protected fun psiMethod(): PsiMethod = context.element as PsiMethod
 
-    open fun returnType(): ScriptTypeContext? = readSync {
+    override fun returnType(): ScriptTypeContext? = readSync {
         val type = psiMethod().returnType ?: return@readSync null
         ScriptTypeContext(context, TypeResolver.resolve(type))
     }
 
-    fun type(): ScriptTypeContext? = returnType()
+    override fun type(): ScriptTypeContext? = returnType()
 
-    fun isVarArgs(): Boolean = readSync { psiMethod().isVarArgs }
+    override fun isVarArgs(): Boolean = readSync { psiMethod().isVarArgs }
 
-    open fun args(): Array<ScriptPsiParameterContext> = readSync {
+    override fun args(): Array<ScriptPsiParameterContext> = readSync {
         val params = psiMethod().parameterList.parameters
         Array(params.size) { i -> ScriptPsiParameterContext(context.withElement(params[i])) }
     }
 
-    fun params(): Array<ScriptPsiParameterContext> = args()
+    override fun params(): Array<ScriptPsiParameterContext> = args()
 
-    fun parameters(): Array<ScriptPsiParameterContext> = args()
+    override fun parameters(): Array<ScriptPsiParameterContext> = args()
 
-    open fun argTypes(): Array<ScriptTypeContext> = readSync {
+    override fun argTypes(): Array<ScriptTypeContext> = readSync {
         val params = psiMethod().parameterList.parameters
         Array(params.size) { i -> ScriptTypeContext(context, TypeResolver.resolve(params[i].type)) }
     }
 
-    fun argCnt(): Int = readSync { psiMethod().parameterList.parametersCount }
+    override fun argCnt(): Int = readSync { psiMethod().parameterList.parametersCount }
 
-    fun paramCnt(): Int = argCnt()
+    override fun paramCnt(): Int = argCnt()
 
-    open fun containingClass(): ScriptPsiClassContext? = readSync {
+    override fun containingClass(): ScriptPsiClassContext? = readSync {
         val cls = psiMethod().containingClass ?: return@readSync null
         ScriptPsiClassContext(context.withElement(cls))
     }
 
-    open fun defineClass(): ScriptPsiClassContext? = containingClass()
+    override fun defineClass(): ScriptPsiClassContext? = containingClass()
 
     /* for backward compatibility only */
-    fun isEnumField(): Boolean = false
+    override fun isEnumField(): Boolean = false
 
-    fun isConstructor(): Boolean = readSync { psiMethod().isConstructor }
+    override fun isConstructor(): Boolean = readSync { psiMethod().isConstructor }
 
-    fun isOverride(): Boolean = readSync {
+    override fun isOverride(): Boolean = readSync {
         val method = psiMethod()
         method.modifierList.findAnnotation("java.lang.Override") != null ||
                 method.findSuperMethods().isNotEmpty()
     }
 
-    fun throwsExceptions(): Array<String> = readSync {
+    override fun throwsExceptions(): Array<String> = readSync {
         psiMethod().throwsList.referencedTypes.map { it.canonicalText }.toTypedArray()
     }
 
-    fun isDefault(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.DEFAULT) }
+    override fun isDefault(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.DEFAULT) }
 
-    fun isAbstract(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.ABSTRACT) }
+    override fun isAbstract(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.ABSTRACT) }
 
-    fun isSynchronized(): Boolean =
+    override fun isSynchronized(): Boolean =
         readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.SYNCHRONIZED) }
 
-    fun isNative(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.NATIVE) }
+    override fun isNative(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.NATIVE) }
 
     override fun canonicalText(): String {
         val cls = readSync { psiMethod().containingClass?.qualifiedName } ?: ""
@@ -303,38 +441,38 @@ class ScriptPsiMethodInClassContext(
  * if (it.isEnumField()) { ... }
  * ```
  */
-open class ScriptPsiFieldContext(context: RuleContext) : ScriptItContext(context) {
+open class ScriptPsiFieldContext(context: RuleContext) : ScriptItContext(context), FieldContext {
 
     protected fun psiField(): PsiField = context.element as PsiField
 
-    open fun type(): ScriptTypeContext = readSync {
+    override fun type(): ScriptTypeContext = readSync {
         ScriptTypeContext(context, TypeResolver.resolve(psiField().type))
     }
 
-    open fun jsonType(): ScriptTypeContext = type()
+    override fun jsonType(): ScriptTypeContext = type()
 
-    open fun containingClass(): ScriptPsiClassContext? = readSync {
+    override fun containingClass(): ScriptPsiClassContext? = readSync {
         val cls = psiField().containingClass ?: return@readSync null
         ScriptPsiClassContext(context.withElement(cls))
     }
 
-    open fun defineClass(): ScriptPsiClassContext? = containingClass()
+    override fun defineClass(): ScriptPsiClassContext? = containingClass()
 
-    fun isEnumField(): Boolean = readSync { psiField() is PsiEnumConstant }
+    override fun isEnumField(): Boolean = readSync { psiField() is PsiEnumConstant }
 
-    fun asEnumField(): ScriptPsiEnumConstantContext? = readSync {
+    override fun asEnumField(): ScriptPsiEnumConstantContext? = readSync {
         (psiField() as? PsiEnumConstant)?.let { ScriptPsiEnumConstantContext(context, it) }
     }
 
-    fun isStatic(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.STATIC) }
+    override fun isStatic(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.STATIC) }
 
-    fun isFinal(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.FINAL) }
+    override fun isFinal(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.FINAL) }
 
-    fun isTransient(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.TRANSIENT) }
+    override fun isTransient(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.TRANSIENT) }
 
-    fun isVolatile(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.VOLATILE) }
+    override fun isVolatile(): Boolean = readSync { psiField().hasModifierProperty(com.intellij.psi.PsiModifier.VOLATILE) }
 
-    fun constantValue(): Any? = readSync {
+    override fun constantValue(): Any? = readSync {
         val field = psiField()
         if (field.hasModifierProperty(com.intellij.psi.PsiModifier.STATIC) &&
             field.hasModifierProperty(com.intellij.psi.PsiModifier.FINAL)
@@ -392,24 +530,24 @@ class ScriptPsiFieldInClassContext(
  * it.method().name()
  * ```
  */
-open class ScriptPsiParameterContext(context: RuleContext) : ScriptItContext(context) {
+open class ScriptPsiParameterContext(context: RuleContext) : ScriptItContext(context), ParameterContext {
 
     private fun psiParameter(): PsiParameter = context.element as PsiParameter
 
-    open fun type(): ScriptTypeContext = readSync {
+    override fun type(): ScriptTypeContext = readSync {
         ScriptTypeContext(context, TypeResolver.resolve(psiParameter().type))
     }
 
-    open fun jsonType(): ScriptTypeContext = type()
+    override fun jsonType(): ScriptTypeContext = type()
 
-    fun isVarArgs(): Boolean = readSync { psiParameter().isVarArgs }
+    override fun isVarArgs(): Boolean = readSync { psiParameter().isVarArgs }
 
-    fun isFinal(): Boolean = readSync { psiParameter().hasModifierProperty(com.intellij.psi.PsiModifier.FINAL) }
+    override fun isFinal(): Boolean = readSync { psiParameter().hasModifierProperty(com.intellij.psi.PsiModifier.FINAL) }
 
     /**
      * Returns the method which declares this parameter. May be null.
      */
-    open fun method(): ScriptPsiMethodContext? = readSync {
+    override fun method(): ScriptPsiMethodContext? = readSync {
         val scope = psiParameter().declarationScope
         if (scope is PsiMethod) ScriptPsiMethodContext(context.withElement(scope)) else null
     }
@@ -417,7 +555,7 @@ open class ScriptPsiParameterContext(context: RuleContext) : ScriptItContext(con
     /**
      * Returns the element which declares this parameter.
      */
-    open fun declaration(): ScriptItContext? = readSync {
+    override fun declaration(): ScriptItContext? = readSync {
         val scope = psiParameter().declarationScope
         when (scope) {
             is PsiMethod -> ScriptPsiMethodContext(context.withElement(scope))
@@ -588,6 +726,22 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
             ref.resolve()?.let { ScriptPsiClassContext(context.withElement(it)) }
         }?.toTypedArray()
     }
+
+    fun toJson(): String {
+        val helper = PsiClassHelper.getInstance(context.project)
+        val model = runBlocking {
+            helper.buildObjectModel(resolvedType, JsonOption.READ_GETTER_OR_SETTER)
+        }
+        return ObjectModelJsonConverter.toJson(model)
+    }
+
+    fun toJson5(): String {
+        val helper = PsiClassHelper.getInstance(context.project)
+        val model = runBlocking {
+            helper.buildObjectModel(resolvedType, JsonOption.ALL)
+        }
+        return ObjectModelJsonConverter.toJson5(model)
+    }
 }
 
 /**
@@ -607,15 +761,75 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
 class ScriptPsiTypeContext(
     context: RuleContext,
     private val psiType: com.intellij.psi.PsiType
-) : ScriptItContext(context) {
+) : ScriptItContext(context), ClassContext {
 
     private val resolvedType: ResolvedType by lazy { TypeResolver.resolve(psiType) }
 
-    fun type(): ScriptTypeContext = ScriptTypeContext(context, resolvedType)
+    private val typeContext: ScriptTypeContext by lazy { ScriptTypeContext(context, resolvedType) }
 
-    fun returnType(): ScriptTypeContext = type()
+    override fun type(): ScriptTypeContext = typeContext
 
-    override fun contextType(): String = "type"
+    override fun contextType(): String = "class"
+
+    override fun methods(): Array<ScriptPsiMethodContext> = typeContext.methods()
+
+    override fun methodCnt(): Int = typeContext.methods().size
+
+    override fun fields(): Array<ScriptPsiFieldContext> = typeContext.fields()
+
+    override fun fieldCnt(): Int = typeContext.fields().size
+
+    override fun isExtend(superClass: String): Boolean = typeContext.isExtend(superClass)
+
+    override fun isMap(): Boolean = typeContext.isMap()
+
+    override fun isCollection(): Boolean = typeContext.isCollection()
+
+    override fun isArray(): Boolean = typeContext.isArray()
+
+    override fun isInterface(): Boolean = typeContext.isInterface()
+
+    override fun isAnnotationType(): Boolean = typeContext.isAnnotationType()
+
+    override fun isEnum(): Boolean = typeContext.isEnum()
+
+    override fun isPrimitive(): Boolean = typeContext.isPrimitive()
+
+    override fun isPrimitiveWrapper(): Boolean = typeContext.isPrimitiveWrapper()
+
+    override fun isNormalType(): Boolean = typeContext.isNormalType()
+
+    override fun qualifiedName(): String? = typeContext.name()
+
+    override fun packageName(): String? = readSync {
+        val name = typeContext.name()
+        val lastDot = name.lastIndexOf('.')
+        if (lastDot > 0) name.substring(0, lastDot) else null
+    }
+
+    override fun isPublic(): Boolean = true
+
+    override fun isProtected(): Boolean = false
+
+    override fun isPrivate(): Boolean = false
+
+    override fun isPackagePrivate(): Boolean = false
+
+    override fun isInnerClass(): Boolean = false
+
+    override fun isStatic(): Boolean = false
+
+    override fun outerClass(): ScriptPsiClassContext? = null
+
+    override fun superClass(): ScriptPsiClassContext? = typeContext.superClass()
+
+    override fun extends(): Array<ScriptPsiClassContext>? = typeContext.extends()
+
+    override fun implements(): Array<ScriptPsiClassContext>? = typeContext.implements()
+
+    override fun toJson(): String = typeContext.toJson()
+
+    override fun toJson5(): String = typeContext.toJson5()
 
     override fun toString(): String = resolvedType.qualifiedName()
 }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
@@ -108,7 +108,7 @@ abstract class Jsr223ScriptParser(
         // localStorage (wrapped to match legacy Storage API)
         bindings["localStorage"] = ScriptStorageWrapper(context.localStorage)
 
-        // extensions from rule context — fieldContext strings are auto-wrapped as ScriptFieldContext
+        // extensions from rule context — fieldContext strings are auto-wrapped as ScriptFieldPathContext
         context.exts().forEach { (key, value) ->
             bindings[key] = context.wrapExt(key, value)
         }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/type/InheritanceHelperTest.kt
@@ -1,6 +1,5 @@
 package com.itangcent.easyapi.psi.type
 
-import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -11,32 +10,32 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsCollectionWithArrayList() {
-        val psiClass = loadJavaCollectionClass("ArrayList")
+        val psiClass = loadJDKClass("java.util.ArrayList")
         assertTrue("ArrayList should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsCollectionWithHashSet() {
-        val psiClass = loadJavaCollectionClass("HashSet")
+        val psiClass = loadJDKClass("java.util.HashSet")
         assertTrue("HashSet should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsCollectionWithLinkedList() {
-        val psiClass = loadJavaCollectionClass("LinkedList")
+        val psiClass = loadJDKClass("java.util.LinkedList")
         assertTrue("LinkedList should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsCollectionWithListInterface() {
-        val psiClass = loadJavaCollectionClass("List")
+        val psiClass = loadJDKClass("java.util.List")
         assertTrue("List should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsCollectionWithSetInterface() {
-        val psiClass = loadJavaCollectionClass("Set")
+        val psiClass = loadJDKClass("java.util.Set")
         assertTrue("Set should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsCollectionWithCollectionInterface() {
-        val psiClass = loadJavaCollectionClass("Collection")
+        val psiClass = loadJDKClass("java.util.Collection")
         assertTrue("Collection should be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
@@ -53,7 +52,7 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsCollectionWithCustomCollectionSubclass() {
-        setupCollectionInheritanceStubs()
+        loadJDKClass("java.util.ArrayList")
         myFixture.addClass("""
             package com.test;
             import java.util.ArrayList;
@@ -64,22 +63,22 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsMapWithHashMap() {
-        val psiClass = loadJavaMapClass("HashMap")
+        val psiClass = loadJDKClass("java.util.HashMap")
         assertTrue("HashMap should be detected as Map", InheritanceHelper.isMap(psiClass))
     }
 
     fun testIsMapWithLinkedHashMap() {
-        val psiClass = loadJavaMapClass("LinkedHashMap")
+        val psiClass = loadJDKClass("java.util.LinkedHashMap")
         assertTrue("LinkedHashMap should be detected as Map", InheritanceHelper.isMap(psiClass))
     }
 
     fun testIsMapWithTreeMap() {
-        val psiClass = loadJavaMapClass("TreeMap")
+        val psiClass = loadJDKClass("java.util.TreeMap")
         assertTrue("TreeMap should be detected as Map", InheritanceHelper.isMap(psiClass))
     }
 
     fun testIsMapWithMapInterface() {
-        val psiClass = loadJavaMapClass("Map")
+        val psiClass = loadJDKClass("java.util.Map")
         assertTrue("Map interface should be detected as Map", InheritanceHelper.isMap(psiClass))
     }
 
@@ -96,7 +95,7 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsMapWithCustomMapSubclass() {
-        setupMapInheritanceStubs()
+        loadJDKClass("java.util.HashMap")
         myFixture.addClass("""
             package com.test;
             import java.util.HashMap;
@@ -107,12 +106,12 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsInheritorDirectMatch() {
-        val psiClass = loadJavaMapClass("Map")
+        val psiClass = loadJDKClass("java.util.Map")
         assertTrue("Map should be inheritor of itself", InheritanceHelper.isInheritor(psiClass, "java.util.Map"))
     }
 
     fun testIsInheritorSubclass() {
-        setupCollectionInheritanceStubs()
+        loadJDKClass("java.util.ArrayList")
         myFixture.addClass("""
             package com.test;
             import java.util.ArrayList;
@@ -133,14 +132,14 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testCacheReturnsSameResult() {
-        val psiClass = loadJavaCollectionClass("ArrayList")
+        val psiClass = loadJDKClass("java.util.ArrayList")
         val result1 = InheritanceHelper.isCollection(psiClass)
         val result2 = InheritanceHelper.isCollection(psiClass)
         assertEquals("Cached result should be the same", result1, result2)
     }
 
     fun testClearCache() {
-        val psiClass = loadJavaCollectionClass("ArrayList")
+        val psiClass = loadJDKClass("java.util.ArrayList")
         InheritanceHelper.isCollection(psiClass)
         InheritanceHelper.clearCache()
         val result = InheritanceHelper.isCollection(psiClass)
@@ -148,76 +147,12 @@ class InheritanceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testIsCollectionReturnsFalseForMap() {
-        val psiClass = loadJavaMapClass("HashMap")
+        val psiClass = loadJDKClass("java.util.HashMap")
         assertFalse("HashMap should not be detected as Collection", InheritanceHelper.isCollection(psiClass))
     }
 
     fun testIsMapReturnsFalseForCollection() {
-        val psiClass = loadJavaCollectionClass("ArrayList")
+        val psiClass = loadJDKClass("java.util.ArrayList")
         assertFalse("ArrayList should not be detected as Map", InheritanceHelper.isMap(psiClass))
-    }
-
-    private fun setupCollectionInheritanceStubs() {
-        myFixture.addClass("""
-            package java.util;
-            public interface Collection<E> extends Iterable<E> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public interface List<E> extends Collection<E> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public interface Set<E> extends Collection<E> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public abstract class AbstractCollection<E> implements Collection<E> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public abstract class AbstractList<E> extends AbstractCollection<E> implements List<E> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public class ArrayList<E> extends AbstractList<E> {}
-        """.trimIndent())
-    }
-
-    private fun setupMapInheritanceStubs() {
-        myFixture.addClass("""
-            package java.util;
-            public interface Map<K, V> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public abstract class AbstractMap<K, V> implements Map<K, V> {}
-        """.trimIndent())
-        myFixture.addClass("""
-            package java.util;
-            public class HashMap<K, V> extends AbstractMap<K, V> {}
-        """.trimIndent())
-    }
-
-    private fun loadJavaCollectionClass(className: String): PsiClass {
-        val fqn = "java.util.$className"
-        val existing = findClass(fqn)
-        if (existing != null) return existing
-        myFixture.addClass("""
-            package java.util;
-            public class $className {}
-        """.trimIndent())
-        return findClass(fqn)!!
-    }
-
-    private fun loadJavaMapClass(className: String): PsiClass {
-        val fqn = "java.util.$className"
-        val existing = findClass(fqn)
-        if (existing != null) return existing
-        myFixture.addClass("""
-            package java.util;
-            public class $className {}
-        """.trimIndent())
-        return findClass(fqn)!!
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptFieldPathContextTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptFieldPathContextTest.kt
@@ -3,47 +3,47 @@ package com.itangcent.easyapi.rule.context
 import org.junit.Assert.*
 import org.junit.Test
 
-class ScriptFieldContextTest {
+class ScriptFieldPathContextTest {
 
     @Test
     fun testPathReturnsFieldPath() {
-        val context = ScriptFieldContext("user.name")
+        val context = ScriptFieldPathContext("user.name")
         assertEquals("user.name", context.path())
     }
 
     @Test
     fun testPathTopLevel() {
-        val context = ScriptFieldContext("name")
+        val context = ScriptFieldPathContext("name")
         assertEquals("name", context.path())
     }
 
     @Test
     fun testPropertyWithParent() {
-        val context = ScriptFieldContext("user.name")
+        val context = ScriptFieldPathContext("user.name")
         assertEquals("user.age", context.property("age"))
     }
 
     @Test
     fun testPropertyTopLevel() {
-        val context = ScriptFieldContext("name")
+        val context = ScriptFieldPathContext("name")
         assertEquals("age", context.property("age"))
     }
 
     @Test
     fun testPropertyNestedPath() {
-        val context = ScriptFieldContext("user.address.city")
+        val context = ScriptFieldPathContext("user.address.city")
         assertEquals("user.address.zip", context.property("zip"))
     }
 
     @Test
     fun testToStringReturnsPath() {
-        val context = ScriptFieldContext("user.name")
+        val context = ScriptFieldPathContext("user.name")
         assertEquals("user.name", context.toString())
     }
 
     @Test
     fun testPropertyWithEmptyPath() {
-        val context = ScriptFieldContext("")
+        val context = ScriptFieldPathContext("")
         assertEquals("field", context.property("field"))
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptItContextPureTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptItContextPureTest.kt
@@ -22,4 +22,207 @@ class ScriptItContextPureTest {
         assertTrue("Should have getExt() method", methods.contains("getExt"))
         assertTrue("Should have setExt() method", methods.contains("setExt"))
     }
+
+    //region Interface existence tests
+
+    @Test
+    fun testClassContextInterfaceExists() {
+        val clazz = Class.forName("com.itangcent.easyapi.rule.context.ClassContext")
+        assertNotNull("ClassContext interface should exist", clazz)
+        assertTrue("ClassContext should be an interface", clazz.isInterface)
+    }
+
+    @Test
+    fun testMethodContextInterfaceExists() {
+        val clazz = Class.forName("com.itangcent.easyapi.rule.context.MethodContext")
+        assertNotNull("MethodContext interface should exist", clazz)
+        assertTrue("MethodContext should be an interface", clazz.isInterface)
+    }
+
+    @Test
+    fun testFieldContextInterfaceExists() {
+        val clazz = Class.forName("com.itangcent.easyapi.rule.context.FieldContext")
+        assertNotNull("FieldContext interface should exist", clazz)
+        assertTrue("FieldContext should be an interface", clazz.isInterface)
+    }
+
+    @Test
+    fun testParameterContextInterfaceExists() {
+        val clazz = Class.forName("com.itangcent.easyapi.rule.context.ParameterContext")
+        assertNotNull("ParameterContext interface should exist", clazz)
+        assertTrue("ParameterContext should be an interface", clazz.isInterface)
+    }
+
+    //endregion
+
+    //region Interface method contract tests
+
+    @Test
+    fun testClassContextInterfaceMethods() {
+        val methods = ClassContext::class.java.methods.map { it.name }.toSet()
+        // Core class operations
+        assertTrue("ClassContext should define methods()", methods.contains("methods"))
+        assertTrue("ClassContext should define methodCnt()", methods.contains("methodCnt"))
+        assertTrue("ClassContext should define fields()", methods.contains("fields"))
+        assertTrue("ClassContext should define fieldCnt()", methods.contains("fieldCnt"))
+        assertTrue("ClassContext should define type()", methods.contains("type"))
+        // Type checking
+        assertTrue("ClassContext should define isExtend()", methods.contains("isExtend"))
+        assertTrue("ClassContext should define isMap()", methods.contains("isMap"))
+        assertTrue("ClassContext should define isCollection()", methods.contains("isCollection"))
+        assertTrue("ClassContext should define isArray()", methods.contains("isArray"))
+        assertTrue("ClassContext should define isInterface()", methods.contains("isInterface"))
+        assertTrue("ClassContext should define isAnnotationType()", methods.contains("isAnnotationType"))
+        assertTrue("ClassContext should define isEnum()", methods.contains("isEnum"))
+        assertTrue("ClassContext should define isPrimitive()", methods.contains("isPrimitive"))
+        assertTrue("ClassContext should define isPrimitiveWrapper()", methods.contains("isPrimitiveWrapper"))
+        assertTrue("ClassContext should define isNormalType()", methods.contains("isNormalType"))
+        // Naming
+        assertTrue("ClassContext should define qualifiedName()", methods.contains("qualifiedName"))
+        assertTrue("ClassContext should define packageName()", methods.contains("packageName"))
+        // Visibility
+        assertTrue("ClassContext should define isPublic()", methods.contains("isPublic"))
+        assertTrue("ClassContext should define isProtected()", methods.contains("isProtected"))
+        assertTrue("ClassContext should define isPrivate()", methods.contains("isPrivate"))
+        assertTrue("ClassContext should define isPackagePrivate()", methods.contains("isPackagePrivate"))
+        // Structure
+        assertTrue("ClassContext should define isInnerClass()", methods.contains("isInnerClass"))
+        assertTrue("ClassContext should define isStatic()", methods.contains("isStatic"))
+        assertTrue("ClassContext should define outerClass()", methods.contains("outerClass"))
+        assertTrue("ClassContext should define superClass()", methods.contains("superClass"))
+        assertTrue("ClassContext should define extends()", methods.contains("extends"))
+        assertTrue("ClassContext should define implements()", methods.contains("implements"))
+        // JSON serialization
+        assertTrue("ClassContext should define toJson()", methods.contains("toJson"))
+        assertTrue("ClassContext should define toJson5()", methods.contains("toJson5"))
+    }
+
+    @Test
+    fun testMethodContextInterfaceMethods() {
+        val methods = MethodContext::class.java.methods.map { it.name }.toSet()
+        assertTrue("MethodContext should define returnType()", methods.contains("returnType"))
+        assertTrue("MethodContext should define type()", methods.contains("type"))
+        assertTrue("MethodContext should define isVarArgs()", methods.contains("isVarArgs"))
+        assertTrue("MethodContext should define args()", methods.contains("args"))
+        assertTrue("MethodContext should define params()", methods.contains("params"))
+        assertTrue("MethodContext should define parameters()", methods.contains("parameters"))
+        assertTrue("MethodContext should define argTypes()", methods.contains("argTypes"))
+        assertTrue("MethodContext should define argCnt()", methods.contains("argCnt"))
+        assertTrue("MethodContext should define paramCnt()", methods.contains("paramCnt"))
+        assertTrue("MethodContext should define containingClass()", methods.contains("containingClass"))
+        assertTrue("MethodContext should define defineClass()", methods.contains("defineClass"))
+        assertTrue("MethodContext should define isEnumField()", methods.contains("isEnumField"))
+        assertTrue("MethodContext should define isConstructor()", methods.contains("isConstructor"))
+        assertTrue("MethodContext should define isOverride()", methods.contains("isOverride"))
+        assertTrue("MethodContext should define throwsExceptions()", methods.contains("throwsExceptions"))
+        assertTrue("MethodContext should define isDefault()", methods.contains("isDefault"))
+        assertTrue("MethodContext should define isAbstract()", methods.contains("isAbstract"))
+        assertTrue("MethodContext should define isSynchronized()", methods.contains("isSynchronized"))
+        assertTrue("MethodContext should define isNative()", methods.contains("isNative"))
+    }
+
+    @Test
+    fun testFieldContextInterfaceMethods() {
+        val methods = FieldContext::class.java.methods.map { it.name }.toSet()
+        assertTrue("FieldContext should define type()", methods.contains("type"))
+        assertTrue("FieldContext should define jsonType()", methods.contains("jsonType"))
+        assertTrue("FieldContext should define containingClass()", methods.contains("containingClass"))
+        assertTrue("FieldContext should define defineClass()", methods.contains("defineClass"))
+        assertTrue("FieldContext should define isEnumField()", methods.contains("isEnumField"))
+        assertTrue("FieldContext should define asEnumField()", methods.contains("asEnumField"))
+        assertTrue("FieldContext should define isStatic()", methods.contains("isStatic"))
+        assertTrue("FieldContext should define isFinal()", methods.contains("isFinal"))
+        assertTrue("FieldContext should define isTransient()", methods.contains("isTransient"))
+        assertTrue("FieldContext should define isVolatile()", methods.contains("isVolatile"))
+        assertTrue("FieldContext should define constantValue()", methods.contains("constantValue"))
+    }
+
+    @Test
+    fun testParameterContextInterfaceMethods() {
+        val methods = ParameterContext::class.java.methods.map { it.name }.toSet()
+        assertTrue("ParameterContext should define type()", methods.contains("type"))
+        assertTrue("ParameterContext should define jsonType()", methods.contains("jsonType"))
+        assertTrue("ParameterContext should define isVarArgs()", methods.contains("isVarArgs"))
+        assertTrue("ParameterContext should define isFinal()", methods.contains("isFinal"))
+        assertTrue("ParameterContext should define method()", methods.contains("method"))
+        assertTrue("ParameterContext should define declaration()", methods.contains("declaration"))
+    }
+
+    //endregion
+
+    //region Implementation-Interface relationship tests
+
+    @Test
+    fun testScriptPsiClassContextImplementsClassContext() {
+        assertTrue(
+            "ScriptPsiClassContext should implement ClassContext",
+            ClassContext::class.java.isAssignableFrom(ScriptPsiClassContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptPsiMethodContextImplementsMethodContext() {
+        assertTrue(
+            "ScriptPsiMethodContext should implement MethodContext",
+            MethodContext::class.java.isAssignableFrom(ScriptPsiMethodContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptPsiFieldContextImplementsFieldContext() {
+        assertTrue(
+            "ScriptPsiFieldContext should implement FieldContext",
+            FieldContext::class.java.isAssignableFrom(ScriptPsiFieldContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptPsiParameterContextImplementsParameterContext() {
+        assertTrue(
+            "ScriptPsiParameterContext should implement ParameterContext",
+            ParameterContext::class.java.isAssignableFrom(ScriptPsiParameterContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptPsiTypeContextImplementsClassContext() {
+        assertTrue(
+            "ScriptPsiTypeContext should implement ClassContext",
+            ClassContext::class.java.isAssignableFrom(ScriptPsiTypeContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptResolvedClassContextImplementsClassContext() {
+        assertTrue(
+            "ScriptResolvedClassContext should implement ClassContext (via ScriptPsiClassContext)",
+            ClassContext::class.java.isAssignableFrom(ScriptResolvedClassContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptResolvedMethodContextImplementsMethodContext() {
+        assertTrue(
+            "ScriptResolvedMethodContext should implement MethodContext (via ScriptPsiMethodContext)",
+            MethodContext::class.java.isAssignableFrom(ScriptResolvedMethodContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptResolvedFieldContextImplementsFieldContext() {
+        assertTrue(
+            "ScriptResolvedFieldContext should implement FieldContext (via ScriptPsiFieldContext)",
+            FieldContext::class.java.isAssignableFrom(ScriptResolvedFieldContext::class.java)
+        )
+    }
+
+    @Test
+    fun testScriptResolvedParameterContextImplementsParameterContext() {
+        assertTrue(
+            "ScriptResolvedParameterContext should implement ParameterContext (via ScriptPsiParameterContext)",
+            ParameterContext::class.java.isAssignableFrom(ScriptResolvedParameterContext::class.java)
+        )
+    }
+
+    //endregion
 }

--- a/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContextsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContextsTest.kt
@@ -487,6 +487,9 @@ class ScriptPsiContextsTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testMethodContext_ThrowsExceptions() {
+        loadJDKClass("java.io.IOException")
+        loadJDKClass("java.lang.RuntimeException")
+
         val classSource = """
             package com.test;
             public class TestClass {
@@ -662,4 +665,466 @@ class ScriptPsiContextsTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull("Parameter should have containing method", method)
         assertEquals("testMethod", method?.name())
     }
+
+    //region Interface implementation tests
+
+    fun testScriptPsiClassContext_ImplementsClassContext() {
+        val classSource = """
+            package com.test;
+            public class TestClass {}
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        assertTrue("ScriptPsiClassContext should implement ClassContext", context is ClassContext)
+    }
+
+    fun testScriptPsiMethodContext_ImplementsMethodContext() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public void testMethod() {}
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createMethodContext("com.test.TestClass", "testMethod")
+        assertTrue("ScriptPsiMethodContext should implement MethodContext", context is MethodContext)
+    }
+
+    fun testScriptPsiFieldContext_ImplementsFieldContext() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public String testField;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createFieldContext("com.test.TestClass", "testField")
+        assertTrue("ScriptPsiFieldContext should implement FieldContext", context is FieldContext)
+    }
+
+    fun testScriptPsiParameterContext_ImplementsParameterContext() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public void testMethod(String param1) {}
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val methodContext = createMethodContext("com.test.TestClass", "testMethod")
+        val paramContext = methodContext.args()[0]
+        assertTrue("ScriptPsiParameterContext should implement ParameterContext", paramContext is ParameterContext)
+    }
+
+    fun testClassContext_InterfaceMethods() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public String name;
+                public int age;
+                public void doSomething() {}
+            }
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val classContext = context as ClassContext
+
+        // Verify ClassContext interface methods are accessible
+        assertNotNull("methods() should work via ClassContext", classContext.methods())
+        assertTrue("methodCnt() should be >= 0 via ClassContext", classContext.methodCnt() >= 0)
+        assertNotNull("fields() should work via ClassContext", classContext.fields())
+        assertTrue("fieldCnt() should be >= 0 via ClassContext", classContext.fieldCnt() >= 0)
+        assertNotNull("type() should work via ClassContext", classContext.type())
+        assertFalse("isExtend() should work via ClassContext", classContext.isExtend("java.lang.List"))
+        assertFalse("isMap() should work via ClassContext", classContext.isMap())
+        assertFalse("isCollection() should work via ClassContext", classContext.isCollection())
+        assertFalse("isArray() should work via ClassContext", classContext.isArray())
+        assertFalse("isInterface() should work via ClassContext", classContext.isInterface())
+        assertFalse("isAnnotationType() should work via ClassContext", classContext.isAnnotationType())
+        assertFalse("isEnum() should work via ClassContext", classContext.isEnum())
+        assertFalse("isPrimitive() should work via ClassContext", classContext.isPrimitive())
+        assertFalse("isPrimitiveWrapper() should work via ClassContext", classContext.isPrimitiveWrapper())
+        assertFalse("isNormalType() should work via ClassContext", classContext.isNormalType())
+        assertEquals("com.test.TestClass", classContext.qualifiedName())
+        assertEquals("com.test", classContext.packageName())
+        assertTrue("isPublic() should work via ClassContext", classContext.isPublic())
+        assertFalse("isProtected() should work via ClassContext", classContext.isProtected())
+        assertFalse("isPrivate() should work via ClassContext", classContext.isPrivate())
+        assertFalse("isPackagePrivate() should work via ClassContext", classContext.isPackagePrivate())
+        assertFalse("isInnerClass() should work via ClassContext", classContext.isInnerClass())
+        assertFalse("isStatic() should work via ClassContext", classContext.isStatic())
+        assertNull("outerClass() should work via ClassContext", classContext.outerClass())
+    }
+
+    fun testMethodContext_InterfaceMethods() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public String testMethod(String param1, int param2) { return null; }
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createMethodContext("com.test.TestClass", "testMethod")
+        val methodContext = context as MethodContext
+
+        // Verify MethodContext interface methods are accessible
+        assertNotNull("returnType() should work via MethodContext", methodContext.returnType())
+        assertNotNull("type() should work via MethodContext", methodContext.type())
+        assertFalse("isVarArgs() should work via MethodContext", methodContext.isVarArgs())
+        assertEquals(2, methodContext.args().size)
+        assertEquals(2, methodContext.params().size)
+        assertEquals(2, methodContext.parameters().size)
+        assertEquals(2, methodContext.argCnt())
+        assertEquals(2, methodContext.paramCnt())
+        assertNotNull("containingClass() should work via MethodContext", methodContext.containingClass())
+        assertNotNull("defineClass() should work via MethodContext", methodContext.defineClass())
+        assertFalse("isEnumField() should work via MethodContext", methodContext.isEnumField())
+        assertFalse("isConstructor() should work via MethodContext", methodContext.isConstructor())
+        assertFalse("isOverride() should work via MethodContext", methodContext.isOverride())
+        assertFalse("isDefault() should work via MethodContext", methodContext.isDefault())
+        assertFalse("isAbstract() should work via MethodContext", methodContext.isAbstract())
+        assertFalse("isSynchronized() should work via MethodContext", methodContext.isSynchronized())
+        assertFalse("isNative() should work via MethodContext", methodContext.isNative())
+    }
+
+    fun testFieldContext_InterfaceMethods() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public String testField;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createFieldContext("com.test.TestClass", "testField")
+        val fieldContext = context as FieldContext
+
+        // Verify FieldContext interface methods are accessible
+        assertNotNull("type() should work via FieldContext", fieldContext.type())
+        assertNotNull("jsonType() should work via FieldContext", fieldContext.jsonType())
+        assertNotNull("containingClass() should work via FieldContext", fieldContext.containingClass())
+        assertNotNull("defineClass() should work via FieldContext", fieldContext.defineClass())
+        assertFalse("isEnumField() should work via FieldContext", fieldContext.isEnumField())
+        assertNull("asEnumField() should work via FieldContext", fieldContext.asEnumField())
+        assertFalse("isStatic() should work via FieldContext", fieldContext.isStatic())
+        assertFalse("isFinal() should work via FieldContext", fieldContext.isFinal())
+        assertFalse("isTransient() should work via FieldContext", fieldContext.isTransient())
+        assertFalse("isVolatile() should work via FieldContext", fieldContext.isVolatile())
+        assertNull("constantValue() should work via FieldContext", fieldContext.constantValue())
+    }
+
+    fun testParameterContext_InterfaceMethods() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public void testMethod(String param1) {}
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val methodContext = createMethodContext("com.test.TestClass", "testMethod")
+        val paramContext = methodContext.args()[0] as ParameterContext
+
+        // Verify ParameterContext interface methods are accessible
+        assertNotNull("type() should work via ParameterContext", paramContext.type())
+        assertNotNull("jsonType() should work via ParameterContext", paramContext.jsonType())
+        assertFalse("isVarArgs() should work via ParameterContext", paramContext.isVarArgs())
+        assertFalse("isFinal() should work via ParameterContext", paramContext.isFinal())
+        assertNotNull("method() should work via ParameterContext", paramContext.method())
+        assertNotNull("declaration() should work via ParameterContext", paramContext.declaration())
+    }
+
+    //endregion
+
+    //region contextType tests
+
+    fun testContextType_Class() {
+        val classSource = """
+            package com.test;
+            public class TestClass {}
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        assertEquals("class", context.contextType())
+    }
+
+    fun testContextType_Method() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public void testMethod() {}
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createMethodContext("com.test.TestClass", "testMethod")
+        assertEquals("method", context.contextType())
+    }
+
+    fun testContextType_Field() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public String testField;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val context = createFieldContext("com.test.TestClass", "testField")
+        assertEquals("field", context.contextType())
+    }
+
+    fun testContextType_Parameter() {
+        val classSource = """
+            package com.test;
+            public class TestClass {
+                public void testMethod(String param1) {}
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val methodContext = createMethodContext("com.test.TestClass", "testMethod")
+        val paramContext = methodContext.args()[0]
+        assertEquals("param", paramContext.contextType())
+    }
+
+    //endregion
+
+    //region toJson/toJson5 tests
+
+    fun testToJson_SimpleClass() {
+        val classSource = """
+            package com.test;
+            public class SimpleModel {
+                public String name;
+                public int age;
+                public boolean active;
+            }
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val json = context.toJson()
+
+        assertNotNull("toJson should not return null", json)
+        assertTrue("toJson should contain 'name'", json.contains("name"))
+        assertTrue("toJson should contain 'age'", json.contains("age"))
+        assertTrue("toJson should contain 'active'", json.contains("active"))
+        assertTrue("toJson should start with {", json.trimStart().startsWith("{"))
+    }
+
+    fun testToJson5_SimpleClass() {
+        val classSource = """
+            package com.test;
+            public class SimpleModel {
+                public String name;
+                public int age;
+                public boolean active;
+            }
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val json5 = context.toJson5()
+
+        assertNotNull("toJson5 should not return null", json5)
+        assertTrue("toJson5 should contain 'name'", json5.contains("name"))
+        assertTrue("toJson5 should contain 'age'", json5.contains("age"))
+        assertTrue("toJson5 should contain 'active'", json5.contains("active"))
+        assertTrue("toJson5 should start with {", json5.trimStart().startsWith("{"))
+    }
+
+    fun testToJson_EmptyClass() {
+        val classSource = """
+            package com.test;
+            public class EmptyClass {}
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val json = context.toJson()
+
+        assertNotNull("toJson should not return null for empty class", json)
+        assertTrue("toJson should return valid JSON", json.startsWith("{"))
+    }
+
+    fun testToJson5_EmptyClass() {
+        val classSource = """
+            package com.test;
+            public class EmptyClass {}
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val json5 = context.toJson5()
+
+        assertNotNull("toJson5 should not return null for empty class", json5)
+        assertTrue("toJson5 should return valid JSON5", json5.startsWith("{"))
+    }
+
+    fun testToJson_NestedClass() {
+        val classSource = """
+            package com.test;
+            public class OuterModel {
+                public String name;
+                public InnerModel inner;
+            }
+            public class InnerModel {
+                public String value;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val outerContext = createClassContextFromText("com.test.OuterModel", classSource)
+        val json = outerContext.toJson()
+
+        assertNotNull("toJson should not return null for nested class", json)
+        assertTrue("toJson should contain 'name'", json.contains("name"))
+        assertTrue("toJson should contain 'inner'", json.contains("inner"))
+    }
+
+    fun testToJson5_NestedClass() {
+        val classSource = """
+            package com.test;
+            public class OuterModel {
+                public String name;
+                public InnerModel inner;
+            }
+            public class InnerModel {
+                public String value;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val outerContext = createClassContextFromText("com.test.OuterModel", classSource)
+        val json5 = outerContext.toJson5()
+
+        assertNotNull("toJson5 should not return null for nested class", json5)
+        assertTrue("toJson5 should contain 'name'", json5.contains("name"))
+        assertTrue("toJson5 should contain 'inner'", json5.contains("inner"))
+    }
+
+    fun testToJson_ViaClassContextInterface() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public String name;
+            }
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val classContext = context as ClassContext
+        val json = classContext.toJson()
+
+        assertNotNull("toJson should work via ClassContext interface", json)
+        assertTrue("toJson should contain 'name'", json.contains("name"))
+    }
+
+    fun testToJson5_ViaClassContextInterface() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public String name;
+            }
+        """.trimIndent()
+
+        val context = createClassContext(classSource)
+        val classContext = context as ClassContext
+        val json5 = classContext.toJson5()
+
+        assertNotNull("toJson5 should work via ClassContext interface", json5)
+        assertTrue("toJson5 should contain 'name'", json5.contains("name"))
+    }
+
+    fun testToJson_ArrayType() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public String[] items;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val fieldContext = createFieldContext("com.test.TestModel", "items")
+        val typeContext = fieldContext.type()
+        val json = typeContext.toJson()
+
+        assertNotNull("toJson should not return null for array type", json)
+        assertTrue("toJson for array type should start with [", json.trimStart().startsWith("["))
+    }
+
+    fun testToJson5_ArrayType() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public String[] items;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val fieldContext = createFieldContext("com.test.TestModel", "items")
+        val typeContext = fieldContext.type()
+        val json5 = typeContext.toJson5()
+
+        assertNotNull("toJson5 should not return null for array type", json5)
+        assertTrue("toJson5 for array type should start with [", json5.trimStart().startsWith("["))
+    }
+
+    fun testToJson_PrimitiveType() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public int count;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val fieldContext = createFieldContext("com.test.TestModel", "count")
+        val typeContext = fieldContext.type()
+        val json = typeContext.toJson()
+
+        assertNotNull("toJson should not return null for primitive type", json)
+        assertTrue("toJson for primitive type should return a value", json.isNotEmpty())
+    }
+
+    fun testToJson5_PrimitiveType() {
+        val classSource = """
+            package com.test;
+            public class TestModel {
+                public int count;
+            }
+        """.trimIndent()
+
+        fixture.addClass(classSource)
+        val fieldContext = createFieldContext("com.test.TestModel", "count")
+        val typeContext = fieldContext.type()
+        val json5 = typeContext.toJson5()
+
+        assertNotNull("toJson5 should not return null for primitive type", json5)
+        assertTrue("toJson5 for primitive type should return a value", json5.isNotEmpty())
+    }
+
+    fun testToJson_CollectionType() {
+        loadJDKClass("java.util.List")
+        loadJDKClass("java.lang.String")
+        loadFile("model/Model.java")
+        val fieldContext = createFieldContext("com.itangcent.model.Model", "stringList")
+        val typeContext = fieldContext.type()
+        val json = typeContext.toJson()
+
+        assertNotNull("toJson should not return null for collection type", json)
+        assertTrue("toJson for collection type should start with [ but got: $json", json.trimStart().startsWith("["))
+    }
+
+    fun testToJson5_CollectionType() {
+        loadJDKClass("java.util.List")
+        loadFile("model/Model.java")
+        val fieldContext = createFieldContext("com.itangcent.model.Model", "stringList")
+        val typeContext = fieldContext.type()
+        val json5 = typeContext.toJson5()
+
+        assertNotNull("toJson5 should not return null for collection type", json5)
+        assertTrue("toJson5 for collection type should start with [ but got: $json5", json5.trimStart().startsWith("["))
+    }
+
+    //endregion
 }

--- a/src/test/kotlin/com/itangcent/easyapi/rule/parser/ClassMatchParserTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/rule/parser/ClassMatchParserTest.kt
@@ -44,6 +44,7 @@ class ClassMatchParserTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testParseExtendsMatch() = runBlocking {
+        loadJDKClass("java.util.ArrayList")
         loadFile("rule/SubClass.java", """
             package com.test.rule;
             public class SubClass extends java.util.ArrayList {}

--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
@@ -119,6 +119,7 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
 
     override fun setUp() {
         super.setUp()
+        loadCommonJDKClasses()
         val configReader = createConfigReader() ?: TestConfigReader.empty(project)
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,
@@ -199,6 +200,34 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
         }
     }
 
+    /**
+     * Loads commonly needed JDK classes into the test fixture.
+     *
+     * Called automatically by [setUp] so all test classes have access to
+     * basic JDK types. This is necessary because the light test fixture
+     * environment does not include a real JDK classpath.
+     *
+     * **Important**: Only classes that are known to be safe to load as source
+     * stubs are included here. The mock JDK already provides some core types
+     * (e.g., `java.lang.Object`, `java.lang.String`, `java.util.List`,
+     * `java.util.Map`), and loading them as source stubs would shadow the
+     * compiled versions, breaking generic type resolution and collection
+     * detection. Similarly, wrapper types like `java.lang.Integer` and
+     * `java.lang.Long` should not be loaded as source stubs because their
+     * minimal stubs interfere with generic type binding.
+     *
+     * Tests that need specific JDK classes should call [loadJDKClass]
+     * explicitly in their test methods.
+     */
+    protected fun loadCommonJDKClasses() {
+        // Annotations commonly used in test source code
+        loadJDKClass("java.lang.Override")
+        loadJDKClass("java.lang.Deprecated")
+        loadJDKClass("java.lang.SuppressWarnings")
+        // Common interface
+        loadJDKClass("java.io.Serializable")
+    }
+
     protected fun loadSource(clazz: Class<*>): PsiClass {
         val className = clazz.simpleName
         val packageName = clazz.`package`.name
@@ -218,6 +247,60 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
         return findClass(clazz.name)!!
     }
 
+    /**
+     * Loads a JDK class into the test fixture's virtual file system with proper inheritance.
+     *
+     * In the light test fixture environment, JDK classes are not available by default.
+     * This method loads a JDK class by its fully qualified name, first checking for a
+     * pre-written stub in `/jdk/<simpleName>.java` resources, then falling back to a
+     * built-in stub from [JDK_STUBS], and finally generating a minimal empty stub.
+     *
+     * Dependencies (superclasses/interfaces) are automatically loaded first to ensure
+     * the PSI resolver can traverse the full inheritance chain.
+     *
+     * Example usage:
+     * ```kotlin
+     * loadJDKClass("java.util.ArrayList")  // loads ArrayList + all dependencies
+     * loadJDKClass("java.util.List")       // loads List + Collection + Iterable
+     * ```
+     *
+     * @param fqn the fully qualified name of the JDK class (e.g., "java.util.List")
+     * @return the loaded PsiClass
+     */
+    protected fun loadJDKClass(fqn: String): PsiClass {
+        val existing = findClass(fqn)
+        if (existing != null) return existing
+
+        val stub = JDK_STUBS[fqn]
+        val content = if (stub != null) {
+            // Load dependencies first so the PSI resolver can resolve supertypes
+            for (dep in stub.dependencies) {
+                loadJDKClass(dep)
+            }
+            stub.source
+        } else {
+            val lastDot = fqn.lastIndexOf('.')
+            val packageName = fqn.substring(0, lastDot)
+            val className = fqn.substring(lastDot + 1)
+            // Try resource file before generating empty stub
+            val resourceStream = javaClass.getResourceAsStream("/jdk/$className.java")
+            if (resourceStream != null) {
+                val reader = InputStreamReader(resourceStream, Charsets.UTF_8)
+                val text = reader.readText()
+                reader.close()
+                text
+            } else {
+                "package $packageName; public class $className {}"
+            }
+        }
+
+        val path = fqn.replace('.', '/') + ".java"
+        ApplicationManager.getApplication().runWriteAction<PsiFile> {
+            myFixture.addFileToProject(path, content)
+        }
+        return findClass(fqn) ?: throw AssertionError("Failed to load JDK class: $fqn")
+    }
+
     private fun generateStubClass(clazz: Class<*>): String {
         val packageName = clazz.`package`.name
         val className = clazz.simpleName
@@ -227,5 +310,213 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
             clazz.isArray -> "package $packageName; public class $className {}"
             else -> "package $packageName; public class $className {}"
         }
+    }
+
+    /**
+     * Pre-built JDK class stubs with correct inheritance hierarchies.
+     *
+     * Each entry maps a fully qualified name to a [JdkStub] containing the source
+     * and a list of dependency FQNs that must be loaded first. This ensures the
+     * PSI resolver can traverse the complete type hierarchy (e.g., ArrayList →
+     * AbstractList → AbstractCollection → Collection → Iterable).
+     */
+    private data class JdkStub(val source: String, val dependencies: List<String> = emptyList())
+
+    private val JDK_STUBS: Map<String, JdkStub> by lazy {
+        mapOf(
+            // java.lang
+            "java.lang.Iterable" to JdkStub(
+                "package java.lang; public interface Iterable<T> {}"
+            ),
+            "java.lang.Comparable" to JdkStub(
+                "package java.lang; public interface Comparable<T> {}"
+            ),
+            // java.util - Collection hierarchy
+            "java.util.Collection" to JdkStub(
+                "package java.util; public interface Collection<E> extends Iterable<E> {}",
+                listOf("java.lang.Iterable")
+            ),
+            "java.util.List" to JdkStub(
+                "package java.util; public interface List<E> extends Collection<E> {}",
+                listOf("java.util.Collection")
+            ),
+            "java.util.Set" to JdkStub(
+                "package java.util; public interface Set<E> extends Collection<E> {}",
+                listOf("java.util.Collection")
+            ),
+            "java.util.SortedSet" to JdkStub(
+                "package java.util; public interface SortedSet<E> extends Set<E> {}",
+                listOf("java.util.Set")
+            ),
+            "java.util.NavigableSet" to JdkStub(
+                "package java.util; public interface NavigableSet<E> extends SortedSet<E> {}",
+                listOf("java.util.SortedSet")
+            ),
+            "java.util.Queue" to JdkStub(
+                "package java.util; public interface Queue<E> extends Collection<E> {}",
+                listOf("java.util.Collection")
+            ),
+            "java.util.Deque" to JdkStub(
+                "package java.util; public interface Deque<E> extends Queue<E> {}",
+                listOf("java.util.Queue")
+            ),
+            "java.util.AbstractCollection" to JdkStub(
+                "package java.util; public abstract class AbstractCollection<E> implements Collection<E> {}",
+                listOf("java.util.Collection")
+            ),
+            "java.util.AbstractList" to JdkStub(
+                "package java.util; public abstract class AbstractList<E> extends AbstractCollection<E> implements List<E> {}",
+                listOf("java.util.AbstractCollection", "java.util.List")
+            ),
+            "java.util.AbstractSet" to JdkStub(
+                "package java.util; public abstract class AbstractSet<E> extends AbstractCollection<E> implements Set<E> {}",
+                listOf("java.util.AbstractCollection", "java.util.Set")
+            ),
+            "java.util.AbstractSequentialList" to JdkStub(
+                "package java.util; public abstract class AbstractSequentialList<E> extends AbstractList<E> {}",
+                listOf("java.util.AbstractList")
+            ),
+            "java.util.ArrayList" to JdkStub(
+                "package java.util; public class ArrayList<E> extends AbstractList<E> implements List<E>, RandomAccess {}",
+                listOf("java.util.AbstractList", "java.util.List")
+            ),
+            "java.util.LinkedList" to JdkStub(
+                "package java.util; public class LinkedList<E> extends AbstractSequentialList<E> implements List<E>, Deque {}",
+                listOf("java.util.AbstractSequentialList", "java.util.List", "java.util.Deque")
+            ),
+            "java.util.HashSet" to JdkStub(
+                "package java.util; public class HashSet<E> extends AbstractSet<E> implements Set<E> {}",
+                listOf("java.util.AbstractSet", "java.util.Set")
+            ),
+            "java.util.LinkedHashSet" to JdkStub(
+                "package java.util; public class LinkedHashSet<E> extends HashSet<E> implements Set<E> {}",
+                listOf("java.util.HashSet", "java.util.Set")
+            ),
+            "java.util.TreeSet" to JdkStub(
+                "package java.util; public class TreeSet<E> extends AbstractSet<E> implements NavigableSet<E> {}",
+                listOf("java.util.AbstractSet", "java.util.NavigableSet")
+            ),
+            "java.util.Vector" to JdkStub(
+                "package java.util; public class Vector<E> extends AbstractList<E> implements List<E> {}",
+                listOf("java.util.AbstractList", "java.util.List")
+            ),
+            "java.util.Stack" to JdkStub(
+                "package java.util; public class Stack<E> extends Vector<E> {}",
+                listOf("java.util.Vector")
+            ),
+            "java.util.ArrayDeque" to JdkStub(
+                "package java.util; public class ArrayDeque<E> extends AbstractCollection<E> implements Deque<E> {}",
+                listOf("java.util.AbstractCollection", "java.util.Deque")
+            ),
+            "java.util.Collections" to JdkStub(
+                "package java.util; public class Collections {}"
+            ),
+            "java.util.RandomAccess" to JdkStub(
+                "package java.util; public interface RandomAccess {}"
+            ),
+            // java.util - Map hierarchy
+            "java.util.Map" to JdkStub(
+                "package java.util; public interface Map<K, V> {}"
+            ),
+            "java.util.SortedMap" to JdkStub(
+                "package java.util; public interface SortedMap<K, V> extends Map<K, V> {}",
+                listOf("java.util.Map")
+            ),
+            "java.util.NavigableMap" to JdkStub(
+                "package java.util; public interface NavigableMap<K, V> extends SortedMap<K, V> {}",
+                listOf("java.util.SortedMap")
+            ),
+            "java.util.AbstractMap" to JdkStub(
+                "package java.util; public abstract class AbstractMap<K, V> implements Map<K, V> {}",
+                listOf("java.util.Map")
+            ),
+            "java.util.HashMap" to JdkStub(
+                "package java.util; public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {}",
+                listOf("java.util.AbstractMap", "java.util.Map")
+            ),
+            "java.util.LinkedHashMap" to JdkStub(
+                "package java.util; public class LinkedHashMap<K, V> extends HashMap<K, V> implements Map<K, V> {}",
+                listOf("java.util.HashMap", "java.util.Map")
+            ),
+            "java.util.TreeMap" to JdkStub(
+                "package java.util; public class TreeMap<K, V> extends AbstractMap<K, V> implements NavigableMap<K, V> {}",
+                listOf("java.util.AbstractMap", "java.util.NavigableMap")
+            ),
+            // java.util.concurrent - Map hierarchy
+            "java.util.concurrent.ConcurrentMap" to JdkStub(
+                "package java.util.concurrent; public interface ConcurrentMap<K, V> extends Map<K, V> {}",
+                listOf("java.util.Map")
+            ),
+            "java.util.concurrent.ConcurrentHashMap" to JdkStub(
+                "package java.util.concurrent; public class ConcurrentHashMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {}",
+                listOf("java.util.AbstractMap", "java.util.concurrent.ConcurrentMap")
+            ),
+            // java.lang - core types
+            "java.lang.Object" to JdkStub(
+                "package java.lang; public class Object {}"
+            ),
+            "java.lang.Enum" to JdkStub(
+                "package java.lang; public abstract class Enum<E extends Enum<E>> implements Comparable<E> {}",
+                listOf("java.lang.Comparable")
+            ),
+            "java.lang.String" to JdkStub(
+                "package java.lang; public final class String implements Comparable<String>, CharSequence {}",
+                listOf("java.lang.Comparable")
+            ),
+            "java.lang.CharSequence" to JdkStub(
+                "package java.lang; public interface CharSequence {}"
+            ),
+            "java.lang.Number" to JdkStub(
+                "package java.lang; public abstract class Number implements java.io.Serializable {}"
+            ),
+            "java.lang.Integer" to JdkStub(
+                "package java.lang; public final class Integer extends Number implements Comparable<Integer> {}",
+                listOf("java.lang.Number", "java.lang.Comparable")
+            ),
+            "java.lang.Long" to JdkStub(
+                "package java.lang; public final class Long extends Number implements Comparable<Long> {}",
+                listOf("java.lang.Number", "java.lang.Comparable")
+            ),
+            "java.lang.Double" to JdkStub(
+                "package java.lang; public final class Double extends Number implements Comparable<Double> {}",
+                listOf("java.lang.Number", "java.lang.Comparable")
+            ),
+            "java.lang.Float" to JdkStub(
+                "package java.lang; public final class Float extends Number implements Comparable<Float> {}",
+                listOf("java.lang.Number", "java.lang.Comparable")
+            ),
+            "java.lang.Boolean" to JdkStub(
+                "package java.lang; public final class Boolean implements Comparable<Boolean> {}",
+                listOf("java.lang.Comparable")
+            ),
+            "java.lang.Throwable" to JdkStub(
+                "package java.lang; public class Throwable {}"
+            ),
+            "java.lang.Exception" to JdkStub(
+                "package java.lang; public class Exception extends Throwable {}",
+                listOf("java.lang.Throwable")
+            ),
+            "java.lang.RuntimeException" to JdkStub(
+                "package java.lang; public class RuntimeException extends Exception {}",
+                listOf("java.lang.Exception")
+            ),
+            "java.lang.Deprecated" to JdkStub(
+                "package java.lang; public @interface Deprecated {}"
+            ),
+            "java.lang.Override" to JdkStub(
+                "package java.lang; public @interface Override {}"
+            ),
+            "java.lang.SuppressWarnings" to JdkStub(
+                "package java.lang; public @interface SuppressWarnings {}"
+            ),
+            // java.io
+            "java.io.Serializable" to JdkStub(
+                "package java.io; public interface Serializable {}"
+            ),
+            "java.io.IOException" to JdkStub(
+                "package java.io; public class IOException extends Exception {}",
+                listOf("java.lang.Exception")
+            ),
+        )
     }
 }


### PR DESCRIPTION
Script class type contexts now support toJson() and toJson5() methods for JSON serialization.

Changes:
- Define ClassContext, MethodContext, FieldContext, ParameterContext interfaces
- Make context classes implement corresponding interfaces
- Add toJson/toJson5 to ClassContext interface and implementations
- Remove TypeContext; ScriptPsiTypeContext now implements ClassContext
- Fix buildObjectModel(PsiClass) to delegate to buildObjectModel(ResolvedType)
- Add comprehensive tests