### PR TITLE
fix: channel export actions missing from Keymap settings

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelActionInitActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelActionInitActivity.kt
@@ -1,0 +1,14 @@
+package com.itangcent.easyapi.ide.action
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Eagerly registers channel export actions with the IntelliJ action system
+ * at project startup so they appear in Settings > Keymap.
+ */
+class ChannelActionInitActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        ChannelQuickActionGroup.ensureActionsRegistered()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelQuickActionGroup.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelQuickActionGroup.kt
@@ -1,19 +1,60 @@
 package com.itangcent.easyapi.ide.action
 
-import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.itangcent.easyapi.exporter.channel.ApiChannelRegistry
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.extensions.PluginId
+import com.itangcent.easyapi.exporter.channel.ApiChannel
 import com.itangcent.easyapi.logging.IdeaLog
 
-class ChannelQuickActionGroup : ActionGroup(), IdeaLog {
+/**
+ * Dynamic action group that exposes channel-specific export actions.
+ *
+ * Each [ChannelExportAction] is registered with [ActionManager] using a stable ID
+ * and the plugin's [PluginId], so IntelliJ's Keymap system can:
+ * - Discover the action (stable ID)
+ * - Place it under the "EasyYapi" category (plugin ID)
+ *
+ * Registration is triggered eagerly via [ensureActionsRegistered] (called from
+ * [ChannelActionInitActivity]) and lazily via [getChildren] as a fallback.
+ */
+class ChannelQuickActionGroup : DefaultActionGroup(), IdeaLog {
+
+    companion object {
+        const val ACTION_ID_PREFIX = "com.itangcent.easy_api.actions.channel."
+        private const val GROUP_ID = "com.itangcent.idea.easy_api.actions.ChannelQuickExportGroup"
+        private val PLUGIN_ID = PluginId.getId("com.itangcent.idea.plugin.easy-yapi")
+
+        private val CHANNEL_EP =
+            ExtensionPointName.create<ApiChannel>("com.itangcent.idea.plugin.easy-yapi.apiChannel")
+
+        /**
+         * Registers all channel actions with [ActionManager] (with plugin ID for
+         * keymap categorization) and adds them as children of this group.
+         * Safe to call multiple times (idempotent).
+         */
+        fun ensureActionsRegistered() {
+            val actionManager = ActionManager.getInstance()
+            val group = actionManager.getAction(GROUP_ID) as? ChannelQuickActionGroup ?: return
+
+            CHANNEL_EP.extensionList
+                .filter { it.exposeAsAction }
+                .forEach { channel ->
+                    val actionId = ACTION_ID_PREFIX + channel.id
+                    if (actionManager.getAction(actionId) == null) {
+                        val action = ChannelExportAction(channel.id, channel.actionText ?: channel.displayName)
+                        actionManager.registerAction(actionId, action, PLUGIN_ID)
+                        group.addAction(action)
+                    }
+                }
+        }
+    }
 
     override fun getChildren(e: AnActionEvent?): Array<AnAction> {
-        val project = e?.project ?: return emptyArray()
-        val registry = ApiChannelRegistry.getInstance(project)
-        return registry.getActionChannels()
-            .map { channel -> ChannelExportAction(channel.id, channel.actionText ?: channel.displayName) }
-            .toTypedArray()
+        ensureActionsRegistered()
+        return super.getChildren(e)
     }
 
     override fun update(e: AnActionEvent) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -69,6 +69,7 @@
         <projectService serviceImplementation="com.itangcent.easyapi.cache.VcsBranchChangeListener"/>
 
         <postStartupActivity implementation="com.itangcent.easyapi.ide.ApiIndexStartupActivity"/>
+        <postStartupActivity implementation="com.itangcent.easyapi.ide.action.ChannelActionInitActivity"/>
 
         <projectConfigurable groupId="null"
                              displayName="EasyApi"


### PR DESCRIPTION
## Problem

Channel export actions (e.g., "Export to YApi") were not visible in IntelliJ's Keymap settings, making it impossible to configure keyboard shortcuts for them. This was reported in #1370.

## Root Cause

Actions were registered lazily inside `ChannelQuickActionGroup.getChildren()`, which only runs when the group action is first activated. If a user opens Keymap settings before activating the group, the actions don't exist yet and can't be found or assigned shortcuts.

## Fix

- Eagerly register channel actions at project startup via `ChannelActionInitActivity` (a `ProjectActivity`)
- Register actions with `PluginId` and add them to the group using `group.addAction(action, actionManager)` to establish proper parent-child relationships
- This ensures actions appear under the "EasyYapi" group in Keymap settings immediately

Fixes #1370