### PR TITLE
fix : method.return support generic canonical types

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -2,21 +2,19 @@ package com.itangcent.easyapi.exporter
 
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
-import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.exporter.model.ApiHeader
 import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.psi.PsiClassHelper
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
-import com.itangcent.easyapi.psi.helper.SourceHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.PrimitiveKind
 import com.itangcent.easyapi.psi.type.ResolvedType
+import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.Settings
 
@@ -60,8 +58,8 @@ class EndpointBuilder(private val project: Project) {
      * Builds the response body model from an already-resolved return type.
      *
      * Resolution order:
-     * 1. **`method.return` rule** — if set, resolves the class by qualified name and delegates
-     *    to [modelBuilder] to construct the model.
+     * 1. **`method.return` rule** — if set, resolves the configured canonical type
+     *    and builds the model from the resolved type.
      * 2. **Resolved return type** — uses [PsiClassHelper.buildObjectModel] with the
      *    already-resolved type (generics already substituted by the caller).
      * 3. **`method.return.main` rule** — after building the model, applies the `@return` doc
@@ -82,11 +80,12 @@ class EndpointBuilder(private val project: Project) {
         val returnTypeByRule = metadataResolver.resolveMethodReturn(method)
         if (!returnTypeByRule.isNullOrBlank()) {
             LOG.info("buildResponseBody: method.return rule override: $returnTypeByRule")
-            val psiClass = JavaPsiFacade.getInstance(project)
-                .findClass(returnTypeByRule.trim(), GlobalSearchScope.allScope(project))
-                ?.let { SourceHelper.getInstance(project).getSourceClassSync(it) }
-            if (psiClass != null) {
-                return runCatching { modelBuilder.buildModel(psiClass) }.getOrNull()
+            val responseModel = runCatching {
+                val resolvedType = TypeResolver.resolveFromCanonicalText(returnTypeByRule.trim(), project, method)
+                PsiClassHelper.getInstance(project).buildObjectModel(resolvedType)
+            }.getOrNull()
+            if (responseModel != null) {
+                return applyReturnMain(method, responseModel)
             }
         }
 

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/MethodReturnEndpointBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/MethodReturnEndpointBuilderTest.kt
@@ -1,0 +1,85 @@
+package com.itangcent.easyapi.exporter
+
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.type.TypeResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.*
+
+abstract class MethodReturnEndpointBuilderTestBase : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var endpointBuilder: EndpointBuilder
+
+    override fun setUp() {
+        super.setUp()
+        endpointBuilder = EndpointBuilder.getInstance(project)
+    }
+
+    protected suspend fun buildResponseBody(): ObjectModel.Object {
+        loadFile("model/IResult.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile(
+            "api/springmvc/MethodReturnCtrl.java",
+            """
+            package com.itangcent.springboot.demo.controller;
+
+            import com.itangcent.model.UserInfo;
+
+            public class MethodReturnCtrl {
+                public UserInfo getUser() {
+                    return new UserInfo();
+                }
+            }
+            """.trimIndent()
+        )
+
+        val psiClass = findClass("com.itangcent.springboot.demo.controller.MethodReturnCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val resolvedReturnType = TypeResolver.resolve(method.returnType!!)
+
+        return endpointBuilder.buildResponseBody(method, resolvedReturnType)!!.asObject()!!
+    }
+}
+
+class MethodReturnBareClassEndpointBuilderTest : MethodReturnEndpointBuilderTestBase() {
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        method.return=groovy:"com.itangcent.model.Result"
+        method.return.main=groovy:"data"
+        """.trimIndent()
+    )
+
+    fun testMethodReturnSupportsBareClassName() = runTest {
+        val responseObj = buildResponseBody()
+
+        assertTrue(responseObj.fields.containsKey("code"))
+        assertTrue(responseObj.fields.containsKey("msg"))
+        assertTrue(responseObj.fields.containsKey("data"))
+    }
+}
+
+class MethodReturnGenericEndpointBuilderTest : MethodReturnEndpointBuilderTestBase() {
+
+    override fun createConfigReader() = TestConfigReader.fromConfigText(
+        project,
+        """
+        method.return=groovy:"com.itangcent.model.Result<" + it.returnType().name() + ">"
+        method.return.main=groovy:"data"
+        """.trimIndent()
+    )
+
+    fun testMethodReturnSupportsGenericCanonicalType() = runTest {
+        val responseObj = buildResponseBody()
+
+        assertTrue(responseObj.fields.containsKey("code"))
+        assertTrue(responseObj.fields.containsKey("msg"))
+
+        val dataObj = responseObj.fields["data"]!!.model as ObjectModel.Object
+        assertTrue(dataObj.fields.containsKey("id"))
+        assertTrue(dataObj.fields.containsKey("name"))
+        assertTrue(dataObj.fields.containsKey("age"))
+    }
+}


### PR DESCRIPTION
## Summary

Fix `method.return` so it can resolve generic canonical return types, not only bare class names.

## Changes

- Updated `method.return` response model construction to parse the configured value as a canonical type via `TypeResolver.resolveFromCanonicalText(...)`.
- Reused `PsiClassHelper.buildObjectModel(resolvedType)` so rule-based return overrides follow the same generic-aware path as normal method return types.
- Preserved support for bare class names like:
  ```properties
  method.return=groovy:"com.itangcent.model.Result"