### PR TITLE
build: fix github workflow permissions and add missing configs

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,8 +1,12 @@
 name: 'Auto Label PR'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   label-pr:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   package-and-comment:
     runs-on: ubuntu-latest
@@ -82,6 +87,7 @@ jobs:
       - name: Comment on target issue
         if: steps.check_issue.outputs.has_issue == 'true'
         uses: actions/github-script@v6
+        continue-on-error: true
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -98,6 +104,7 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v6
+        continue-on-error: true
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,9 +1,14 @@
 name: 'Update Release PR'
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
 
 jobs:
   update-pr:
@@ -13,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Check if branch is release branch and add label if needed
         uses: actions/github-script@v6


### PR DESCRIPTION
1. update trigger event from pull_request to pull_request_target for cross-repo workflow access
2. add required GITHUB_TOKEN permissions for each workflow
3. add repository field to checkout action for pr-package.yml
4. add continue-on-error to comment steps in pr-package.yml