### PR TITLE
fix: make ApiIndex.invalidate() atomic to prevent race condition

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/cache/api/ApiIndex.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/cache/api/ApiIndex.kt
@@ -233,10 +233,12 @@ class ApiIndex {
      *
      * The cache will be repopulated by the next scan from [ApiIndexManager].
      */
-    fun invalidate() {
-        LOG.debug("Cache invalidated")
-        cacheValid.set(false)
-        endpointsByClass = emptyMap()
+    suspend fun invalidate() {
+        cacheMutex.withLock {
+            LOG.debug("Cache invalidated")
+            cacheValid.set(false)
+            endpointsByClass = emptyMap()
+        }
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/cache/api/ApiIndexManagerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/cache/api/ApiIndexManagerTest.kt
@@ -1,12 +1,12 @@
 package com.itangcent.easyapi.cache.api
 
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
-import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 
 class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -18,7 +18,7 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
         loadTestFiles()
         apiIndexManager = ApiIndexManager.getInstance(project)
         apiIndex = ApiIndex.getInstance(project)
-        apiIndex.invalidate()
+        runBlocking { apiIndex.invalidate() }
         apiIndexManager.start(triggerInitialScan = false)
     }
 


### PR DESCRIPTION
## Changes

- fix: make ApiIndex.invalidate() atomic to prevent race condition

## Details

`ApiIndex.invalidate()` was not synchronized with the mutex-protected `updateEndpoints()`, causing a race where a scan could complete between `cacheValid.set(false)` and `endpointsByClass = emptyMap()`, leaving the cache in an inconsistent state (valid but empty).

This caused `testMultipleRequestScanDoesNotDuplicate` to fail intermittently with `firstCount=0, secondCount=11`.

**Fix:** Made `invalidate()` acquire `cacheMutex.withLock` so it is atomic with respect to `updateEndpoints()`. Updated callers to handle the new `suspend` signature.
