### PR TITLE
test: replace fragile delay with waitForClass to fix flaky test

### DIFF
--- a/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/testFramework/EasyApiLightCodeInsightFixtureTestCase.kt
@@ -15,6 +15,7 @@ import com.itangcent.easyapi.core.event.ActionCompletedTopic
 import com.itangcent.easyapi.core.event.ActionCompletedTopic.Companion.syncPublish
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.settings.SettingBinder
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.InputStreamReader
 
@@ -157,6 +158,40 @@ abstract class EasyApiLightCodeInsightFixtureTestCase : LightJavaCodeInsightFixt
 
     protected fun findMethod(psiClass: PsiClass, name: String): PsiMethod? {
         return psiClass.findMethodsByName(name, false).firstOrNull() as? PsiMethod
+    }
+
+    /**
+     * Waits until a class with the given qualified name is findable via [JavaPsiFacade].
+     *
+     * In the light test fixture, [addFileToProject] creates the VirtualFile and PsiFile
+     * immediately, but [JavaPsiFacade.findClass] depends on the PSI index which updates
+     * asynchronously. A fixed [delay] is fragile because the indexing latency is
+     * non-deterministic. This method polls with short intervals until the class is
+     * resolvable, or throws after [timeoutMs].
+     *
+     * @param qualifiedName the fully qualified class name to wait for
+     * @param timeoutMs maximum time to wait in milliseconds (default 5000)
+     * @param pollIntervalMs interval between polls in milliseconds (default 50)
+     * @return the found PsiClass
+     * @throws AssertionError if the class is not found within the timeout
+     */
+    protected suspend fun waitForClass(
+        qualifiedName: String,
+        timeoutMs: Long = 5000,
+        pollIntervalMs: Long = 50
+    ): PsiClass {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (true) {
+            val psiClass = readSync {
+                JavaPsiFacade.getInstance(project)
+                    .findClass(qualifiedName, GlobalSearchScope.allScope(project))
+            }
+            if (psiClass != null) return psiClass
+            if (System.currentTimeMillis() >= deadline) {
+                throw AssertionError("Class '$qualifiedName' not found within ${timeoutMs}ms")
+            }
+            delay(pollIntervalMs)
+        }
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/util/ide/ProjectClassAvailabilityServiceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/ide/ProjectClassAvailabilityServiceTest.kt
@@ -1,8 +1,6 @@
 package com.itangcent.easyapi.util.ide
 
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
-import kotlinx.coroutines.delay
-import kotlin.time.Duration.Companion.milliseconds
 
 class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -11,11 +9,12 @@ class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCa
     override fun setUp() {
         super.setUp()
         availabilityService = ProjectClassAvailabilityService.getInstance(project)
+        availabilityService.clearCache()
     }
 
     fun testHasClassInProjectReturnsTrueForExistingClass() = runTest {
         loadFile("spring/RestController.java")
-        delay(1000.milliseconds)
+        waitForClass("org.springframework.web.bind.annotation.RestController")
         
         val hasClass = availabilityService.hasClassInProject(
             "org.springframework.web.bind.annotation.RestController"
@@ -32,7 +31,7 @@ class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCa
 
     fun testHasAnyClassInProjectReturnsTrueWhenAnyExists() = runTest {
         loadFile("spring/RestController.java")
-        delay(1000.milliseconds)
+        waitForClass("org.springframework.web.bind.annotation.RestController")
         
         val hasAny = availabilityService.hasAnyClassInProject(
             setOf(
@@ -55,7 +54,7 @@ class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCa
 
     fun testCacheIsUsedForRepeatedCalls() = runTest {
         loadFile("spring/RestController.java")
-        delay(1000.milliseconds)
+        waitForClass("org.springframework.web.bind.annotation.RestController")
         
         val qName = "org.springframework.web.bind.annotation.RestController"
         
@@ -68,7 +67,7 @@ class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCa
 
     fun testClearCache() = runTest {
         loadFile("spring/RestController.java")
-        delay(1000.milliseconds)
+        waitForClass("org.springframework.web.bind.annotation.RestController")
         
         val qName = "org.springframework.web.bind.annotation.RestController"
         
@@ -84,7 +83,8 @@ class ProjectClassAvailabilityServiceTest : EasyApiLightCodeInsightFixtureTestCa
     fun testMultipleFrameworks() = runTest {
         loadFile("spring/RestController.java")
         loadFile("spring/GetMapping.java")
-        delay(1000.milliseconds)
+        waitForClass("org.springframework.web.bind.annotation.RestController")
+        waitForClass("org.springframework.web.bind.annotation.GetMapping")
         
         val springAnnotations = setOf(
             "org.springframework.web.bind.annotation.RestController",


### PR DESCRIPTION
## Changes

- fix: replace fragile delay with waitForClass to fix flaky test

## Details

`ProjectClassAvailabilityServiceTest` was intermittently failing because `addFileToProject` creates the VirtualFile immediately but `JavaPsiFacade.findClass` depends on the PSI index which updates asynchronously. The fixed `delay(1000ms)` was not always sufficient.

Added `waitForClass` utility to `EasyApiLightCodeInsightFixtureTestCase` that polls `JavaPsiFacade.findClass()` every 50ms until the class is resolvable, with a 5-second timeout for slow CI environments. This is more robust than a blind fixed delay — it's fast when indexing is quick and tolerant when it's slow.