### PR TITLE
feat: make yapiInfo mutable so save.before scripts can customize YAPI exports

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
@@ -10,6 +10,7 @@ import com.itangcent.easyapi.http.HttpRequest
 import com.itangcent.easyapi.http.HttpResponse
 import com.itangcent.easyapi.http.KeyValue
 import com.itangcent.easyapi.util.json.GsonUtils
+import com.itangcent.easyapi.util.markdown.BundledMarkdownRender
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URLEncoder
@@ -34,7 +35,8 @@ import java.net.URLEncoder
 class DefaultYapiApiClient(
     private val serverUrl: String,
     private val token: String,
-    private val httpClient: HttpClient
+    private val httpClient: HttpClient,
+    private val yapiFormatter: YapiFormatter = YapiFormatter(markdownRender = BundledMarkdownRender())
 ) : YapiApiClient {
 
     /** Cached project ID for this client instance. Populated on first [getProjectId] call. */
@@ -233,7 +235,7 @@ class DefaultYapiApiClient(
                         url = "$serverUrl$SAVE_API",
                         method = "POST",
                         headers = listOf("Content-Type" to "application/json"),
-                        body = buildApiDocBody(doc, catId, existingId)
+                        body = yapiFormatter.buildApiDocBody(doc, token, catId, existingId)
                     )
                 )
                 parseResponse(resp) { Unit }
@@ -271,7 +273,7 @@ class DefaultYapiApiClient(
                         url = "$serverUrl$SAVE_API",
                         method = "POST",
                         headers = listOf("Content-Type" to "application/json"),
-                        body = buildApiDocBody(doc, catId, existingId)
+                        body = yapiFormatter.buildApiDocBody(doc, token, catId, existingId)
                     )
                 )
                 parseResponse(resp) { Unit }
@@ -335,55 +337,6 @@ class DefaultYapiApiClient(
          */
         @Volatile
         private var apiPageLimit: Int = 1000
-    }
-
-    /**
-     * Serializes [doc] and [catId] into the JSON body expected by [SAVE_API].
-     * If [existingId] is provided it is included as `id`, triggering an update instead of insert.
-     */
-    private fun buildApiDocBody(doc: YapiApiDoc, catId: String, existingId: String? = null): String {
-        val map = mutableMapOf<String, Any?>(
-            "token" to token,
-            "catid" to catId,
-            "title" to doc.title,
-            "path" to doc.path,
-            "method" to doc.method,
-            "desc" to doc.desc,
-            "markdown" to doc.markdown,
-            "status" to (doc.status ?: "done"),
-            "req_body_is_json_schema" to doc.reqBodyIsJsonSchema,
-            "res_body_is_json_schema" to doc.resBodyIsJsonSchema,
-            "req_headers" to (doc.reqHeaders?.map {
-                linkedMapOf(
-                    "name" to it.name, "value" to (it.value ?: ""), "desc" to (it.desc ?: ""),
-                    "example" to (it.example ?: it.value ?: ""), "required" to it.required
-                )
-            } ?: emptyList<Any>()),
-            "req_query" to (doc.reqQuery?.map {
-                linkedMapOf(
-                    "name" to it.name, "value" to (it.value ?: ""), "example" to (it.example ?: it.value ?: ""),
-                    "desc" to (it.desc ?: ""), "required" to it.required
-                )
-            } ?: emptyList<Any>()),
-            "req_params" to (doc.reqParams?.map {
-                linkedMapOf("name" to it.name, "example" to (it.example ?: ""), "desc" to (it.desc ?: ""))
-            } ?: emptyList<Any>()),
-            "req_body_other" to (doc.reqBodyOther ?: ""),
-            "res_body" to (doc.resBody ?: ""),
-            "req_body_form" to (doc.reqBodyForm?.map {
-                linkedMapOf(
-                    "name" to it.name, "example" to (it.example ?: ""), "type" to it.type,
-                    "required" to it.required, "desc" to (it.desc ?: "")
-                )
-            } ?: emptyList<Any>())
-        )
-        doc.reqBodyType?.let { map["req_body_type"] = it }
-        doc.resBodyType?.let { map["res_body_type"] = it }
-        doc.open?.let { map["api_opened"] = it }
-        doc.tag?.let { map["tag"] = it }
-        doc.tags?.let { map["tags"] = it }
-        existingId?.let { map["id"] = it }
-        return GsonUtils.toJson(map)
     }
 
     private fun enc(value: String): String = URLEncoder.encode(value, "UTF-8")

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/JsonSchemaBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/JsonSchemaBuilder.kt
@@ -81,7 +81,7 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
             val propSchema = linkedMapOf<String, Any?>()
 
             param.type.rawType().let { type ->
-                propSchema["type"] = mapJsonTypeToSchemaType(type)
+                propSchema["type"] = JsonType.toSchemaType(type)
             }
 
             param.description?.let { desc ->
@@ -145,7 +145,7 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
      * @return A schema map with type
      */
     private fun buildSingleSchema(model: ObjectModel.Single): LinkedHashMap<String, Any?> {
-        return linkedMapOf("type" to mapJsonTypeToSchemaType(model.type))
+        return linkedMapOf("type" to JsonType.toSchemaType(model.type))
     }
 
     /**
@@ -273,27 +273,5 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
             "type" to "object",
             "additionalProperties" to buildSchema(model.valueType, visitCounts)
         )
-    }
-
-    /**
-     * Maps a JSON type string to JSON Schema type.
-     * Handles standard JSON types plus date/datetime extensions.
-     * 
-     * @param type The JSON type string
-     * @return The corresponding JSON Schema type
-     */
-    private fun mapJsonTypeToSchemaType(type: String): String {
-        return when (type) {
-            JsonType.STRING, JsonType.DATE, JsonType.DATETIME, JsonType.FILE -> "string"
-            JsonType.SHORT, JsonType.INT, JsonType.LONG -> "integer"
-            JsonType.FLOAT, JsonType.DOUBLE -> "number"
-            JsonType.BOOLEAN -> "boolean"
-            JsonType.ARRAY -> "array"
-            JsonType.OBJECT -> "object"
-            "null" -> "null"
-            "text" -> "string"
-            "file" -> "string"
-            else -> "string"
-        }
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
@@ -8,6 +8,7 @@ import com.itangcent.easyapi.exporter.model.ExportMetadata
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.exporter.model.path
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiApiDoc
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.settings.SettingBinder

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatter.kt
@@ -4,13 +4,16 @@ import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.model.path
+import com.itangcent.easyapi.exporter.yapi.model.Extension
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiApiDoc
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiFormParam
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiHeader
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiPathParam
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiQuery
 import com.itangcent.easyapi.exporter.yapi.model.YapiApiDoc
-import com.itangcent.easyapi.exporter.yapi.model.YapiFormParam
-import com.itangcent.easyapi.exporter.yapi.model.YapiHeader
-import com.itangcent.easyapi.exporter.yapi.model.YapiPathParam
-import com.itangcent.easyapi.exporter.yapi.model.YapiQuery
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.util.json.GsonUtils
 import com.itangcent.easyapi.util.markdown.MarkdownRender
 
 /**
@@ -81,7 +84,7 @@ class YapiFormatter(
     fun format(endpoint: ApiEndpoint): YapiApiDoc {
         val httpMeta = endpoint.httpMetadata
         val headers = (httpMeta?.headers ?: emptyList()).map {
-            YapiHeader(
+            MutableYapiHeader(
                 name = it.name,
                 value = it.value,
                 desc = it.description,
@@ -94,7 +97,7 @@ class YapiFormatter(
         val query = parameters
             .filter { it.binding == ParameterBinding.Query }
             .map {
-                YapiQuery(
+                MutableYapiQuery(
                     name = it.name,
                     value = it.defaultValue,
                     desc = it.description,
@@ -106,7 +109,7 @@ class YapiFormatter(
         val pathParams = parameters
             .filter { it.binding == ParameterBinding.Path }
             .map {
-                YapiPathParam(
+                MutableYapiPathParam(
                     name = it.name,
                     example = it.example ?: it.defaultValue,
                     desc = it.description
@@ -116,7 +119,7 @@ class YapiFormatter(
         val formParams = parameters
             .filter { it.binding == ParameterBinding.Form }
             .map {
-                YapiFormParam(
+                MutableYapiFormParam(
                     name = it.name,
                     example = it.example ?: it.defaultValue,
                     type = it.type.rawType(),
@@ -170,7 +173,7 @@ class YapiFormatter(
         // res_body_is_json_schema: true when we use JSON schema (not JSON5) for response body
         val resBodyIsJsonSchema = responseBody != null && !resBodyJson5
 
-        return YapiApiDoc(
+        return MutableYapiApiDoc.create(
             title = endpoint.name ?: "${httpMeta?.method?.name ?: "UNKNOWN"} ${endpoint.path}",
             path = formatPath(endpoint.path),
             method = httpMeta?.method?.name?.lowercase() ?: "get",
@@ -221,7 +224,7 @@ class YapiFormatter(
      * @return A YAPI document with mock examples
      */
     fun formatWithMock(endpoint: ApiEndpoint): YapiApiDoc {
-        val doc = format(endpoint)
+        val doc = format(endpoint) as MutableYapiApiDoc
         val parameters = endpoint.httpMetadata?.parameters ?: emptyList()
 
         mockGenerator?.let { generator ->
@@ -311,6 +314,84 @@ class YapiFormatter(
         if (desc.isNullOrBlank()) return null
         val html = markdownRender.render(desc)
         return html.ifBlank { "<p>$desc</p>" }
+    }
+
+    /**
+     * Builds the JSON request body for YAPI's save API endpoint.
+     *
+     * Serializes [doc] and [catId] into the JSON body expected by
+     * `POST /api/interface/save`. If [existingId] is provided it is included
+     * as `id`, triggering an update instead of insert.
+     *
+     * Any extra key-value pairs from [Extension.getExts] on the doc or its
+     * sub-objects are merged into the respective serialized maps, allowing
+     * secondary developers to inject custom fields for customized YAPI servers.
+     *
+     * @param doc The YAPI API document to serialize
+     * @param token Project private token for authentication
+     * @param catId Target category ID
+     * @param existingId Optional existing API ID for update (null = create new)
+     * @return JSON string ready for the request body
+     */
+    fun buildApiDocBody(doc: YapiApiDoc, token: String, catId: String, existingId: String? = null): String {
+        val map = mutableMapOf(
+            "token" to token,
+            "catid" to catId,
+            "title" to doc.title,
+            "path" to doc.path,
+            "method" to doc.method,
+            "desc" to doc.desc,
+            "markdown" to doc.markdown,
+            "status" to (doc.status ?: "done"),
+            "req_body_is_json_schema" to doc.reqBodyIsJsonSchema,
+            "res_body_is_json_schema" to doc.resBodyIsJsonSchema,
+            "req_headers" to (doc.reqHeaders?.map {
+                linkedMapOf(
+                    "name" to it.name, "value" to (it.value ?: ""), "desc" to (it.desc ?: ""),
+                    "example" to (it.example ?: it.value ?: ""), "required" to it.required
+                ).mergeExtension(it)
+            } ?: emptyList<Any>()),
+            "req_query" to (doc.reqQuery?.map {
+                linkedMapOf(
+                    "name" to it.name, "value" to (it.value ?: ""), "example" to (it.example ?: it.value ?: ""),
+                    "desc" to (it.desc ?: ""), "required" to it.required
+                ).mergeExtension(it)
+            } ?: emptyList<Any>()),
+            "req_params" to (doc.reqParams?.map {
+                linkedMapOf(
+                    "name" to it.name, "example" to (it.example ?: ""), "desc" to (it.desc ?: "")
+                ).mergeExtension(it)
+            } ?: emptyList<Any>()),
+            "req_body_other" to (doc.reqBodyOther ?: ""),
+            "res_body" to (doc.resBody ?: ""),
+            "req_body_form" to (doc.reqBodyForm?.map {
+                linkedMapOf(
+                    "name" to it.name, "example" to (it.example ?: ""), "type" to it.type,
+                    "required" to it.required, "desc" to (it.desc ?: "")
+                ).mergeExtension(it)
+            } ?: emptyList<Any>())
+        )
+        doc.reqBodyType?.let { map["req_body_type"] = it }
+        doc.resBodyType?.let { map["res_body_type"] = it }
+        doc.open?.let { map["api_opened"] = it }
+        doc.tag?.let { map["tag"] = it }
+        doc.tags?.let { map["tags"] = it }
+        existingId?.let { map["id"] = it }
+
+        // Merge top-level extensions from the doc
+        map.mergeExtension(doc)
+
+        return GsonUtils.toJson(map)
+    }
+
+    /**
+     * Merges extension key-value pairs from an [Extension] object into a base map.
+     * Extension values take precedence over base map values for the same key.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : MutableMap<*, *>> T.mergeExtension(ext: Extension): T {
+        (this as MutableMap<Any?, Any?>).putAll(ext.getExts())
+        return this
     }
 
     companion object {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/model/YapiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/model/YapiModels.kt
@@ -1,114 +1,466 @@
 package com.itangcent.easyapi.exporter.yapi.model
 
 /**
- * Represents a complete API documentation for YAPI.
- * Contains all information needed to create or update an API in YAPI.
- * 
- * @property title The API title/name
- * @property path The API path (e.g., "/api/users")
- * @property method The HTTP method (e.g., "get", "post")
- * @property desc API description (rendered HTML)
- * @property markdown Raw Markdown description (preserved for YApi's markdown field)
- * @property status API status (e.g., "done", "undone")
- * @property tag Tags for categorization
- * @property reqHeaders Request headers
- * @property reqQuery Query parameters
- * @property reqParams Path parameters
- * @property reqBodyForm Form data parameters
- * @property reqBodyOther Request body (JSON Schema or JSON5)
- * @property reqBodyType Request body type ("json", "form", etc.)
- * @property reqBodyIsJsonSchema Whether reqBodyOther is JSON Schema format
- * @property resBody Response body (JSON Schema or JSON5)
- * @property resBodyType Response body type
- * @property resBodyIsJsonSchema Whether resBody is JSON Schema format
- * @property tags API tags
- * @property open Whether the API is publicly accessible
+ * Interface for extending YAPI model objects with custom key-value pairs.
+ *
+ * Secondary developers who customize YAPI can implement this interface to
+ * inject additional fields into the YAPI save API request body. The extra
+ * key-value pairs returned by [getExts] are merged into the top-level
+ * request map (for [YapiApiDoc]) or into the item-level map (for sub-objects
+ * like [YapiHeader], [YapiQuery], etc.).
  */
-data class YapiApiDoc(
-    val title: String,
-    val path: String,
-    val method: String,
-    val desc: String? = null,
-    val markdown: String? = null,
-    val status: String? = null,
-    val tag: List<String>? = null,
-    val reqHeaders: List<YapiHeader>? = null,
-    val reqQuery: List<YapiQuery>? = null,
-    val reqParams: List<YapiPathParam>? = null,
-    val reqBodyForm: List<YapiFormParam>? = null,
-    val reqBodyOther: String? = null,
-    val reqBodyType: String? = null,
-    val reqBodyIsJsonSchema: Boolean = false,
-    val resBody: String? = null,
-    val resBodyType: String? = "json",
-    val resBodyIsJsonSchema: Boolean = true,
-    val tags: List<String>? = null,
-    val open: Boolean? = null
-)
+interface Extension {
+    /**
+     * Returns extra key-value pairs to be included in the YAPI API request.
+     * Keys that collide with standard YAPI fields will overwrite the defaults.
+     */
+    fun getExts(): Map<String, Any?>
+}
+
+/**
+ * Contract for YAPI API documentation.
+ *
+ * Used as the type throughout the export pipeline ([YapiApiClient],
+ * [YapiFormatter], [UpdateConfirmation], etc.).
+ *
+ * The standard implementation is [MutableYapiApiDoc], which is also the only
+ * implementation used internally.  It is returned as [YapiApiDoc] so that
+ * consumers are decoupled from mutability; only the rule-engine layer casts
+ * to [MutableYapiApiDoc] when it needs to modify the document.
+ */
+interface YapiApiDoc : Extension {
+    val title: String
+    val path: String
+    val method: String
+    val desc: String?
+    val markdown: String?
+    val status: String?
+    val tag: List<String>?
+    val reqHeaders: List<YapiHeader>?
+    val reqQuery: List<YapiQuery>?
+    val reqParams: List<YapiPathParam>?
+    val reqBodyForm: List<YapiFormParam>?
+    val reqBodyOther: String?
+    val reqBodyType: String?
+    val reqBodyIsJsonSchema: Boolean
+    val resBody: String?
+    val resBodyType: String?
+    val resBodyIsJsonSchema: Boolean
+    val tags: List<String>?
+    val open: Boolean?
+
+    /**
+     * Creates a copy of this [YapiApiDoc] with optionally modified field values.
+     *
+     * Extension key-value pairs are included via [exts], defaulting to [getExts].
+     * Pass an explicit value (e.g. `exts = emptyMap()`) to drop extensions on copy.
+     *
+     * @return A new [MutableYapiApiDoc] with the requested field values.
+     */
+    fun copy(
+        title: String = this.title,
+        path: String = this.path,
+        method: String = this.method,
+        desc: String? = this.desc,
+        markdown: String? = this.markdown,
+        status: String? = this.status,
+        tag: List<String>? = this.tag,
+        reqHeaders: List<YapiHeader>? = this.reqHeaders,
+        reqQuery: List<YapiQuery>? = this.reqQuery,
+        reqParams: List<YapiPathParam>? = this.reqParams,
+        reqBodyForm: List<YapiFormParam>? = this.reqBodyForm,
+        reqBodyOther: String? = this.reqBodyOther,
+        reqBodyType: String? = this.reqBodyType,
+        reqBodyIsJsonSchema: Boolean = this.reqBodyIsJsonSchema,
+        resBody: String? = this.resBody,
+        resBodyType: String? = this.resBodyType,
+        resBodyIsJsonSchema: Boolean = this.resBodyIsJsonSchema,
+        tags: List<String>? = this.tags,
+        open: Boolean? = this.open,
+        exts: Map<String, Any?> = this.getExts(),
+    ): MutableYapiApiDoc
+}
+
+/**
+ * Mutable implementation of [YapiApiDoc].
+ *
+ * This is the only implementation used in the codebase.  It is always
+ * returned as [YapiApiDoc] from public APIs so that callers do not depend
+ * on mutability.  The rule-engine layer casts to [MutableYapiApiDoc] when
+ * it needs to modify the document (e.g. in `YAPI_SAVE_BEFORE` scripts).
+ *
+ * All properties are `var` and the extension map is mutable via [setExt].
+ * Sub-object lists use mutable types ([MutableYapiHeader], [MutableYapiQuery],
+ * [MutableYapiPathParam], [MutableYapiFormParam]) so that individual items
+ * can be mutated directly in rule scripts.
+ *
+ * Create an instance via the companion factory methods.
+ */
+data class MutableYapiApiDoc(
+    override var title: String,
+    override var path: String,
+    override var method: String,
+    override var desc: String? = null,
+    override var markdown: String? = null,
+    override var status: String? = null,
+    override var tag: List<String>? = null,
+    override var reqHeaders: List<MutableYapiHeader>? = null,
+    override var reqQuery: List<MutableYapiQuery>? = null,
+    override var reqParams: List<MutableYapiPathParam>? = null,
+    override var reqBodyForm: List<MutableYapiFormParam>? = null,
+    override var reqBodyOther: String? = null,
+    override var reqBodyType: String? = null,
+    override var reqBodyIsJsonSchema: Boolean = false,
+    override var resBody: String? = null,
+    override var resBodyType: String? = "json",
+    override var resBodyIsJsonSchema: Boolean = true,
+    override var tags: List<String>? = null,
+    override var open: Boolean? = null,
+) : YapiApiDoc {
+
+    private val _exts: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getExts(): Map<String, Any?> = java.util.Collections.unmodifiableMap(_exts)
+
+    /** Adds or overwrites a single extension key-value pair. */
+    fun setExt(key: String, value: Any?) {
+        _exts[key] = value
+    }
+
+    /** Adds all entries from [exts] into the extension map, overwriting existing keys. */
+    fun putAllExts(exts: Map<String, Any?>) {
+        _exts.putAll(exts)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun copy(
+        title: String,
+        path: String,
+        method: String,
+        desc: String?,
+        markdown: String?,
+        status: String?,
+        tag: List<String>?,
+        reqHeaders: List<YapiHeader>?,
+        reqQuery: List<YapiQuery>?,
+        reqParams: List<YapiPathParam>?,
+        reqBodyForm: List<YapiFormParam>?,
+        reqBodyOther: String?,
+        reqBodyType: String?,
+        reqBodyIsJsonSchema: Boolean,
+        resBody: String?,
+        resBodyType: String?,
+        resBodyIsJsonSchema: Boolean,
+        tags: List<String>?,
+        open: Boolean?,
+        exts: Map<String, Any?>,
+    ): MutableYapiApiDoc = MutableYapiApiDoc(
+        title = title,
+        path = path,
+        method = method,
+        desc = desc,
+        markdown = markdown,
+        status = status,
+        tag = tag,
+        reqHeaders = reqHeaders as? List<MutableYapiHeader>,
+        reqQuery = reqQuery as? List<MutableYapiQuery>,
+        reqParams = reqParams as? List<MutableYapiPathParam>,
+        reqBodyForm = reqBodyForm as? List<MutableYapiFormParam>,
+        reqBodyOther = reqBodyOther,
+        reqBodyType = reqBodyType,
+        reqBodyIsJsonSchema = reqBodyIsJsonSchema,
+        resBody = resBody,
+        resBodyType = resBodyType,
+        resBodyIsJsonSchema = resBodyIsJsonSchema,
+        tags = tags,
+        open = open,
+    ).also { it.putAllExts(exts) }
+
+    companion object {
+        /** Creates a [MutableYapiApiDoc] with all fields set to their defaults. */
+        @Suppress("UNCHECKED_CAST")
+        fun create(
+            title: String,
+            path: String,
+            method: String,
+            desc: String? = null,
+            markdown: String? = null,
+            status: String? = null,
+            tag: List<String>? = null,
+            reqHeaders: List<YapiHeader>? = null,
+            reqQuery: List<YapiQuery>? = null,
+            reqParams: List<YapiPathParam>? = null,
+            reqBodyForm: List<YapiFormParam>? = null,
+            reqBodyOther: String? = null,
+            reqBodyType: String? = null,
+            reqBodyIsJsonSchema: Boolean = false,
+            resBody: String? = null,
+            resBodyType: String? = "json",
+            resBodyIsJsonSchema: Boolean = true,
+            tags: List<String>? = null,
+            open: Boolean? = null,
+            exts: Map<String, Any?> = emptyMap()
+        ): MutableYapiApiDoc = MutableYapiApiDoc(
+            title = title,
+            path = path,
+            method = method,
+            desc = desc,
+            markdown = markdown,
+            status = status,
+            tag = tag,
+            reqHeaders = reqHeaders as? List<MutableYapiHeader>,
+            reqQuery = reqQuery as? List<MutableYapiQuery>,
+            reqParams = reqParams as? List<MutableYapiPathParam>,
+            reqBodyForm = reqBodyForm as? List<MutableYapiFormParam>,
+            reqBodyOther = reqBodyOther,
+            reqBodyType = reqBodyType,
+            reqBodyIsJsonSchema = reqBodyIsJsonSchema,
+            resBody = resBody,
+            resBodyType = resBodyType,
+            resBodyIsJsonSchema = resBodyIsJsonSchema,
+            tags = tags,
+            open = open,
+        ).also { it.putAllExts(exts) }
+
+        /** Creates a [MutableYapiApiDoc] copied from [source]. */
+        @Suppress("UNCHECKED_CAST")
+        fun from(source: YapiApiDoc): MutableYapiApiDoc = MutableYapiApiDoc(
+            title = source.title,
+            path = source.path,
+            method = source.method,
+            desc = source.desc,
+            markdown = source.markdown,
+            status = source.status,
+            tag = source.tag,
+            reqHeaders = source.reqHeaders as? List<MutableYapiHeader>,
+            reqQuery = source.reqQuery as? List<MutableYapiQuery>,
+            reqParams = source.reqParams as? List<MutableYapiPathParam>,
+            reqBodyForm = source.reqBodyForm as? List<MutableYapiFormParam>,
+            reqBodyOther = source.reqBodyOther,
+            reqBodyType = source.reqBodyType,
+            reqBodyIsJsonSchema = source.reqBodyIsJsonSchema,
+            resBody = source.resBody,
+            resBodyType = source.resBodyType,
+            resBodyIsJsonSchema = source.resBodyIsJsonSchema,
+            tags = source.tags,
+            open = source.open,
+        ).also { it.putAllExts(source.getExts()) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-model interfaces & mutable implementations
+// ---------------------------------------------------------------------------
 
 /**
  * Represents an HTTP header in YAPI API documentation.
- * 
- * @property name Header name
- * @property value Header value
- * @property desc Header description
- * @property example Example value
- * @property required Whether the header is required (1 = required, 0 = optional)
+ *
+ * The mutable implementation is [MutableYapiHeader].
  */
-data class YapiHeader(
-    val name: String, 
-    val value: String? = null,
-    val desc: String? = null,
-    val example: String? = null,
-    val required: Int = 0
-)
+interface YapiHeader : Extension {
+    val name: String
+    val value: String?
+    val desc: String?
+    val example: String?
+    val required: Int
+}
+
+/**
+ * Mutable implementation of [YapiHeader].
+ *
+ * All properties are `var` so they can be modified in rule scripts.
+ * The auto-generated data-class [copy] returns a [MutableYapiHeader].
+ * Use [putAllExts] after copy if extensions must be preserved.
+ */
+data class MutableYapiHeader(
+    override var name: String,
+    override var value: String? = null,
+    override var desc: String? = null,
+    override var example: String? = null,
+    override var required: Int = 0,
+) : YapiHeader {
+
+    private val _exts: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getExts(): Map<String, Any?> = java.util.Collections.unmodifiableMap(_exts)
+
+    /** Adds or overwrites a single extension key-value pair. */
+    fun setExt(key: String, value: Any?) {
+        _exts[key] = value
+    }
+
+    /** Adds all entries from [exts] into the extension map, overwriting existing keys. */
+    fun putAllExts(exts: Map<String, Any?>) {
+        _exts.putAll(exts)
+    }
+
+    companion object {
+        /** Creates a [MutableYapiHeader] copied from [source] including extensions. */
+        fun from(source: YapiHeader): MutableYapiHeader = MutableYapiHeader(
+            name = source.name,
+            value = source.value,
+            desc = source.desc,
+            example = source.example,
+            required = source.required,
+        ).also { it.putAllExts(source.getExts()) }
+    }
+}
 
 /**
  * Represents a query parameter in YAPI API documentation.
- * 
- * @property name Parameter name
- * @property value Default value
- * @property desc Parameter description
- * @property example Example value
- * @property required Whether the parameter is required (1 = required, 0 = optional)
+ *
+ * The mutable implementation is [MutableYapiQuery].
  */
-data class YapiQuery(
-    val name: String, 
-    val value: String? = null,
-    val desc: String? = null,
-    val example: String? = null,
-    val required: Int = 0
-)
+interface YapiQuery : Extension {
+    val name: String
+    val value: String?
+    val desc: String?
+    val example: String?
+    val required: Int
+}
+
+/**
+ * Mutable implementation of [YapiQuery].
+ *
+ * All properties are `var` so they can be modified in rule scripts.
+ * The auto-generated data-class [copy] returns a [MutableYapiQuery].
+ * Use [putAllExts] after copy if extensions must be preserved.
+ */
+data class MutableYapiQuery(
+    override var name: String,
+    override var value: String? = null,
+    override var desc: String? = null,
+    override var example: String? = null,
+    override var required: Int = 0,
+) : YapiQuery {
+
+    private val _exts: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getExts(): Map<String, Any?> = java.util.Collections.unmodifiableMap(_exts)
+
+    /** Adds or overwrites a single extension key-value pair. */
+    fun setExt(key: String, value: Any?) {
+        _exts[key] = value
+    }
+
+    /** Adds all entries from [exts] into the extension map, overwriting existing keys. */
+    fun putAllExts(exts: Map<String, Any?>) {
+        _exts.putAll(exts)
+    }
+
+    companion object {
+        /** Creates a [MutableYapiQuery] copied from [source] including extensions. */
+        fun from(source: YapiQuery): MutableYapiQuery = MutableYapiQuery(
+            name = source.name,
+            value = source.value,
+            desc = source.desc,
+            example = source.example,
+            required = source.required,
+        ).also { it.putAllExts(source.getExts()) }
+    }
+}
 
 /**
  * Represents a path parameter in YAPI API documentation.
- * 
- * @property name Parameter name
- * @property example Example value
- * @property desc Parameter description
+ *
+ * The mutable implementation is [MutableYapiPathParam].
  */
-data class YapiPathParam(
-    val name: String, 
-    val example: String? = null,
-    val desc: String? = null
-)
+interface YapiPathParam : Extension {
+    val name: String
+    val example: String?
+    val desc: String?
+}
+
+/**
+ * Mutable implementation of [YapiPathParam].
+ *
+ * All properties are `var` so they can be modified in rule scripts.
+ * The auto-generated data-class [copy] returns a [MutableYapiPathParam].
+ * Use [putAllExts] after copy if extensions must be preserved.
+ */
+data class MutableYapiPathParam(
+    override var name: String,
+    override var example: String? = null,
+    override var desc: String? = null,
+) : YapiPathParam {
+
+    private val _exts: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getExts(): Map<String, Any?> = java.util.Collections.unmodifiableMap(_exts)
+
+    /** Adds or overwrites a single extension key-value pair. */
+    fun setExt(key: String, value: Any?) {
+        _exts[key] = value
+    }
+
+    /** Adds all entries from [exts] into the extension map, overwriting existing keys. */
+    fun putAllExts(exts: Map<String, Any?>) {
+        _exts.putAll(exts)
+    }
+
+    companion object {
+        /** Creates a [MutableYapiPathParam] copied from [source] including extensions. */
+        fun from(source: YapiPathParam): MutableYapiPathParam = MutableYapiPathParam(
+            name = source.name,
+            example = source.example,
+            desc = source.desc,
+        ).also { it.putAllExts(source.getExts()) }
+    }
+}
 
 /**
  * Represents a form parameter in YAPI API documentation.
- * 
- * @property name Parameter name
- * @property example Example value
- * @property type Parameter type ("text", "file", etc.)
- * @property required Whether the parameter is required (1 = required, 0 = optional)
- * @property desc Parameter description
+ *
+ * The mutable implementation is [MutableYapiFormParam].
  */
-data class YapiFormParam(
-    val name: String, 
-    val example: String? = null,
-    val type: String = "text",
-    val required: Int = 0,
-    val desc: String? = null
-)
+interface YapiFormParam : Extension {
+    val name: String
+    val example: String?
+    val type: String
+    val required: Int
+    val desc: String?
+}
+
+/**
+ * Mutable implementation of [YapiFormParam].
+ *
+ * All properties are `var` so they can be modified in rule scripts.
+ * The auto-generated data-class [copy] returns a [MutableYapiFormParam].
+ * Use [putAllExts] after copy if extensions must be preserved.
+ */
+data class MutableYapiFormParam(
+    override var name: String,
+    override var example: String? = null,
+    override var type: String = "text",
+    override var required: Int = 0,
+    override var desc: String? = null,
+) : YapiFormParam {
+
+    private val _exts: MutableMap<String, Any?> = mutableMapOf()
+
+    override fun getExts(): Map<String, Any?> = java.util.Collections.unmodifiableMap(_exts)
+
+    /** Adds or overwrites a single extension key-value pair. */
+    fun setExt(key: String, value: Any?) {
+        _exts[key] = value
+    }
+
+    /** Adds all entries from [exts] into the extension map, overwriting existing keys. */
+    fun putAllExts(exts: Map<String, Any?>) {
+        _exts.putAll(exts)
+    }
+
+    companion object {
+        /** Creates a [MutableYapiFormParam] copied from [source] including extensions. */
+        fun from(source: YapiFormParam): MutableYapiFormParam = MutableYapiFormParam(
+            name = source.name,
+            example = source.example,
+            type = source.type,
+            required = source.required,
+            desc = source.desc,
+        ).also { it.putAllExts(source.getExts()) }
+    }
+}
 
 /**
  * Represents a YAPI category (cart) for organizing APIs.

--- a/src/main/kotlin/com/itangcent/easyapi/psi/type/JsonType.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/type/JsonType.kt
@@ -52,6 +52,25 @@ object JsonType {
 
     fun isValid(type: String?): Boolean = type != null && type in ALL_TYPES
 
+    /**
+     * Map a JSON type to the corresponding JSON Schema / YApi type.
+     * Standard JSON types + date/datetime extensions → YApi schema types.
+     */
+    fun toSchemaType(type: String): String {
+        return when (type) {
+            STRING, DATE, DATETIME, FILE -> "string"
+            SHORT, INT, LONG -> "integer"
+            FLOAT, DOUBLE -> "number"
+            BOOLEAN -> "boolean"
+            ARRAY -> "array"
+            OBJECT -> "object"
+            "null" -> "null"
+            "text" -> "string"
+            "file" -> "string"
+            else -> "string"
+        }
+    }
+
     fun defaultValueForType(type: String): Any? {
         return when (type) {
             STRING -> ""

--- a/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/parser/Jsr223ScriptParser.kt
@@ -8,6 +8,7 @@ import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.http.HttpClientProvider
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.SourceHelper
+import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKey
 import com.itangcent.easyapi.rule.context.*
 import com.itangcent.easyapi.util.text.RegexUtils
@@ -157,6 +158,30 @@ class ScriptHelper(private val context: RuleContext) {
 
     private val linkResolver: com.itangcent.easyapi.psi.LinkResolver? by lazy {
         com.itangcent.easyapi.psi.LinkResolver.getInstance(context.project)
+    }
+
+    /**
+     * Converts a JSON type string to a YAPI data type string.
+     *
+     * Mapping:
+     * - string/date/datetime/file → "string"
+     * - short/int/long → "integer"
+     * - float/double → "number"
+     * - boolean → "boolean"
+     * - array → "array"
+     * - object → "object"
+     * - null/unknown → "string"
+     *
+     * ## Usage in Scripts
+     * ```
+     * helper.jsonTypeToYapiType("int")    // "integer"
+     * helper.jsonTypeToYapiType("string") // "string"
+     * H.jsonTypeToYapiType("long")        // "integer"
+     * ```
+     */
+    fun jsonTypeToYapiType(jsonType: String?): String {
+        if (jsonType.isNullOrBlank()) return "string"
+        return JsonType.toSchemaType(jsonType)
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultUpdateConfirmationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultUpdateConfirmationTest.kt
@@ -2,7 +2,12 @@ package com.itangcent.easyapi.exporter.yapi
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiApiDoc
 import com.itangcent.easyapi.exporter.yapi.model.YapiApiDoc
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiFormParam
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiHeader
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiPathParam
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiQuery
 import com.itangcent.easyapi.exporter.yapi.model.YapiFormParam
 import com.itangcent.easyapi.exporter.yapi.model.YapiHeader
 import com.itangcent.easyapi.exporter.yapi.model.YapiPathParam
@@ -246,7 +251,7 @@ class DefaultUpdateConfirmationTest {
         val doc = testDoc(
             title = "Get Users",
             reqHeaders = listOf(
-                YapiHeader(name = "Authorization", desc = "Auth header updated", required = 1)
+                MutableYapiHeader(name = "Authorization", desc = "Auth header updated", required = 1)
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -278,8 +283,8 @@ class DefaultUpdateConfirmationTest {
         val doc = testDoc(
             title = "Get Users",
             reqQuery = listOf(
-                YapiQuery(name = "page", required = 0),
-                YapiQuery(name = "size", required = 0)
+                MutableYapiQuery(name = "page", required = 0),
+                MutableYapiQuery(name = "size", required = 0)
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -311,7 +316,7 @@ class DefaultUpdateConfirmationTest {
         val doc = testDoc(
             title = "Get Users",
             reqQuery = listOf(
-                YapiQuery(name = "pageNumber", required = 0)
+                MutableYapiQuery(name = "pageNumber", required = 0)
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -344,7 +349,7 @@ class DefaultUpdateConfirmationTest {
             path = "/api/users/{id}",
             title = "Get User",
             reqParams = listOf(
-                YapiPathParam(name = "id", desc = "User ID updated")
+                MutableYapiPathParam(name = "id", desc = "User ID updated")
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -379,7 +384,7 @@ class DefaultUpdateConfirmationTest {
             method = "POST",
             title = "Upload File",
             reqBodyForm = listOf(
-                YapiFormParam(name = "file", type = "file", required = 0)
+                MutableYapiFormParam(name = "file", type = "file", required = 0)
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -487,7 +492,7 @@ class DefaultUpdateConfirmationTest {
         val doc = testDoc(
             title = "Get Users",
             reqQuery = listOf(
-                YapiQuery(name = "page", desc = "Page number", example = "1", required = 0)
+                MutableYapiQuery(name = "page", desc = "Page number", example = "1", required = 0)
             )
         )
         val result = confirmation.confirm(doc, "cat1")
@@ -511,7 +516,7 @@ class DefaultUpdateConfirmationTest {
         reqParams: List<YapiPathParam>? = null,
         reqBodyForm: List<YapiFormParam>? = null
     ): YapiApiDoc {
-        return YapiApiDoc(
+        return MutableYapiApiDoc.create(
             title = title,
             path = path,
             method = method,

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClientTest.kt
@@ -2,9 +2,10 @@ package com.itangcent.easyapi.exporter.yapi
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiApiDoc
 import com.itangcent.easyapi.exporter.yapi.model.YapiApiDoc
-import com.itangcent.easyapi.exporter.yapi.model.YapiHeader
-import com.itangcent.easyapi.exporter.yapi.model.YapiQuery
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiHeader
+import com.itangcent.easyapi.exporter.yapi.model.MutableYapiQuery
 import com.itangcent.easyapi.http.HttpClient
 import com.itangcent.easyapi.http.HttpRequest
 import com.itangcent.easyapi.http.HttpResponse
@@ -522,12 +523,12 @@ class DefaultYapiApiClientTest {
     // Helpers
     // -------------------------------------------------------------------------
 
-    private fun testDoc(path: String = "/api/test", method: String = "GET") = YapiApiDoc(
+    private fun testDoc(path: String = "/api/test", method: String = "GET") = MutableYapiApiDoc.create(
         title = "Test API",
         path = path,
         method = method,
         desc = "desc",
-        reqHeaders = listOf(YapiHeader("Content-Type", "application/json")),
-        reqQuery = listOf(YapiQuery("id", "1"))
+        reqHeaders = listOf(MutableYapiHeader("Content-Type", "application/json")),
+        reqQuery = listOf(MutableYapiQuery("id", "1"))
     )
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/YapiFormatterTest.kt
@@ -1,6 +1,8 @@
 package com.itangcent.easyapi.exporter.yapi
 
+import com.google.gson.JsonParser
 import com.itangcent.easyapi.exporter.model.*
+import com.itangcent.easyapi.exporter.yapi.model.*
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.JsonType
@@ -74,7 +76,7 @@ class YapiFormatterTest {
 
         assertNotNull(doc.reqBodyOther)
         assertTrue(doc.reqBodyOther!!.contains("name"))
-        assertTrue(doc.reqBodyOther.contains("email"))
+        assertTrue(doc.reqBodyOther!!.contains("email"))
     }
 
     @Test
@@ -724,6 +726,530 @@ class YapiFormatterTest {
 
         assertNotNull(doc.reqQuery)
         assertEquals("@email", doc.reqQuery!![0].example)
+    }
+
+    // endregion
+
+    // region buildApiDocBody
+
+    @Test
+    fun testBuildApiDocBodyBasicFields() {
+        val doc = MutableYapiApiDoc.create(
+            title = "Get User",
+            path = "/api/users/{id}",
+            method = "get",
+            desc = "<p>desc</p>",
+            markdown = "desc",
+            status = "done"
+        )
+        val json = formatter.buildApiDocBody(doc, "my-token", "cat123")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("my-token", obj.get("token").asString)
+        assertEquals("cat123", obj.get("catid").asString)
+        assertEquals("Get User", obj.get("title").asString)
+        assertEquals("/api/users/{id}", obj.get("path").asString)
+        assertEquals("get", obj.get("method").asString)
+        assertEquals("<p>desc</p>", obj.get("desc").asString)
+        assertEquals("desc", obj.get("markdown").asString)
+        assertEquals("done", obj.get("status").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithExistingId() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1", "existing-123")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("existing-123", obj.get("id").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithoutExistingId() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertNull(obj.get("id"))
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithHeaders() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            reqHeaders = listOf(
+                MutableYapiHeader(name = "Authorization", value = "Bearer x", desc = "Auth header", required = 1)
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val headers = obj.getAsJsonArray("req_headers")
+
+        assertEquals(1, headers.size())
+        val header = headers[0].asJsonObject
+        assertEquals("Authorization", header.get("name").asString)
+        assertEquals("Bearer x", header.get("value").asString)
+        assertEquals("Auth header", header.get("desc").asString)
+        assertEquals(1, header.get("required").asInt)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithQueryParams() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            reqQuery = listOf(
+                MutableYapiQuery(name = "page", value = "1", desc = "Page number", required = 0)
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val queries = obj.getAsJsonArray("req_query")
+
+        assertEquals(1, queries.size())
+        val query = queries[0].asJsonObject
+        assertEquals("page", query.get("name").asString)
+        assertEquals("1", query.get("value").asString)
+        assertEquals("Page number", query.get("desc").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithFormParams() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "post",
+            reqBodyType = "form",
+            reqBodyForm = listOf(
+                MutableYapiFormParam(name = "username", example = "admin", type = "text", required = 1, desc = "Login name")
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val forms = obj.getAsJsonArray("req_body_form")
+
+        assertEquals(1, forms.size())
+        val form = forms[0].asJsonObject
+        assertEquals("username", form.get("name").asString)
+        assertEquals("admin", form.get("example").asString)
+        assertEquals("text", form.get("type").asString)
+        assertEquals(1, form.get("required").asInt)
+        assertEquals("form", obj.get("req_body_type").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithPathParams() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p/{id}", method = "get",
+            reqParams = listOf(
+                MutableYapiPathParam(name = "id", example = "42", desc = "User ID")
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val params = obj.getAsJsonArray("req_params")
+
+        assertEquals(1, params.size())
+        val param = params[0].asJsonObject
+        assertEquals("id", param.get("name").asString)
+        assertEquals("42", param.get("example").asString)
+        assertEquals("User ID", param.get("desc").asString)
+    }
+
+    // endregion
+
+    // region Extension support
+
+    @Test
+    fun testExtensionDefaultReturnsEmptyMap() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        assertTrue(doc.getExts().isEmpty())
+
+        val header = MutableYapiHeader(name = "X-Custom")
+        assertTrue(header.getExts().isEmpty())
+
+        val query = MutableYapiQuery(name = "q")
+        assertTrue(query.getExts().isEmpty())
+
+        val pathParam = MutableYapiPathParam(name = "id")
+        assertTrue(pathParam.getExts().isEmpty())
+
+        val formParam = MutableYapiFormParam(name = "field")
+        assertTrue(formParam.getExts().isEmpty())
+    }
+
+    @Test
+    fun testExtensionWithCustomExts() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("custom_field" to "custom_value", "is_custom" to true)
+        )
+        assertEquals(mapOf("custom_field" to "custom_value", "is_custom" to true), doc.getExts())
+    }
+
+    @Test
+    fun testBuildApiDocBodyMergesDocExtensions() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("custom_field" to "custom_value", "api_opened" to 1)
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("custom_value", obj.get("custom_field").asString)
+        // Extension value overwrites the standard field
+        assertEquals(1, obj.get("api_opened").asInt)
+    }
+
+    @Test
+    fun testBuildApiDocBodyMergesHeaderExtensions() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            reqHeaders = listOf(
+                MutableYapiHeader(
+                    name = "Authorization",
+                    value = "Bearer x"
+                ).also { it.putAllExts(mapOf("custom_header_field" to "extra")) }
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val header = obj.getAsJsonArray("req_headers")[0].asJsonObject
+
+        assertEquals("Authorization", header.get("name").asString)
+        assertEquals("extra", header.get("custom_header_field").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyMergesQueryExtensions() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            reqQuery = listOf(
+                MutableYapiQuery(
+                    name = "page",
+                    value = "1"
+                ).also { it.putAllExts(mapOf("custom_query_field" to "extra")) }
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val query = obj.getAsJsonArray("req_query")[0].asJsonObject
+
+        assertEquals("page", query.get("name").asString)
+        assertEquals("extra", query.get("custom_query_field").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyMergesPathParamExtensions() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p/{id}", method = "get",
+            reqParams = listOf(
+                MutableYapiPathParam(
+                    name = "id",
+                    example = "1"
+                ).also { it.putAllExts(mapOf("custom_param_field" to "extra")) }
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val param = obj.getAsJsonArray("req_params")[0].asJsonObject
+
+        assertEquals("id", param.get("name").asString)
+        assertEquals("extra", param.get("custom_param_field").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyMergesFormParamExtensions() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "post",
+            reqBodyForm = listOf(
+                MutableYapiFormParam(
+                    name = "file",
+                    type = "file"
+                ).also { it.putAllExts(mapOf("custom_form_field" to "extra")) }
+            )
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+        val form = obj.getAsJsonArray("req_body_form")[0].asJsonObject
+
+        assertEquals("file", form.get("name").asString)
+        assertEquals("file", form.get("type").asString)
+        assertEquals("extra", form.get("custom_form_field").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyExtensionOverwritesStandardField() {
+        val doc = MutableYapiApiDoc.create(
+            title = "Original Title",
+            path = "/p",
+            method = "get",
+            exts = mapOf("title" to "Overridden Title")
+        )
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        // Extension value should overwrite the standard field
+        assertEquals("Overridden Title", obj.get("title").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyWithNoExtensions() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val json = formatter.buildApiDocBody(doc, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        // Should have standard fields but no extra extension fields
+        assertEquals("T", obj.get("title").asString)
+        assertEquals("/p", obj.get("path").asString)
+        assertFalse(obj.has("custom_field"))
+    }
+
+    // endregion
+
+    // region YapiApiDoc interface
+
+    @Test
+    fun testYapiApiDocInterface() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        assertEquals("T", doc.title)
+        assertEquals("/p", doc.path)
+        assertEquals("get", doc.method)
+        assertNull(doc.desc)
+        assertNull(doc.markdown)
+        assertNull(doc.status)
+        assertNull(doc.tag)
+        assertNull(doc.reqHeaders)
+        assertNull(doc.reqQuery)
+        assertNull(doc.reqParams)
+        assertNull(doc.reqBodyForm)
+        assertNull(doc.reqBodyOther)
+        assertNull(doc.reqBodyType)
+        assertFalse(doc.reqBodyIsJsonSchema)
+        assertNull(doc.resBody)
+        assertEquals("json", doc.resBodyType)
+        assertTrue(doc.resBodyIsJsonSchema)
+        assertNull(doc.tags)
+        assertNull(doc.open)
+        assertTrue(doc.getExts().isEmpty())
+    }
+
+    @Test
+    fun testYapiApiDocPolymorphism() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(title = "A", path = "/a", method = "get")
+        val copy: YapiApiDoc = MutableYapiApiDoc.from(doc)
+
+        assertEquals("A", doc.title)
+        assertEquals("A", copy.title)
+    }
+
+    @Test
+    fun testBuildApiDocBodyAcceptsYapiApiDoc() {
+        val info: YapiApiDoc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val json = formatter.buildApiDocBody(info, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("T", obj.get("title").asString)
+        assertEquals("/p", obj.get("path").asString)
+    }
+
+    @Test
+    fun testBuildApiDocBodyAcceptsMutableYapiApiDoc() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        )
+        mutable.title = "Changed"
+        mutable.setExt("custom", "value")
+
+        val json = formatter.buildApiDocBody(mutable, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("Changed", obj.get("title").asString)
+        assertEquals("value", obj.get("custom").asString)
+    }
+
+    // endregion
+
+    // region MutableYapiApiDoc
+
+    @Test
+    fun testMutableYapiApiDocFromYapiApiDoc() {
+        val doc = MutableYapiApiDoc.create(
+            title = "Get User",
+            path = "/api/users/{id}",
+            method = "get",
+            desc = "desc",
+            markdown = "md",
+            status = "done",
+            tag = listOf("user"),
+            reqHeaders = listOf(MutableYapiHeader(name = "Auth")),
+            reqQuery = listOf(MutableYapiQuery(name = "page")),
+            reqParams = listOf(MutableYapiPathParam(name = "id")),
+            reqBodyForm = listOf(MutableYapiFormParam(name = "name")),
+            reqBodyOther = "{}",
+            reqBodyType = "json",
+            reqBodyIsJsonSchema = true,
+            resBody = "{}",
+            resBodyType = "json",
+            resBodyIsJsonSchema = false,
+            tags = listOf("tag1"),
+            open = true,
+            exts = mapOf("key1" to "val1")
+        )
+        val mutable = MutableYapiApiDoc.from(doc)
+
+        assertEquals("Get User", mutable.title)
+        assertEquals("/api/users/{id}", mutable.path)
+        assertEquals("get", mutable.method)
+        assertEquals("desc", mutable.desc)
+        assertEquals("md", mutable.markdown)
+        assertEquals("done", mutable.status)
+        assertEquals(listOf("user"), mutable.tag)
+        assertEquals(1, mutable.reqHeaders?.size)
+        assertEquals(1, mutable.reqQuery?.size)
+        assertEquals(1, mutable.reqParams?.size)
+        assertEquals(1, mutable.reqBodyForm?.size)
+        assertEquals("{}", mutable.reqBodyOther)
+        assertEquals("json", mutable.reqBodyType)
+        assertTrue(mutable.reqBodyIsJsonSchema)
+        assertEquals("{}", mutable.resBody)
+        assertEquals("json", mutable.resBodyType)
+        assertFalse(mutable.resBodyIsJsonSchema)
+        assertEquals(listOf("tag1"), mutable.tags)
+        assertEquals(true, mutable.open)
+        assertEquals(mapOf("key1" to "val1"), mutable.getExts())
+    }
+
+    @Test
+    fun testMutableYapiApiDocFromMutableYapiApiDoc() {
+        val original = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "T", path = "/p", method = "get", exts = mapOf("k" to "v"))
+        )
+        original.setExt("extra", "data")
+        val copy = MutableYapiApiDoc.from(original)
+
+        assertEquals("T", copy.title)
+        assertEquals(mapOf("k" to "v", "extra" to "data"), copy.getExts())
+    }
+
+    @Test
+    fun testMutableYapiApiDocPropertyMutation() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "Original", path = "/original", method = "get")
+        )
+
+        mutable.title = "Changed"
+        mutable.path = "/changed"
+        mutable.method = "post"
+        mutable.desc = "new desc"
+        mutable.markdown = "new md"
+        mutable.status = "undone"
+        mutable.tag = listOf("new-tag")
+        mutable.reqHeaders = listOf(MutableYapiHeader(name = "X-New"))
+        mutable.reqQuery = listOf(MutableYapiQuery(name = "q"))
+        mutable.reqParams = listOf(MutableYapiPathParam(name = "p"))
+        mutable.reqBodyForm = listOf(MutableYapiFormParam(name = "f"))
+        mutable.reqBodyOther = """{"type":"object"}"""
+        mutable.reqBodyType = "json"
+        mutable.reqBodyIsJsonSchema = true
+        mutable.resBody = """{"type":"array"}"""
+        mutable.resBodyType = "json"
+        mutable.resBodyIsJsonSchema = false
+        mutable.tags = listOf("new-tag")
+        mutable.open = false
+
+        assertEquals("Changed", mutable.title)
+        assertEquals("/changed", mutable.path)
+        assertEquals("post", mutable.method)
+        assertEquals("new desc", mutable.desc)
+        assertEquals("new md", mutable.markdown)
+        assertEquals("undone", mutable.status)
+        assertEquals(listOf("new-tag"), mutable.tag)
+        assertEquals(1, mutable.reqHeaders!!.size)
+        assertEquals("X-New", mutable.reqHeaders!![0].name)
+        assertEquals(1, mutable.reqQuery!!.size)
+        assertEquals(1, mutable.reqParams!!.size)
+        assertEquals(1, mutable.reqBodyForm!!.size)
+        assertEquals("""{"type":"object"}""", mutable.reqBodyOther)
+        assertEquals("json", mutable.reqBodyType)
+        assertTrue(mutable.reqBodyIsJsonSchema)
+        assertEquals("""{"type":"array"}""", mutable.resBody)
+        assertFalse(mutable.resBodyIsJsonSchema)
+        assertEquals(listOf("new-tag"), mutable.tags)
+        assertEquals(false, mutable.open)
+    }
+
+    @Test
+    fun testMutableYapiApiDocSetExt() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        )
+
+        assertTrue(mutable.getExts().isEmpty())
+
+        mutable.setExt("custom_field", "custom_value")
+        assertEquals("custom_value", mutable.getExts()["custom_field"])
+
+        mutable.setExt("custom_field", "updated")
+        assertEquals("updated", mutable.getExts()["custom_field"])
+
+        mutable.setExt("null_field", null)
+        assertTrue(mutable.getExts().containsKey("null_field"))
+        assertNull(mutable.getExts()["null_field"])
+    }
+
+    @Test
+    fun testMutableYapiApiDocPutAllExts() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "T", path = "/p", method = "get", exts = mapOf("a" to 1))
+        )
+
+        mutable.putAllExts(mapOf("b" to 2, "c" to 3))
+        assertEquals(mapOf("a" to 1, "b" to 2, "c" to 3), mutable.getExts())
+
+        mutable.putAllExts(mapOf("a" to 10))
+        assertEquals(10, mutable.getExts()["a"])
+    }
+
+    @Test
+    fun testMutableYapiApiDocExtsInheritedFromSource() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("inherited" to true)
+        )
+        val mutable = MutableYapiApiDoc.from(doc)
+
+        assertEquals(mapOf("inherited" to true), mutable.getExts())
+
+        // Modifying mutable exts should not affect the original
+        mutable.setExt("new_key", "new_val")
+        assertEquals(mapOf("inherited" to true), doc.getExts())
+        assertEquals(mapOf("inherited" to true, "new_key" to "new_val"), mutable.getExts())
+    }
+
+    @Test
+    fun testMutableYapiApiDocBuildApiDocBody() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        )
+        mutable.title = "Modified Title"
+        mutable.setExt("custom_ext", "ext_value")
+
+        val json = formatter.buildApiDocBody(mutable, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("Modified Title", obj.get("title").asString)
+        assertEquals("ext_value", obj.get("custom_ext").asString)
+    }
+
+    @Test
+    fun testMutableYapiApiDocExtensionOverwritesStandardField() {
+        val mutable = MutableYapiApiDoc.from(
+            MutableYapiApiDoc.create(title = "Original", path = "/p", method = "get")
+        )
+        mutable.setExt("title", "Overridden")
+
+        val json = formatter.buildApiDocBody(mutable, "tok", "cat1")
+        val obj = JsonParser.parseString(json).asJsonObject
+
+        assertEquals("Overridden", obj.get("title").asString)
     }
 
     // endregion

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/model/YapiModelsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/yapi/model/YapiModelsTest.kt
@@ -1,0 +1,364 @@
+package com.itangcent.easyapi.exporter.yapi.model
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Unit tests for YAPI model classes in [com.itangcent.easyapi.exporter.yapi.model].
+ *
+ * Covers [YapiApiDoc.copy], data class semantics of [MutableYapiApiDoc],
+ * and [Extension] support on all model types.
+ */
+class YapiModelsTest {
+
+    // -------------------------------------------------------------------------
+    // MutableYapiApiDoc.create
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `create builds instance with required fields`() {
+        val doc = MutableYapiApiDoc.create(
+            title = "Get User",
+            path = "/api/users/{id}",
+            method = "get"
+        )
+        assertEquals("Get User", doc.title)
+        assertEquals("/api/users/{id}", doc.path)
+        assertEquals("get", doc.method)
+    }
+
+    @Test
+    fun `create respects all optional fields`() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T",
+            path = "/p",
+            method = "post",
+            desc = "description",
+            markdown = "# markdown",
+            status = "done",
+            tag = listOf("user", "admin"),
+            reqHeaders = listOf(MutableYapiHeader(name = "X-Auth")),
+            reqQuery = listOf(MutableYapiQuery(name = "page")),
+            reqParams = listOf(MutableYapiPathParam(name = "id")),
+            reqBodyForm = listOf(MutableYapiFormParam(name = "file")),
+            reqBodyOther = "{}",
+            reqBodyType = "json",
+            reqBodyIsJsonSchema = true,
+            resBody = "{}",
+            resBodyType = "json",
+            resBodyIsJsonSchema = true,
+            tags = listOf("api"),
+            open = true
+        )
+        assertEquals("description", doc.desc)
+        assertEquals("# markdown", doc.markdown)
+        assertEquals("done", doc.status)
+        assertEquals(listOf("user", "admin"), doc.tag)
+        assertEquals(1, doc.reqHeaders?.size)
+        assertEquals(1, doc.reqQuery?.size)
+        assertEquals(1, doc.reqParams?.size)
+        assertEquals(1, doc.reqBodyForm?.size)
+        assertEquals("{}", doc.reqBodyOther)
+        assertEquals("json", doc.reqBodyType)
+        assertTrue(doc.reqBodyIsJsonSchema)
+        assertEquals("{}", doc.resBody)
+        assertEquals("json", doc.resBodyType)
+        assertTrue(doc.resBodyIsJsonSchema)
+        assertEquals(listOf("api"), doc.tags)
+        assertEquals(true, doc.open)
+    }
+
+    @Test
+    fun `create with exts populates extension map`() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("custom" to "value", "enabled" to true)
+        )
+        assertEquals(mapOf("custom" to "value", "enabled" to true), doc.getExts())
+    }
+
+    @Test
+    fun `create with empty exts yields empty extension map`() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        assertTrue(doc.getExts().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // MutableYapiApiDoc.from
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `from copies all fields from source`() {
+        val original = MutableYapiApiDoc.create(
+            title = "Original", path = "/orig", method = "put",
+            desc = "desc", markdown = "md", status = "undone",
+            open = false
+        )
+        val copy = MutableYapiApiDoc.from(original)
+        assertEquals(original.title, copy.title)
+        assertEquals(original.path, copy.path)
+        assertEquals(original.method, copy.method)
+        assertEquals(original.desc, copy.desc)
+        assertEquals(original.markdown, copy.markdown)
+        assertEquals(original.status, copy.status)
+        assertEquals(original.open, copy.open)
+    }
+
+    @Test
+    fun `from copies extension map from source`() {
+        val original = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("k1" to "v1", "k2" to 42)
+        )
+        val copy = MutableYapiApiDoc.from(original)
+        assertEquals(mapOf("k1" to "v1", "k2" to 42), copy.getExts())
+    }
+
+    @Test
+    fun `from result is independent from source`() {
+        val original = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        original.setExt("key", "original")
+        val copy = MutableYapiApiDoc.from(original)
+
+        original.setExt("key", "modified")
+        assertEquals("modified", original.getExts()["key"])
+        assertEquals("original", copy.getExts()["key"])
+    }
+
+    // -------------------------------------------------------------------------
+    // YapiApiDoc.copy (interface-level copy)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `copy via interface creates equal instance`() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            desc = "desc", reqBodyType = "json"
+        )
+        val copied = doc.copy()
+        assertEquals(doc.title, copied.title)
+        assertEquals(doc.path, copied.path)
+        assertEquals(doc.method, copied.method)
+        assertEquals(doc.desc, copied.desc)
+        assertEquals(doc.reqBodyType, copied.reqBodyType)
+    }
+
+    @Test
+    fun `copy via interface with overridden fields`() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(
+            title = "Original", path = "/old", method = "get"
+        )
+        val copied = doc.copy(title = "Updated", path = "/new")
+        assertEquals("Updated", copied.title)
+        assertEquals("/new", copied.path)
+        assertEquals("get", copied.method) // unchanged
+    }
+
+    @Test
+    fun `copy via interface carries exts by default`() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("custom" to "value")
+        )
+        val copied = doc.copy()
+        assertEquals(mapOf("custom" to "value"), copied.getExts())
+    }
+
+    @Test
+    fun `copy via interface drops exts when passed explicitly`() {
+        val doc: YapiApiDoc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("custom" to "value")
+        )
+        val copied = doc.copy(exts = emptyMap())
+        assertTrue(copied.getExts().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // MutableYapiApiDoc data class copy (with exts)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `data class copy preserves exts via putAllExts`() {
+        val doc = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("k" to "v")
+        )
+        val copied = MutableYapiApiDoc.from(doc)
+        assertEquals(mapOf("k" to "v"), copied.getExts())
+    }
+
+    @Test
+    fun `data class component functions work`() {
+        val doc = MutableYapiApiDoc.create(
+            title = "Title", path = "/path", method = "post"
+        )
+        val (title, path, method) = doc
+        assertEquals("Title", title)
+        assertEquals("/path", path)
+        assertEquals("post", method)
+    }
+
+    // -------------------------------------------------------------------------
+    // Data class equality
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `data class equality same values`() {
+        val a = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val b = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `data class equality different values`() {
+        val a = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        val b = MutableYapiApiDoc.create(title = "U", path = "/p", method = "get")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `data class equality ignores exts`() {
+        val a = MutableYapiApiDoc.create(
+            title = "T", path = "/p", method = "get",
+            exts = mapOf("k" to "v")
+        )
+        val b = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        // exts are not in the primary constructor, so they don't affect equality
+        assertEquals(a, b)
+    }
+
+    // -------------------------------------------------------------------------
+    // Extension helpers (setExt / putAllExts)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `setExt adds and overwrites keys`() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        doc.setExt("key", "value")
+        assertEquals("value", doc.getExts()["key"])
+
+        doc.setExt("key", "updated")
+        assertEquals("updated", doc.getExts()["key"])
+    }
+
+    @Test
+    fun `putAllExts merges multiple entries`() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        doc.putAllExts(mapOf("a" to 1, "b" to 2))
+        assertEquals(2, doc.getExts().size)
+        assertEquals(1, doc.getExts()["a"])
+        assertEquals(2, doc.getExts()["b"])
+    }
+
+    @Test
+    fun `putAllExts overwrites existing keys`() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        doc.setExt("key", "old")
+        doc.putAllExts(mapOf("key" to "new"))
+        assertEquals("new", doc.getExts()["key"])
+    }
+
+    @Test
+    fun `getExts returns immutable view`() {
+        val doc = MutableYapiApiDoc.create(title = "T", path = "/p", method = "get")
+        doc.setExt("k", "v")
+        val view = doc.getExts()
+        assertThrows(UnsupportedOperationException::class.java) {
+            (view as MutableMap<String, Any?>)["k"] = "x"
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Sub-model extensions
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `YapiHeader extension defaults to empty`() {
+        val header = MutableYapiHeader(name = "Authorization")
+        assertTrue(header.getExts().isEmpty())
+    }
+
+    @Test
+    fun `YapiHeader carries custom extensions`() {
+        val header = MutableYapiHeader(
+            name = "X-Custom"
+        ).also { it.putAllExts(mapOf("custom_field" to "extra")) }
+        assertEquals(mapOf("custom_field" to "extra"), header.getExts())
+    }
+
+    @Test
+    fun `YapiQuery extension defaults to empty`() {
+        val query = MutableYapiQuery(name = "page")
+        assertTrue(query.getExts().isEmpty())
+    }
+
+    @Test
+    fun `YapiQuery carries custom extensions`() {
+        val query = MutableYapiQuery(
+            name = "q"
+        ).also { it.putAllExts(mapOf("custom" to "value")) }
+        assertEquals(mapOf("custom" to "value"), query.getExts())
+    }
+
+    @Test
+    fun `YapiPathParam extension defaults to empty`() {
+        val param = MutableYapiPathParam(name = "id")
+        assertTrue(param.getExts().isEmpty())
+    }
+
+    @Test
+    fun `YapiPathParam carries custom extensions`() {
+        val param = MutableYapiPathParam(
+            name = "id"
+        ).also { it.putAllExts(mapOf("custom" to "value")) }
+        assertEquals(mapOf("custom" to "value"), param.getExts())
+    }
+
+    @Test
+    fun `YapiFormParam extension defaults to empty`() {
+        val form = MutableYapiFormParam(name = "file")
+        assertTrue(form.getExts().isEmpty())
+    }
+
+    @Test
+    fun `YapiFormParam carries custom extensions`() {
+        val form = MutableYapiFormParam(
+            name = "file"
+        ).also { it.putAllExts(mapOf("custom" to "value")) }
+        assertEquals(mapOf("custom" to "value"), form.getExts())
+    }
+
+    // -------------------------------------------------------------------------
+    // Model data class equality (sub-models)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `YapiHeader data class equality`() {
+        val a = MutableYapiHeader(name = "X-Auth", value = "Bearer x")
+        val b = MutableYapiHeader(name = "X-Auth", value = "Bearer x")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `YapiQuery data class equality`() {
+        val a = MutableYapiQuery(name = "page", value = "1")
+        val b = MutableYapiQuery(name = "page", value = "1")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `YapiPathParam data class equality`() {
+        val a = MutableYapiPathParam(name = "id", example = "42")
+        val b = MutableYapiPathParam(name = "id", example = "42")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `YapiFormParam data class equality`() {
+        val a = MutableYapiFormParam(name = "file", required = 1)
+        val b = MutableYapiFormParam(name = "file", required = 1)
+        assertEquals(a, b)
+    }
+}


### PR DESCRIPTION
Previously, the yapiInfo exposed to yapi.save.before groovy scripts was an immutable YapiApiDoc interface, preventing scripts from adding custom fields needed by forked YAPI implementations.

Now YapiApiDoc extends Extension with getExts()/setExt() for custom key-value injection, and all model types are mutable so scripts can freely modify the document before upload.

Resolves #1378