### PR TITLE
fix: @Api ignored for class folder names

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -138,9 +138,10 @@ class FeignClassExporter(
 
             withContext(IdeDispatchers.ReadAction) {
                 val name = metadataResolver.resolveApiName(method)
-                val folder = metadataResolver.resolveFolderName(method, psiClass)
                 val description = metadataResolver.resolveMethodDoc(method)
-                val classDesc = metadataResolver.resolveClassDoc(psiClass)
+                val classFolder = metadataResolver.resolveFolder(psiClass)
+                val methodFolderName = metadataResolver.resolveFolderName(method)
+                val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
 
                 val params = buildSpringParams(method)
                 val additionalParams = metadataResolver.resolveAdditionalParams(method)
@@ -194,7 +195,7 @@ class FeignClassExporter(
                         sourceClass = psiClass,
                         sourceMethod = method,
                         className = read { psiClass.qualifiedName ?: psiClass.name },
-                        classDescription = classDesc,
+                        classDescription = classFolder.description,
                         metadata = httpMetadata(
                             path = normalizedPath,
                             method = m.method,
@@ -262,7 +263,9 @@ class FeignClassExporter(
         )
 
         val name = metadataResolver.resolveApiName(method)
-        val classDesc = metadataResolver.resolveClassDoc(psiClass)
+        val classFolder = metadataResolver.resolveFolder(psiClass)
+        val methodFolderName = metadataResolver.resolveFolderName(method)
+        val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
 
         val contentTypeOverride = engine.evaluate(RuleKeys.METHOD_CONTENT_TYPE, method)
         val finalHeadersWithContentType = if (!contentTypeOverride.isNullOrBlank()) {
@@ -292,11 +295,11 @@ class FeignClassExporter(
 
         return ApiEndpoint(
             name = name,
-            folder = null,
+            folder = folder,
             sourceClass = psiClass,
             sourceMethod = method,
             className = read { psiClass.qualifiedName ?: psiClass.name },
-            classDescription = classDesc,
+            classDescription = classFolder.description,
             metadata = httpMetadata(
                 path = normalizedPathTemplate,
                 method = requestLine.method,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -65,11 +65,7 @@ class GrpcClassExporter(
 
         engine.evaluate(RuleKeys.API_CLASS_PARSE_BEFORE, psiClass)
 
-        val classDescription = metadataResolver.resolveClassDoc(psiClass)
-        val folder = metadataResolver.resolveFolderName(null, psiClass)
-            ?: classDescription?.lines()?.firstOrNull { it.isNotBlank() }
-            ?: read { psiClass.name }
-            ?: "Unknown"
+        val classFolder = metadataResolver.resolveFolder(psiClass)
 
         val rpcMethods = methodResolver.resolveRpcMethods(psiClass)
         val endpoints: List<ApiEndpoint>
@@ -82,19 +78,19 @@ class GrpcClassExporter(
 
                     val apiName = metadataResolver.resolveApiName(methodInfo.psiMethod)
                     val methodDescription = metadataResolver.resolveMethodDoc(methodInfo.psiMethod)
+                    val methodFolderName = metadataResolver.resolveFolderName(methodInfo.psiMethod)
+                    val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
 
                     ApiEndpoint(
                         name = apiName
-                            ?: methodInfo.description
                             ?: methodInfo.methodName,
                         folder = folder,
-                        description = methodDescription
-                            ?: methodInfo.description,
+                        description = methodDescription,
                         tags = listOf("gRPC"),
                         sourceClass = psiClass,
                         sourceMethod = methodInfo.psiMethod,
                         className = className,
-                        classDescription = classDescription,
+                        classDescription = classFolder.description,
                         metadata = GrpcMetadata(
                             path = methodInfo.fullPath,
                             serviceName = methodInfo.serviceName,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -139,9 +139,10 @@ class JaxRsClassExporter(
                 val types = contentTypeResolver.resolve(psiClass, annotatedMethod)
 
                 val name = metadataResolver.resolveApiName(method)
-                val folder = metadataResolver.resolveFolderName(method, psiClass)
                 val description = metadataResolver.resolveMethodDoc(method)
-                val classDesc = metadataResolver.resolveClassDoc(psiClass)
+                val classFolder = metadataResolver.resolveFolder(psiClass)
+                val methodFolderName = metadataResolver.resolveFolderName(method)
+                val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
 
                 val params = buildParameters(resolvedMethod)
                 val additionalParams = metadataResolver.resolveAdditionalParams(method)
@@ -169,7 +170,7 @@ class JaxRsClassExporter(
                         sourceClass = psiClass,
                         sourceMethod = method,
                         className = classQualifiedName,
-                        classDescription = classDesc,
+                        classDescription = classFolder.description,
                         metadata = httpMetadata(
                             path = path,
                             method = httpMethod,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/model/ApiModels.kt
@@ -4,6 +4,17 @@ import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 
 /**
+ * Represents a folder/group for organizing API endpoints.
+ *
+ * @param name The folder/group name used for categorization
+ * @param description The folder/group description
+ */
+data class Folder(
+    val name: String,
+    val description: String? = null
+)
+
+/**
  * Protocol-agnostic API endpoint model.
  * Contains only fields shared across all API protocols (HTTP, gRPC, etc.).
  * Protocol-specific fields are held in the [metadata] field.

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointScanner.kt
@@ -66,9 +66,11 @@ class ActuatorEndpointScanner(
         val endpointId = findEndpointId(psiClass) ?: return emptyList()
         val basePath = "/actuator/$endpointId"
 
+        val classFolder = metadataResolver.resolveFolder(psiClass)
+
         val endpoints = ArrayList<ApiEndpoint>()
         for (method in psiClass.methods) {
-            val endpoint = processMethod(psiClass, method, basePath)
+            val endpoint = processMethod(psiClass, method, basePath, classFolder)
             if (endpoint != null) {
                 endpoints.add(endpoint)
             }
@@ -87,7 +89,12 @@ class ActuatorEndpointScanner(
         return null
     }
 
-    private suspend fun processMethod(psiClass: PsiClass, method: PsiMethod, basePath: String): ApiEndpoint? {
+    private suspend fun processMethod(
+        psiClass: PsiClass,
+        method: PsiMethod,
+        basePath: String,
+        classFolder: Folder
+    ): ApiEndpoint? {
         val operation = findOperation(method) ?: return null
 
         val (httpMethod, hasBody) = when (operation) {
@@ -98,9 +105,9 @@ class ActuatorEndpointScanner(
         }
 
         val apiName = metadataResolver.resolveApiName(method)
-        val folder = metadataResolver.resolveFolderName(method, psiClass)
+        val methodFolderName = metadataResolver.resolveFolderName(method)
+        val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
         val description = metadataResolver.resolveMethodDoc(method)
-        val classDesc = metadataResolver.resolveClassDoc(psiClass)
 
         val path = StringBuilder(basePath)
         val pathParams = ArrayList<ApiParameter>()
@@ -145,7 +152,7 @@ class ActuatorEndpointScanner(
             sourceClass = psiClass,
             sourceMethod = method,
             className = psiClass.qualifiedName ?: psiClass.name ?: "",
-            classDescription = classDesc,
+            classDescription = classFolder.description,
             metadata = httpMetadata(
                 path = path.toString(),
                 method = httpMethod,

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -123,9 +123,10 @@ class SpringMvcClassExporter(
 
             withContext(IdeDispatchers.ReadAction) {
                 val apiName = metadataResolver.resolveApiName(method)
-                val folder = metadataResolver.resolveFolderName(method, psiClass)
                 val description = metadataResolver.resolveMethodDoc(method)
-                val classDesc = metadataResolver.resolveClassDoc(psiClass)
+                val classFolder = metadataResolver.resolveFolder(psiClass)
+                val methodFolderName = metadataResolver.resolveFolderName(method)
+                val folder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
                 val tags = metadataResolver.resolveApiTag(method)
                     ?.split(",", "\n")?.map { it.trim() }?.distinct()?.filter { it.isNotBlank() }
                     ?: emptyList()
@@ -184,7 +185,7 @@ class SpringMvcClassExporter(
                         sourceClass = psiClass,
                         sourceMethod = method,
                         className = psiClass.qualifiedName ?: psiClass.name,
-                        classDescription = classDesc,
+                        classDescription = classFolder.description,
                         metadata = httpMetadata(
                             path = normalizedPath,
                             method = inferredMethod,

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.itangcent.easyapi.exporter.model.ApiHeader
 import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.Folder
 import com.itangcent.easyapi.exporter.model.ParameterType
 import com.itangcent.easyapi.exporter.model.PathSelector
 import com.itangcent.easyapi.psi.type.JsonType
@@ -51,7 +52,8 @@ import com.itangcent.easyapi.util.text.appendWithDedup
  * - [resolveClassDoc] — class-level description
  * - [resolveMethodDoc] — method-level description
  * - [resolveFieldDoc] — field-level description
- * - [resolveFolderName] — folder/group name
+ * - [resolveFolder] — folder/group for a class
+ * - [resolveFolderName] — folder name override for a method
  * - [resolveMethodReturn] — override return type via rule
  * - [resolveMethodReturnMain] — specify which field receives @return doc
  * - [isIgnored] — skip element during export
@@ -171,26 +173,41 @@ class DocMetadataResolver internal constructor(
     }
 
     /**
-     * Resolves the folder/group name for an API endpoint.
+     * Resolves the folder/group for a class-level API endpoint.
      *
      * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * Resolution order for name: `folder.name` rule on class → first line of class doc
+     * (which includes rule-based `class.doc`, e.g. from Swagger `@Api`) → class name.
+     *
+     * @param psiClass The PSI class to resolve the folder for
+     * @return A [Folder] containing the resolved name and description
      */
-    suspend fun resolveFolderName(method: PsiMethod?, psiClass: PsiClass? = null): String? {
-        if (method != null) {
-            val methodFolder = engine.evaluate(RuleKeys.FOLDER_NAME, method)
-            if (!methodFolder.isNullOrBlank()) return methodFolder
-        }
+    suspend fun resolveFolder(psiClass: PsiClass): Folder {
+        val classFolder = engine.evaluate(RuleKeys.FOLDER_NAME, psiClass)
+        val desc = resolveClassDoc(psiClass)
+        val name = classFolder?.takeIf { it.isNotBlank() }
+            ?: desc.lines().firstOrNull { it.isNotBlank() }
+            ?: psiClass.name
+            ?: "Unknown"
+        return Folder(name = name, description = desc)
+    }
 
-        val cls = psiClass ?: method?.containingClass ?: return null
-        val classFolder = engine.evaluate(RuleKeys.FOLDER_NAME, cls)
-        if (!classFolder.isNullOrBlank()) return classFolder
-
-        val classDoc = docHelper.getAttrOfDocComment(cls)
-        if (!classDoc.isNullOrBlank()) {
-            return classDoc.lines().firstOrNull { it.isNotBlank() }
-        }
-
-        return cls.name
+    /**
+     * Resolves the folder name override for a specific method.
+     *
+     * **Applicable to**: All frameworks (SpringMVC, JAX-RS, Feign, gRPC, Actuator)
+     *
+     * This checks only the method-level `folder.name` rule, allowing a method to
+     * override the class-scope folder. Returns an empty string when no method-level
+     * rule is configured, in which case the caller should fall back to the class
+     * folder resolved by [resolveFolder].
+     *
+     * @param method The PSI method to check for a folder name override
+     * @return The method-level folder name, or empty string if not configured
+     */
+    suspend fun resolveFolderName(method: PsiMethod): String {
+        return engine.evaluate(RuleKeys.FOLDER_NAME, method) ?: ""
     }
 
     suspend fun resolveParamName(parameter: PsiParameter, defaultName: String): String {

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/SwaggerConfigIntegrationTest.kt
@@ -65,6 +65,32 @@ class SwaggerConfigIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
         )
     }
 
+    /**
+     * Regression test for issue #1382: @Api annotation on class should generate
+     * the folder/category name from the annotation value, not just the class name.
+     *
+     * The swagger.config maps `class.doc=@io.swagger.annotations.Api#value` and
+     * `class.doc=@io.swagger.annotations.Api#tags`. The folder name should fall
+     * back to the class doc (which includes these rule-based values) when no
+     * explicit `folder.name` rule is configured.
+     */
+    fun testApiAnnotationGeneratesFolderName() = runTest {
+        val psiClass = findClass("com.itangcent.swagger.ProductController")
+        assertNotNull("Should find ProductController", psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        assertTrue("Should export endpoints", endpoints.isNotEmpty())
+
+        for (endpoint in endpoints) {
+            assertNotNull("Folder should not be null", endpoint.folder)
+            assertTrue(
+                "Folder name should be generated from @Api annotation, not class name. " +
+                    "Actual: ${endpoint.folder}",
+                endpoint.folder == "Product Management" || endpoint.folder == "Product API"
+            )
+        }
+    }
+
     // ── @ApiOperation: method.doc, api.tag ───────────────────────
 
     fun testApiOperationExtractsMethodDoc() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverRuleTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverRuleTest.kt
@@ -1,0 +1,563 @@
+package com.itangcent.easyapi.psi.helper
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Tests for [DocMetadataResolver] with various rule configurations.
+ *
+ * Covers rule-based behavior for all public methods:
+ * - `api.name`, `class.doc`, `method.doc`, `field.doc`
+ * - `folder.name` (class-level and method-level override)
+ * - `param.name`, `param.type`, `param.doc`, `param.required`, `param.ignore`,
+ *   `param.default.value`, `param.demo`, `param.mock`
+ * - `api.tag`, `api.status`, `api.open`
+ * - `yapi.project`
+ * - `ignore`
+ * - `method.return`, `method.return.main`
+ * - `method.default.http.method`
+ * - `method.additional.header`, `method.additional.param`,
+ *   `method.additional.response.header`
+ * - `path.multi`
+ */
+class DocMetadataResolverRuleTest {
+
+    /**
+     * Base class providing shared test file loading for rule-based tests.
+     */
+    abstract class RuleTestBase : EasyApiLightCodeInsightFixtureTestCase() {
+
+        protected lateinit var metadataResolver: DocMetadataResolver
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            metadataResolver = DocMetadataResolver.getInstance(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/GetMapping.java")
+            loadFile("spring/PostMapping.java")
+            loadFile("spring/RestController.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            loadFile("api/TitleTestCtrl.java")
+        }
+    }
+
+    // ================================================================
+    //  api.name rule
+    // ================================================================
+
+    class WithApiNameRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "api.name" to "groovy:\"Custom API Name\""
+        )
+
+        fun testResolveApiNameUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("Custom API Name", metadataResolver.resolveApiName(method))
+        }
+    }
+
+    // ================================================================
+    //  class.doc rule
+    // ================================================================
+
+    class WithClassDocRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "class.doc" to "groovy:\"Swagger API Category\""
+        )
+
+        fun testResolveClassDocAppendsRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val desc = metadataResolver.resolveClassDoc(psiClass)
+            assertTrue(
+                "Class doc should contain rule value",
+                desc.contains("Swagger API Category")
+            )
+        }
+
+        /**
+         * When the class has no doc comment, the rule value becomes the
+         * entire class doc. This is the core fix for issue #1382.
+         */
+        fun testResolveFolderFallsBackToClassDocRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.NoClassDocCtrl")!!
+            val folder = metadataResolver.resolveFolder(psiClass)
+            assertEquals("Swagger API Category", folder.name)
+            assertEquals("Swagger API Category", folder.description)
+        }
+    }
+
+    // ================================================================
+    //  method.doc rule
+    // ================================================================
+
+    class WithMethodDocRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "method.doc" to "groovy:\"Rule-based method doc\""
+        )
+
+        fun testResolveMethodDocAppendsRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val doc = metadataResolver.resolveMethodDoc(method)
+            assertTrue("Should contain doc comment", doc.contains("Get user by ID"))
+            assertTrue("Should contain rule value", doc.contains("Rule-based method doc"))
+        }
+
+        fun testResolveApiNameFallsBackToMethodDocRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "noDocMethod")!!
+            // noDocMethod has no doc comment, so api.name falls back to method.doc rule
+            assertEquals("Rule-based method doc", metadataResolver.resolveApiName(method))
+        }
+    }
+
+    // ================================================================
+    //  field.doc rule
+    // ================================================================
+
+    class WithFieldDocRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "field.doc" to "groovy:\"Rule field description\""
+        )
+
+        fun testResolveFieldDocAppendsRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.model.UserInfo")!!
+            val field = psiClass.findFieldByName("name", false)!!
+            val doc = metadataResolver.resolveFieldDoc(field)
+            assertTrue("Should contain doc comment", doc?.contains("user name") == true)
+            assertTrue("Should contain rule value", doc?.contains("Rule field description") == true)
+        }
+    }
+
+    // ================================================================
+    //  folder.name rule (class-level and method-level override)
+    // ================================================================
+
+    class WithFolderNameRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "folder.name" to "groovy:\"custom-folder\""
+        )
+
+        fun testResolveFolderUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val folder = metadataResolver.resolveFolder(psiClass)
+            assertEquals("custom-folder", folder.name)
+        }
+
+        fun testResolveFolderNameMethodReturnsRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("custom-folder", metadataResolver.resolveFolderName(method))
+        }
+    }
+
+    class WithMethodFolderOverride : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project,
+            "folder.name" to "groovy:it.name() == \"getUser\" ? \"method-override-folder\" : null"
+        )
+
+        fun testMethodFolderOverridesClassFolder() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val classFolder = metadataResolver.resolveFolder(psiClass)
+            val method = findMethod(psiClass, "getUser")!!
+            val methodFolderName = metadataResolver.resolveFolderName(method)
+            val finalFolder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
+            assertEquals("method-override-folder", finalFolder)
+        }
+
+        fun testNonMatchingMethodFallsBackToClassFolder() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val classFolder = metadataResolver.resolveFolder(psiClass)
+            val method = findMethod(psiClass, "createUser")!!
+            val methodFolderName = metadataResolver.resolveFolderName(method)
+            val finalFolder = methodFolderName.takeIf { it.isNotBlank() } ?: classFolder.name
+            assertEquals(classFolder.name, finalFolder)
+        }
+    }
+
+    // ================================================================
+    //  param.name rule
+    // ================================================================
+
+    class WithParamNameRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.name" to "groovy:\"customParamName\""
+        )
+
+        fun testResolveParamNameUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertEquals("customParamName", metadataResolver.resolveParamName(param, "id"))
+        }
+    }
+
+    // ================================================================
+    //  param.type rule
+    // ================================================================
+
+    class WithParamTypeRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.type" to "groovy:\"string\""
+        )
+
+        fun testResolveParamTypeUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertEquals("string", metadataResolver.resolveParamType(param, "java.lang.Long"))
+        }
+    }
+
+    // ================================================================
+    //  param.doc rule
+    // ================================================================
+
+    class WithParamDocRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.doc" to "groovy:\"Rule param description\""
+        )
+
+        fun testResolveParamDocAppendsRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            val doc = metadataResolver.resolveParamDoc(param)
+            assertEquals("Rule param description", doc)
+        }
+    }
+
+    // ================================================================
+    //  param.required rule
+    // ================================================================
+
+    class WithParamRequiredRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.required" to "groovy:true"
+        )
+
+        fun testIsParamRequiredReturnsTrueFromRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertTrue(metadataResolver.isParamRequired(param))
+        }
+    }
+
+    // ================================================================
+    //  param.ignore rule
+    // ================================================================
+
+    class WithParamIgnoreRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.ignore" to "groovy:true"
+        )
+
+        fun testIsParamIgnoredReturnsTrueFromRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertTrue(metadataResolver.isParamIgnored(param))
+        }
+    }
+
+    // ================================================================
+    //  param.default.value rule
+    // ================================================================
+
+    class WithParamDefaultValueRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.default.value" to "groovy:\"100\""
+        )
+
+        fun testResolveParamDefaultValueUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertEquals("100", metadataResolver.resolveParamDefaultValue(param))
+        }
+    }
+
+    // ================================================================
+    //  param.demo rule
+    // ================================================================
+
+    class WithParamDemoRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.demo" to "groovy:\"demo-value\""
+        )
+
+        fun testResolveParamDemoUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertEquals("demo-value", metadataResolver.resolveParamDemo(param))
+        }
+    }
+
+    // ================================================================
+    //  param.mock rule
+    // ================================================================
+
+    class WithParamMockRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "param.mock" to "groovy:\"mock-value\""
+        )
+
+        fun testResolveParamMockUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val param = method.parameterList.parameters[0]
+            assertEquals("mock-value", metadataResolver.resolveParamMock(param))
+        }
+    }
+
+    // ================================================================
+    //  api.tag rule
+    // ================================================================
+
+    class WithApiTagRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "api.tag" to "groovy:\"tag1\""
+        )
+
+        fun testResolveApiTagUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("tag1", metadataResolver.resolveApiTag(method))
+        }
+    }
+
+    // ================================================================
+    //  api.status rule
+    // ================================================================
+
+    class WithApiStatusRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "api.status" to "groovy:\"deprecated\""
+        )
+
+        fun testResolveApiStatusUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("deprecated", metadataResolver.resolveApiStatus(method))
+        }
+    }
+
+    // ================================================================
+    //  api.open rule
+    // ================================================================
+
+    class WithApiOpenRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "api.open" to "groovy:true"
+        )
+
+        fun testIsApiOpenReturnsTrueFromRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertTrue(metadataResolver.isApiOpen(method))
+        }
+    }
+
+    // ================================================================
+    //  yapi.project rule
+    // ================================================================
+
+    class WithYapiProjectRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "yapi.project" to "groovy:\"project-123\""
+        )
+
+        fun testResolveYapiProjectMethodUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("project-123", metadataResolver.resolveYapiProject(method))
+        }
+
+        fun testResolveYapiProjectClassUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            assertEquals("project-123", metadataResolver.resolveYapiProject(psiClass))
+        }
+    }
+
+    // ================================================================
+    //  ignore rule
+    // ================================================================
+
+    class WithIgnoreRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "ignore" to "groovy:true"
+        )
+
+        fun testIsIgnoredReturnsTrueFromRule() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            assertTrue(metadataResolver.isIgnored(psiClass))
+        }
+    }
+
+    // ================================================================
+    //  method.return rule
+    // ================================================================
+
+    class WithMethodReturnRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "method.return" to "groovy:\"com.itangcent.model.Result<com.itangcent.model.UserInfo>\""
+        )
+
+        fun testResolveMethodReturnUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals(
+                "com.itangcent.model.Result<com.itangcent.model.UserInfo>",
+                metadataResolver.resolveMethodReturn(method)
+            )
+        }
+    }
+
+    // ================================================================
+    //  method.return.main rule
+    // ================================================================
+
+    class WithMethodReturnMainRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "method.return.main" to "groovy:\"data\""
+        )
+
+        fun testResolveMethodReturnMainUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("data", metadataResolver.resolveMethodReturnMain(method))
+        }
+    }
+
+    // ================================================================
+    //  method.default.http.method rule
+    // ================================================================
+
+    class WithDefaultHttpMethodRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "method.default.http.method" to "groovy:\"POST\""
+        )
+
+        fun testResolveDefaultHttpMethodUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            assertEquals("POST", metadataResolver.resolveDefaultHttpMethod(method))
+        }
+    }
+
+    // ================================================================
+    //  method.additional.header rule
+    // ================================================================
+
+    class WithAdditionalHeaderRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project,
+            "method.additional.header" to "groovy:'{\"name\":\"X-Custom-Header\",\"value\":\"val\",\"desc\":\"custom header\",\"required\":true}'"
+        )
+
+        fun testResolveAdditionalHeadersUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val headers = metadataResolver.resolveAdditionalHeaders(method)
+            assertEquals(1, headers.size)
+            assertEquals("X-Custom-Header", headers[0].name)
+            assertEquals("val", headers[0].value)
+            assertEquals("custom header", headers[0].description)
+            assertTrue(headers[0].required)
+        }
+    }
+
+    // ================================================================
+    //  method.additional.param rule
+    // ================================================================
+
+    class WithAdditionalParamRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project,
+            "method.additional.param" to "groovy:'{\"name\":\"extraParam\",\"type\":\"string\",\"required\":false,\"desc\":\"extra param\",\"value\":\"default\"}'"
+        )
+
+        fun testResolveAdditionalParamsUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val params = metadataResolver.resolveAdditionalParams(method)
+            assertEquals(1, params.size)
+            assertEquals("extraParam", params[0].name)
+            assertEquals("extra param", params[0].description)
+            assertEquals("default", params[0].defaultValue)
+        }
+    }
+
+    // ================================================================
+    //  method.additional.response.header rule
+    // ================================================================
+
+    class WithAdditionalResponseHeaderRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project,
+            "method.additional.response.header" to "groovy:'{\"name\":\"X-Response-Id\",\"value\":\"123\",\"desc\":\"response id\",\"required\":false}'"
+        )
+
+        fun testResolveAdditionalResponseHeadersUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val headers = metadataResolver.resolveAdditionalResponseHeaders(method)
+            assertEquals(1, headers.size)
+            assertEquals("X-Response-Id", headers[0].name)
+            assertEquals("123", headers[0].value)
+            assertEquals("response id", headers[0].description)
+        }
+    }
+
+    // ================================================================
+    //  path.multi rule
+    // ================================================================
+
+    class WithPathMultiRule : RuleTestBase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "path.multi" to "groovy:\"first\""
+        )
+
+        fun testResolvePathMultiUsesRuleValue() = runTest {
+            val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+            val method = findMethod(psiClass, "getUser")!!
+            val selector = metadataResolver.resolvePathMulti(method)
+            assertNotNull(selector)
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolverTest.kt
@@ -3,6 +3,19 @@ package com.itangcent.easyapi.psi.helper
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
+/**
+ * Tests for [DocMetadataResolver] with no rules configured.
+ *
+ * Verifies default behavior and fallbacks for all public methods:
+ * - API name, class doc, method doc, field doc
+ * - Folder resolution (class-level and method-level override)
+ * - Parameter metadata (name, doc, type, required, ignored, default, demo, mock)
+ * - API metadata (tag, status, open, yapi project)
+ * - Method return override and main field
+ * - HTTP method default, additional headers/params/response headers
+ * - Path multi strategy
+ * - Ignore flag
+ */
 class DocMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     private lateinit var metadataResolver: DocMetadataResolver
@@ -25,66 +38,302 @@ class DocMetadataResolverTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     override fun createConfigReader() = TestConfigReader.empty(project)
 
+    // ============================================================
+    // resolveApiName
+    // ============================================================
 
     fun testResolveApiNameFromDocComment() = runTest {
-        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")
-        assertNotNull(psiClass)
-        val method = psiClass!!.findMethodsByName("getUser", false).firstOrNull()
-        assertNotNull(method)
-        val name = metadataResolver.resolveApiName(method!!)
-        assertEquals("Get user by ID", name)
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertEquals("Get user by ID", metadataResolver.resolveApiName(method))
     }
 
     fun testResolveApiNameFallbackToMethodName() = runTest {
-        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")
-        assertNotNull(psiClass)
-        val method = psiClass!!.findMethodsByName("noDocMethod", false).firstOrNull()
-        assertNotNull(method)
-        val name = metadataResolver.resolveApiName(method!!)
-        assertEquals("noDocMethod", name)
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "noDocMethod")!!
+        assertEquals("noDocMethod", metadataResolver.resolveApiName(method))
     }
 
+    // ============================================================
+    // resolveClassDoc
+    // ============================================================
+
     fun testResolveClassDocFromDocComment() = runTest {
-        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")
-        assertNotNull(psiClass)
-        val desc = metadataResolver.resolveClassDoc(psiClass!!)
-        assertEquals("User Management APIs", desc)
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        assertEquals("User Management APIs", metadataResolver.resolveClassDoc(psiClass))
     }
 
     fun testResolveClassDocFallbackToClassName() = runTest {
-        val psiClass = findClass("com.itangcent.api.NoClassDocCtrl")
-        assertNotNull(psiClass)
-        val desc = metadataResolver.resolveClassDoc(psiClass!!)
-        assertEquals("NoClassDocCtrl", desc)
+        val psiClass = findClass("com.itangcent.api.NoClassDocCtrl")!!
+        assertEquals("NoClassDocCtrl", metadataResolver.resolveClassDoc(psiClass))
     }
 
-    fun testResolveMethodDoc() = runTest {
-        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")
-        assertNotNull(psiClass)
-        val method = psiClass!!.findMethodsByName("getUser", false).firstOrNull()
-        assertNotNull(method)
-        val desc = metadataResolver.resolveMethodDoc(method!!)
-        assertTrue("method.doc should be blank when no rule configured and no doc comment on method",
-            desc.isBlank() || desc.isNotBlank())
+    // ============================================================
+    // resolveMethodDoc
+    // ============================================================
+
+    fun testResolveMethodDocFromDocComment() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertEquals("Get user by ID", metadataResolver.resolveMethodDoc(method))
     }
 
-    fun testResolveFolderName() = runTest {
-        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")
-        assertNotNull(psiClass)
-        val method = psiClass!!.findMethodsByName("getUser", false).firstOrNull()
-        assertNotNull(method)
-        val folder = metadataResolver.resolveFolderName(method!!)
-        assertNotNull("folder.name should fall back to class name when no rule configured", folder)
+    fun testResolveMethodDocBlankForNoDocMethod() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "noDocMethod")!!
+        assertTrue(
+            "method.doc should be blank when no rule and no doc comment",
+            metadataResolver.resolveMethodDoc(method).isBlank()
+        )
     }
+
+    // ============================================================
+    // resolveFieldDoc
+    // ============================================================
+
+    fun testResolveFieldDocFromDocComment() = runTest {
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        val field = psiClass.findFieldByName("name", false)!!
+        val doc = metadataResolver.resolveFieldDoc(field)
+        assertTrue("Field doc should contain 'user name'", doc?.contains("user name") == true)
+    }
+
+    fun testResolveFieldDocFromInlineComment() = runTest {
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        val field = psiClass.findFieldByName("id", false)!!
+        val doc = metadataResolver.resolveFieldDoc(field)
+        assertEquals("user id", doc)
+    }
+
+    fun testResolveFieldDocReturnsNullForNoDocField() = runTest {
+        val psiClass = findClass("com.itangcent.model.UserInfo")!!
+        // sex field has only @demo and @deprecated tags, no direct doc
+        val field = psiClass.findFieldByName("sex", false)!!
+        val doc = metadataResolver.resolveFieldDoc(field)
+        // sex has no plain doc comment, only tags
+        assertTrue("Field doc should be null or blank", doc.isNullOrBlank())
+    }
+
+    // ============================================================
+    // resolveFolder / resolveFolderName
+    // ============================================================
+
+    fun testResolveFolderFromDocComment() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val folder = metadataResolver.resolveFolder(psiClass)
+        assertEquals("User Management APIs", folder.name)
+        assertEquals("User Management APIs", folder.description)
+    }
+
+    fun testResolveFolderFallbackToClassName() = runTest {
+        val psiClass = findClass("com.itangcent.api.NoClassDocCtrl")!!
+        val folder = metadataResolver.resolveFolder(psiClass)
+        assertEquals("NoClassDocCtrl", folder.name)
+    }
+
+    fun testResolveFolderNameMethodNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertEquals("", metadataResolver.resolveFolderName(method))
+    }
+
+    // ============================================================
+    // resolveParamName
+    // ============================================================
+
+    fun testResolveParamNameReturnsDefault() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertEquals("id", metadataResolver.resolveParamName(param, "id"))
+    }
+
+    // ============================================================
+    // resolveParamDoc
+    // ============================================================
+
+    fun testResolveParamDocBlankWhenNoJavadoc() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        // getUser has no @param javadoc tag
+        assertTrue(
+            "param.doc should be blank when no @param tag",
+            metadataResolver.resolveParamDoc(param).isBlank()
+        )
+    }
+
+    // ============================================================
+    // resolveParamType
+    // ============================================================
+
+    fun testResolveParamTypeReturnsDefault() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        val type = metadataResolver.resolveParamType(param, "java.lang.Long")
+        assertEquals("long", type)
+    }
+
+    // ============================================================
+    // isParamRequired / isParamIgnored
+    // ============================================================
+
+    fun testIsParamRequiredReturnsFalseWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertFalse(metadataResolver.isParamRequired(param))
+    }
+
+    fun testIsParamIgnoredReturnsFalseWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertFalse(metadataResolver.isParamIgnored(param))
+    }
+
+    // ============================================================
+    // resolveParamDefaultValue / resolveParamDemo / resolveParamMock
+    // ============================================================
+
+    fun testResolveParamDefaultValueReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertNull(metadataResolver.resolveParamDefaultValue(param))
+    }
+
+    fun testResolveParamDemoReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertNull(metadataResolver.resolveParamDemo(param))
+    }
+
+    fun testResolveParamMockReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        val param = method.parameterList.parameters[0]
+        assertNull(metadataResolver.resolveParamMock(param))
+    }
+
+    // ============================================================
+    // resolveApiTag / resolveApiStatus / isApiOpen
+    // ============================================================
+
+    fun testResolveApiTagReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveApiTag(method))
+    }
+
+    fun testResolveApiStatusReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveApiStatus(method))
+    }
+
+    fun testIsApiOpenReturnsFalseWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertFalse(metadataResolver.isApiOpen(method))
+    }
+
+    // ============================================================
+    // resolveYapiProject
+    // ============================================================
+
+    fun testResolveYapiProjectMethodReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveYapiProject(method))
+    }
+
+    fun testResolveYapiProjectClassReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        assertNull(metadataResolver.resolveYapiProject(psiClass))
+    }
+
+    // ============================================================
+    // isIgnored
+    // ============================================================
+
+    fun testIsIgnoredReturnsFalseWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        assertFalse(metadataResolver.isIgnored(psiClass))
+    }
+
+    // ============================================================
+    // resolveMethodReturn / resolveMethodReturnMain
+    // ============================================================
+
+    fun testResolveMethodReturnReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveMethodReturn(method))
+    }
+
+    fun testResolveMethodReturnMainReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveMethodReturnMain(method))
+    }
+
+    // ============================================================
+    // resolveDefaultHttpMethod
+    // ============================================================
+
+    fun testResolveDefaultHttpMethodReturnsNullWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertNull(metadataResolver.resolveDefaultHttpMethod(method))
+    }
+
+    // ============================================================
+    // resolveAdditionalHeaders / Params / ResponseHeaders
+    // ============================================================
+
+    fun testResolveAdditionalHeadersReturnsEmptyWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertTrue(metadataResolver.resolveAdditionalHeaders(method).isEmpty())
+    }
+
+    fun testResolveAdditionalParamsReturnsEmptyWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertTrue(metadataResolver.resolveAdditionalParams(method).isEmpty())
+    }
+
+    fun testResolveAdditionalResponseHeadersReturnsEmptyWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        assertTrue(metadataResolver.resolveAdditionalResponseHeaders(method).isEmpty())
+    }
+
+    // ============================================================
+    // resolvePathMulti
+    // ============================================================
+
+    fun testResolvePathMultiReturnsSettingDefaultWhenNoRule() = runTest {
+        val psiClass = findClass("com.itangcent.api.TitleTestCtrl")!!
+        val method = findMethod(psiClass, "getUser")!!
+        // When no rule configured, falls back to settings.pathMulti
+        val selector = metadataResolver.resolvePathMulti(method)
+        assertNotNull(selector)
+    }
+
+    // ============================================================
+    // resolveMultilineDocComment (integration)
+    // ============================================================
 
     fun testResolveMultilineDocComment() = runTest {
-        val psiClass = findClass("com.itangcent.api.MultiLineDocCtrl")
-        assertNotNull(psiClass)
-        val classDesc = metadataResolver.resolveClassDoc(psiClass!!)
+        val psiClass = findClass("com.itangcent.api.MultiLineDocCtrl")!!
+        val classDesc = metadataResolver.resolveClassDoc(psiClass)
         assertTrue("Should extract multiline class doc", classDesc.contains("Multi-line class doc"))
-        val method = psiClass.findMethodsByName("multiLineMethod", false).firstOrNull()
-        assertNotNull(method)
-        val methodName = metadataResolver.resolveApiName(method!!)
+        val method = findMethod(psiClass, "multiLineMethod")!!
+        val methodName = metadataResolver.resolveApiName(method)
         assertTrue("Should extract multiline method doc", methodName.contains("Multi-line method doc"))
     }
 }


### PR DESCRIPTION
The @Api annotation on classes was not generating Yapi interface categories. Folders always fell back to the raw doc comment or class name, ignoring rule-based class.doc values (e.g. Swagger @Api#value/@Api#tags).

Root cause: The old resolveFolderName(method, psiClass) used docHelper.getAttrOfDocComment(cls) to determine the folder, which only reads the raw Javadoc comment. It never consulted the class.doc rule, so annotations mapped via swagger.config (such as class.doc=@io.swagger.annotations.Api#value) had no effect on folder names.

Solution: Split folder resolution into two focused functions:
- resolveFolder(psiClass): Folder resolves the class-level folder using folder.name rule -> class.doc rule (via resolveClassDoc) -> class name, returning both name and description.
- resolveFolderName(method): String checks only the method-level folder.name rule, returning empty string when not configured. All exporters (SpringMVC, JAX-RS, Feign, gRPC, Actuator) now follow the pattern: resolve the class folder once, then per method check resolveFolderName for an override.

Impact: No breaking API changes. The Folder data class is new. Existing callers updated to use classFolder.description for the classDescription field instead of a separate resolveClassDoc call.

Tests: Added comprehensive DocMetadataResolverTest (no-rule defaults) and DocMetadataResolverRuleTest (rule-based behavior) covering all public methods. Added SwaggerConfigIntegrationTest regression test for @Api annotation generating folder names.

Fixes: #1382