### PR TITLE
docs: add git-commit skill, AGENTS.md, and fix skill accuracy issues

### DIFF
--- a/.skills/bug-fixer/SKILL.md
+++ b/.skills/bug-fixer/SKILL.md
@@ -36,6 +36,7 @@ Before fixing, verify:
 - Create a test that reproduces the bug (should fail)
 - This ensures we understand the bug correctly
 - Provides regression protection
+- Follow the **write-test-case** skill (`.skills/write-test-case/SKILL.md`) to choose the correct test pattern and utilities for the target class
 
 ### 5. Fix the Bug
 
@@ -48,6 +49,14 @@ Before fixing, verify:
 - Run the test case - it should now pass
 - Run related tests to ensure no regression
 - If tests fail, re-analyze and fix again
+
+```bash
+# Run a specific test class
+./gradlew test --tests "com.itangcent.easyapi.{package}.{ClassName}Test"
+
+# Run all tests
+./gradlew test
+```
 
 ## Example Workflow
 

--- a/.skills/git-commit/SKILL.md
+++ b/.skills/git-commit/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: "git-commit"
+description: "Generates standardized Git commit messages following conventional commit rules. Invoke when user asks to write a commit message, create a commit, or needs help formatting a git commit."
+---
+
+# Git Commit
+
+This skill generates clear, standardized Git commit messages that prioritize **human readability** and **debugging efficiency**.
+
+**Core Principle:** The subject line answers *"What is the user/system impact?"* (Issue Y). The body explains *"How did we implement it?"* (Solution X).
+
+## When to Use
+
+Invoke this skill when:
+- User asks to "write a commit message" or "create a commit"
+- User wants to commit staged changes and needs a proper message
+- User asks for help formatting a git commit
+- User mentions "commit", "commit message", or "git commit" in the context of creating one
+
+## Workflow
+
+### Step 1: Analyze the Changes
+
+Before writing the commit message, understand what changed:
+
+```bash
+# View staged changes
+git diff --cached --stat
+git diff --cached
+
+# View recent commit history for style reference
+git log --oneline -10
+```
+
+### Step 2: Determine the Commit Type
+
+Identify the type of change from the mandatory type list (see Section 3).
+
+### Step 3: Draft the Subject Line
+
+Follow the Subject Line Rules (see Section 1).
+
+### Step 4: Draft the Body
+
+Follow the Body Rules (see Section 2). When fixing a bug, the body **MUST** answer the four questions:
+1. The Problem
+2. The Root Cause
+3. The Solution
+4. The Impact
+
+### Step 5: Append Ticket Link
+
+If a ticket/issue exists, append `Fixes: #<issue>` or `Refs: #<issue>` at the bottom.
+
+### Step 6: Create the Commit
+
+Use a HEREDOC to preserve formatting:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <subject>
+
+<body>
+
+Fixes: #<ticket>
+EOF
+)"
+```
+
+---
+
+## 1. Subject Line Rules (The "Headline")
+
+- **Format:** `<type>(<scope>): <subject>` or `<type>!: <subject>` for breaking changes, or `release v?x.y.z` for releases
+- **Tense:** Must use **imperative, present tense** (e.g., `Add`, `Fix`, `Update`, `Remove`). **Never** use past tense (e.g., `Added`, `Fixed`, `Updated`).
+- **Length:** Strictly **≤ 50 characters**.
+- **Capitalization:** Capitalize the first letter of the subject.
+- **Punctuation:** **No period** at the end.
+- **Content Focus (CRITICAL):**
+    - If the commit is a **`fix:`** (bug fix), the subject **MUST** describe the **problem (Y)** (e.g., `Fix login redirect loop on Safari`). **DO NOT** put the implementation (X) in the subject.
+    - If the commit is a **`feat:`** (new feature), the subject **MUST** describe the **feature itself (X)** (e.g., `Add dark mode toggle`).
+
+---
+
+## 2. Body Rules (The "Context")
+
+- **Separation:** Leave exactly **one blank line** between the subject and the body.
+- **Line Wrap:** Wrap text at **72 characters**.
+- **Content Structure:** When fixing an issue (Y), the body **MUST** explicitly answer these four questions:
+    1. **The Problem:** What was broken or lacking?
+    2. **The Root Cause:** Why did it happen?
+    3. **The Solution (X):** How does this code change fix it?
+    4. **The Impact:** Does this affect other systems or APIs?
+
+---
+
+## 3. Conventional Commit Types (Mandatory)
+
+You **MUST** prefix the subject with one of these exact types:
+
+| Type | When to use | Auto-label |
+| :--- | :--- | :--- |
+| **feat** | A new feature for the user (X) | `type: new feature` |
+| **fix** | A bug fix for the user (Y) | `type: bug` |
+| **enhance** | Enhancement to existing features | `type: enhancement` |
+| **refactor** | Code restructuring - no feature change and no bug fix | `type: enhancement` |
+| **perf** | Performance improvement | `type: enhancement` |
+| **docs** | Documentation changes only | `type: doc` |
+| **test** | Adding or fixing tests | `type: test` |
+| **style** | Code style (formatting, semicolons, etc.) - no logic change | `type: chore` |
+| **build** | Build system changes (dependencies, build config) | `type: chore` |
+| **chore** | Maintenance tasks (configs, tooling) | `type: chore` |
+| **amend** | Small amendments or corrections | `type: amend` |
+| **release** | Release version (format: `release x.y.z`) | `release` |
+
+---
+
+## 4. Ticket Linking
+
+If a ticket/issue exists, **MUST** append one of these to the very bottom of the body:
+- `Fixes: #<issue-number>` (if it completely closes the issue)
+- `Refs: #<issue-number>` (if it partially addresses it)
+
+---
+
+## 5. Strict Forbidden Patterns (Never Do These)
+
+- ❌ **No emojis** (e.g., 🐛, ✨) in the subject line.
+- ❌ **No vague subjects** like `Fix stuff`, `Update code`, or `WIP`.
+- ❌ **No passive voice** (e.g., `Error was fixed` → use `Fix error`).
+- ❌ **No past tense** (e.g., `Updated` → use `Update`).
+- ❌ **Do not put the implementation details (X) in the subject line** when fixing a bug—reserve X for the body.
+
+---
+
+## 6. Correct Example
+
+```text
+fix(payment): resolve checkout timeout during 3D Secure redirects
+
+The checkout process was failing for users with banks requiring
+3D Secure authentication due to a strict 5-second timeout.
+
+Root cause: The API client did not account for external redirects,
+which take 7-10 seconds to return to our callback URL.
+
+Solution: Increased the global timeout to 30 seconds and added
+exponential backoff retry logic specifically for the payment endpoint.
+We also added a loading state to prevent duplicate submissions.
+
+This change does not affect the regular non-3DS flow.
+
+Fixes: #4421
+```
+
+---
+
+## 7. Copy-Paste Template
+
+When generating the commit, strictly follow this structural template:
+
+```
+<type>(<scope>): <Imperative summary of Y if fix, or X if feat>
+
+<Problem summary>
+Root cause: <Explanation>
+Solution: <Implementation details X>
+Impact: <Side effects>
+
+Fixes: #<ticket>
+```
+
+---
+
+## 8. Enforcement (Optional for CI/CD)
+
+If you want to enforce this automatically, install `commitlint` and use this `commitlint.config.js`:
+
+```javascript
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [2, 'always', 'sentence-case'],
+    'subject-max-length': [2, 'always', 50],
+    'body-max-line-length': [2, 'always', 72],
+    'type-enum': [2, 'always', [
+      'feat', 'fix', 'enhance', 'refactor', 'perf', 'docs', 'test',
+      'style', 'build', 'chore', 'amend', 'release'
+    ]]
+  }
+};
+```

--- a/.skills/review-commit/SKILL.md
+++ b/.skills/review-commit/SKILL.md
@@ -50,7 +50,7 @@ Filter to focus on source code files:
 
 For each changed source file:
 
-1. Read the file content using `mcp_Filesystem_read_text_file` or `Read` tool
+1. Read the file content using the `Read` tool (preferred) or `mcp_Filesystem_read_text_file`
 2. Analyze the class structure:
    - Class name and purpose
    - Key methods and their responsibilities
@@ -150,8 +150,8 @@ Create a markdown document at `docs/test-plan-<feature-name>.md` with:
 ## 5. Test File Locations
 
 ```
-src/test/kotlin/com/example/
-├── package/
+src/test/kotlin/com/itangcent/easyapi/
+├── {package}/
 │   ├── ClassTest.kt
 │   └── ...
 ```
@@ -178,14 +178,15 @@ src/test/kotlin/com/example/
 
 ## 8. Test Patterns and Utilities
 
-### Test Base Classes
-- List applicable test base classes
+Refer to the **write-test-case** skill (`.skills/write-test-case/SKILL.md`) for the project's test patterns and utilities:
 
-### Test Data
-- Test data file locations
+- **Pattern A** — Simple Unit Test (plain JUnit 4, no IDE dependency)
+- **Pattern B** — IDE Fixture Test (`EasyApiLightCodeInsightFixtureTestCase` for PSI/Project-aware tests)
+- **Pattern C** — ResultLoader Test (golden-file comparison)
+- **Pattern D** — Action Test (extends IDE fixture, uses `AnActionEvent.createFromDataContext`)
+- **Pattern E** — Parity Test (multiple implementations of same interface)
 
-### Mock Utilities
-- Available mock utilities
+Key test utilities: `ApiFixtures`, `TestConfigReader`, `ResultLoader`, `SettingBinder.update { }`, `ProjectWrapper`
 
 ---
 
@@ -250,3 +251,4 @@ The skill produces a comprehensive test plan document that:
 - Check if tests already exist for modified files
 - Consider integration tests for complex workflows
 - Group related classes by package or feature
+- When suggesting test patterns, follow the **write-test-case** skill guidelines (`.skills/write-test-case/SKILL.md`)

--- a/.skills/write-test-case/SKILL.md
+++ b/.skills/write-test-case/SKILL.md
@@ -21,8 +21,7 @@ Read the class under test and answer these questions:
 | Does it need a real IntelliJ `Project` object? | IDE fixture pattern |
 | Does it export/format API endpoints? | IDE fixture + `ResultLoader` pattern |
 | Is it a pure utility / data class with no IDE dependency? | Simple unit test pattern |
-| Is it an `AnAction` subclass? | Action mock pattern |
-| Does it involve coroutines / `ActionContext`? | `ActionContextTestKit` pattern |
+| Is it an `AnAction` subclass? | Action test pattern (extends IDE fixture) |
 | Is it testing that multiple implementations share the same interface? | Parity test pattern |
 
 ---
@@ -47,57 +46,45 @@ The only meaningful exception is legacy code you genuinely cannot refactor. Even
 ## Step 2 — Choose the Right Pattern
 
 ### Pattern A — Simple Unit Test
-**When:** Pure utility, data model, cache service, or any class with no IntelliJ platform dependency.
+**When:** Pure utility, data model, formatter with no IntelliJ platform dependency, or any class with no IDE dependency.
 
-**Base:** None (plain JUnit 4 class)  
-**Annotations:** `@Test`, `@Before`, `@After`  
+**Base:** None (plain JUnit 4 class)
+**Annotations:** `@Test`, `@Before`, `@After`
 **Mocking:** `mock<T>()` from `mockito-kotlin`
 
 ```kotlin
 import org.junit.Assert.*
-import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
 
 class MyServiceTest {
 
-    private lateinit var service: MyService
-
-    @Before
-    fun setUp() {
-        service = MyService(mock()) // inject mocks via constructor
-    }
-
     @Test
     fun testSomeBehavior() {
-        val result = service.doSomething("input")
+        val result = MyService.doSomething("input")
         assertEquals("expected", result)
-    }
-
-    @Test
-    fun testNullCase() {
-        assertNull(service.getString("nonexistent"))
     }
 }
 ```
 
-**Real examples:** `CacheServiceTest`, `GsonUtilsTest`, `HttpModelsTest`
+**Real examples:** `GsonUtilsTest`, `HttpModelsTest`, `CurlFormatterTest`
 
 ---
 
 ### Pattern B — IDE Fixture Test (PSI / Project-aware)
 **When:** Class needs a real `Project`, reads PSI elements, or is a project-level service.
 
-**Base:** `EasyApiLightCodeInsightFixtureTestCase`  
+**Base:** `EasyApiLightCodeInsightFixtureTestCase`
 **Key methods available:**
 - `loadFile(path)` — loads a Java file from `src/test/resources/` into the fixture project
 - `loadFile(path, content)` — loads inline Java source
 - `findClass(qualifiedName)` — finds a `PsiClass` by FQN
 - `findMethod(psiClass, name)` — finds a method on a class
-- `runTest { }` — runs a suspend block inside the `ActionContext`
-- `setSettings(settings)` / `updateSettings { }` — mutate test settings
-- `instance<T>()` — resolve a bound type from `ActionContext`
-- `customizeContext(builder)` — override to add extra bindings
+- `waitForClass(qualifiedName, timeoutMs)` — polls until a class is indexed (use when `findClass` returns null due to async indexing)
+- `loadJDKClass(fqn)` — loads a JDK class stub into the fixture (needed for collection types, etc.)
+- `loadSource(clazz)` — loads a class from source into the fixture
+- `runTest { }` — runs a suspend block inside `runBlocking`
+- `settingBinder` — property to access/modify test settings (via `SettingBinder.getInstance(project)`)
+- `createConfigReader()` — override to supply custom config rules
 
 **Test method naming:** use `fun test...()` (no `@Test` annotation — JUnit 3 style inherited from `LightJavaCodeInsightFixtureTestCase`)
 
@@ -112,16 +99,11 @@ class MyExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
     override fun setUp() {
         super.setUp()
         loadTestFiles()
-        exporter = MyExporter(actionContext)
+        exporter = MyExporter.getInstance(project) // or MyExporter(project)
     }
 
     // Override to supply config rules for this test class
     override fun createConfigReader() = TestConfigReader.empty(project)
-
-    // Override to inject extra services into ActionContext
-    override fun customizeContext(builder: ActionContextBuilder) {
-        builder.bind(MyHelper::class, MyHelperImpl())
-    }
 
     private fun loadTestFiles() {
         loadFile("spring/RequestMapping.java")
@@ -142,12 +124,16 @@ class MyExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
 
 **Real examples:** `ExportOrchestratorTest`, `ApiDashboardServiceTest`, `DefaultConfigReaderTest`, `EndToEndExportTest`
 
+**Important — Same-Package Import Requirement:** In the IntelliJ PSI test fixture environment, all classes referenced by a Java file must be explicitly imported, even if they are in the same package. Without proper imports, the PSI will treat unresolved type references as `UnresolvedType`. For example, if `UserController.java` uses `OrderedDTO` from the same package, it must include `import com.itangcent.jackson.OrderedDTO;` even though they share the same package declaration.
+
+**Important — Async PSI Indexing:** After `loadFile()`, `findClass()` may return `null` because the PSI index updates asynchronously. Use `waitForClass(qualifiedName)` which polls until the class is resolvable, instead of relying on a fixed `delay()`.
+
 ---
 
 ### Pattern C — ResultLoader (snapshot / golden-file) Test
 **When:** The output is a large formatted string (Markdown, Postman JSON, curl commands) that should be compared against a saved expected result.
 
-**Base:** `EasyApiLightCodeInsightFixtureTestCase`  
+**Base:** `EasyApiLightCodeInsightFixtureTestCase`
 **Utility:** `ResultLoader`
 
 **How it works:**
@@ -158,6 +144,7 @@ class MyExporterTest : EasyApiLightCodeInsightFixtureTestCase() {
 **File naming convention:**
 - Default: `com.itangcent.easyapi.exporter.MyFormatterTest.txt`
 - Named: `com.itangcent.easyapi.exporter.MyFormatterTest.testParseRequests.txt`
+- Inner classes: `$` is replaced by `.` (e.g., `MyTest.InnerTest` → `MyTest.InnerTest.txt`)
 
 ```kotlin
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
@@ -175,97 +162,82 @@ class MyFormatterTest : EasyApiLightCodeInsightFixtureTestCase() {
 }
 ```
 
-**Real examples:** `PostmanFormatterTest`, `CurlFormatterTest`, `MarkdownApiExporterTest`
+**Real examples:** `PostmanFormatterTest`, `CurlFormatterTest`
 
 ---
 
-### Pattern D — Action Mock Test
-**When:** Testing an `AnAction` subclass or classes that receive `AnActionEvent`.
+### Pattern D — Action Test
+**When:** Testing an `AnAction` subclass.
 
-**Base:** Plain JUnit 4 (no IDE fixture needed for unit-level action tests)  
-**Mocking:** `mock(Project::class.java)`, `mock(AnActionEvent::class.java)`
+**Base:** `EasyApiLightCodeInsightFixtureTestCase` (provides a real `Project`)
+**Key:** Use `AnActionEvent.createFromDataContext` to construct events with the test `project`.
 
 ```kotlin
-import org.junit.Before
-import org.junit.Test
-import org.mockito.Mockito.*
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.*
 
-class MyActionTest {
+class MyActionTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     private lateinit var action: MyAction
-    private lateinit var mockProject: Project
-    private lateinit var mockEvent: AnActionEvent
 
-    @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         action = MyAction()
-        mockProject = mock(Project::class.java)
-        mockEvent = mock(AnActionEvent::class.java)
-        `when`(mockEvent.project).thenReturn(mockProject)
-        `when`(mockEvent.presentation).thenReturn(Presentation())
     }
 
-    @Test
-    fun testActionUpdate() {
-        action.update(mockEvent)
-        verify(mockEvent).presentation
+    fun testUpdateWithProject() {
+        val presentation = Presentation()
+        val event = AnActionEvent.createFromDataContext(
+            "test",
+            presentation
+        ) { project }
+
+        action.update(event)
+
+        assertTrue("Action should be enabled with project", event.presentation.isEnabled)
     }
-}
-```
 
-**Real examples:** `BaseExportActionTest`
+    fun testUpdateWithoutProject() {
+        val presentation = Presentation()
+        val event = AnActionEvent.createFromDataContext(
+            "test",
+            presentation
+        ) { null }
 
----
+        action.update(event)
 
-### Pattern E — ActionContextTestKit (coroutine / context-scoped)
-**When:** Testing a class that requires `ActionContext` but does NOT need a full IDE fixture (no PSI).
-
-**Utility:** `ActionContextTestKit`
-
-```kotlin
-import com.itangcent.easyapi.testFramework.ActionContextTestKit
-import com.itangcent.easyapi.testFramework.ActionContextTestKit.binding
-import com.itangcent.easyapi.testFramework.TestConfigReader
-import org.junit.Test
-
-class MyContextAwareServiceTest {
-
-    @Test
-    fun testServiceBehavior() {
-        ActionContextTestKit.withTestContext(
-            project = mockProject,
-            configReader = TestConfigReader.fromRules("rule.key" to "rule.value"),
-            additionalBindings = listOf(binding<MyDep>(MyDepImpl()))
-        ) {
-            val service = instance<MyContextAwareService>()
-            val result = service.compute()
-            assertEquals("expected", result)
-        }
+        assertFalse("Action should be disabled without project", event.presentation.isEnabled)
     }
 }
 ```
 
-**Variants:**
-- `withTestContext(project, settings, configReader, additionalBindings) { }` — full control
-- `withSimpleContext { }` — minimal setup with SPI bindings only
-- `createTestContext(...)` — manual lifecycle management
+**Real examples:** `ExportApiActionTest`, `ChannelExportActionTest`, `ApiCallActionTest`, `EasyApiActionTest`
 
 ---
 
-### Pattern F — Parity / Contract Test
+### Pattern E — Parity / Contract Test
 **When:** Verifying that multiple implementations of the same interface all exist and behave consistently.
 
 **Base:** `EasyApiLightCodeInsightFixtureTestCase`
 
 ```kotlin
+import com.itangcent.easyapi.exporter.feign.FeignClassExporter
+import com.itangcent.easyapi.exporter.jaxrs.JaxRsClassExporter
+import com.itangcent.easyapi.exporter.springmvc.SpringMvcClassExporter
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.*
+
 class ExporterParityTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     override fun createConfigReader() = TestConfigReader.empty(project)
 
     fun testAllExportersExist() = runTest {
-        assertNotNull(SpringMvcClassExporter(actionContext))
-        assertNotNull(FeignClassExporter(actionContext))
-        assertNotNull(JaxRsClassExporter(actionContext))
+        assertNotNull(SpringMvcClassExporter(project))
+        assertNotNull(FeignClassExporter(project))
+        assertNotNull(JaxRsClassExporter(project))
     }
 }
 ```
@@ -281,14 +253,15 @@ Use when you need `ApiEndpoint`, `Settings`, or common endpoint lists without PS
 
 ```kotlin
 val endpoint = ApiFixtures.createEndpoint(name = "getUser", path = "/api/users/{id}")
-val endpoints = ApiFixtures.createSampleEndpoints()  // 5 CRUD endpoints
-val settings = ApiFixtures.createSettings()          // settings with test token
+val getEndpoint = ApiFixtures.createGetEndpoint(name = "getUser", path = "/api/users/{id}")
 val postEndpoint = ApiFixtures.createPostEndpoint()  // POST with body params
 val uploadEndpoint = ApiFixtures.createFileUploadEndpoint()
+val endpoints = ApiFixtures.createSampleEndpoints()  // 5 CRUD endpoints
+val settings = ApiFixtures.createSettings()          // settings with test token
 ```
 
 ### `TestConfigReader` — Fake config rules
-Use to inject `.easy.api.config`-style rules without touching the filesystem.
+Use to inject `.easy.api.config`-style rules without touching the filesystem. **All factory methods require `project` as the first parameter.**
 
 ```kotlin
 // No config
@@ -296,28 +269,44 @@ TestConfigReader.empty(project)
 
 // From key=value pairs
 TestConfigReader.fromRules(
+    project,
     "method.return.main.status" to "200",
     "ignore" to "@Deprecated"
 )
 
 // From config file text
-TestConfigReader.fromConfigText("""
+TestConfigReader.fromConfigText(
+    project,
+    """
     method.return.main.status=200
     ignore=@Deprecated
-""".trimIndent())
+    """.trimIndent()
+)
 
 // From a map
-TestConfigReader.fromMap(mapOf("key" to "value"))
+TestConfigReader.fromMap(project, mapOf("key" to "value"))
 ```
 
-### `ConstantSettingBinder` — Mutable in-memory settings
-Already wired into `EasyApiLightCodeInsightFixtureTestCase` as `testSettingBinder`. Use `updateSettings { }` to change settings mid-test.
+### `SettingBinder.update { }` — Mutate settings in tests
+The `settingBinder` property in `EasyApiLightCodeInsightFixtureTestCase` provides access to settings. Use the `update` extension function to modify settings:
 
 ```kotlin
-updateSettings {
-    postmanToken = "my-token"
-    feignEnable = true
-    httpTimeOut = 5000
+// In setUp() — applies to all tests in the class
+override fun setUp() {
+    super.setUp()
+    settingBinder.update {
+        postmanToken = "my-token"
+        feignEnable = true
+        httpTimeOut = 5000
+    }
+}
+
+// In a test method — applies only to that test
+fun testSomething() {
+    settingBinder.update {
+        postmanToken = "custom-token"
+    }
+    // test code
 }
 ```
 
@@ -325,8 +314,22 @@ updateSettings {
 Use when you need to swap out a specific project service without rebuilding the whole context.
 
 ```kotlin
+import com.itangcent.easyapi.testFramework.wrap
+
 val wrappedProject = wrap(project) {
     replaceService(MyProjectService::class, FakeMyProjectService())
+}
+```
+
+Alternatively, use `project.registerServiceInstance(...)` directly in `setUp()`:
+
+```kotlin
+override fun setUp() {
+    super.setUp()
+    project.registerServiceInstance(
+        serviceInterface = MyService::class.java,
+        instance = MockMyService()
+    )
 }
 ```
 
@@ -345,13 +348,14 @@ Java source files used as PSI fixtures live in `src/test/resources/`. Common one
 
 | Path | Contents |
 |---|---|
-| `spring/` | Spring MVC annotations (GetMapping, PostMapping, etc.) |
+| `spring/` | Spring MVC annotations (GetMapping, PostMapping, PutMapping, DeleteMapping, RequestMapping, RequestParam, PathVariable, RequestBody, etc.) |
 | `api/UserCtrl.java` | Sample Spring REST controller |
 | `model/UserInfo.java`, `model/Result.java` | Common model classes |
 | `constant/UserType.java` | Enum example |
 | `jaxrs/` | JAX-RS annotations |
 | `feign/` | Feign annotations |
 | `validation/` | javax.validation annotations |
+| `jdk/` | JDK class stubs for the light fixture |
 
 Always load the minimum set of files needed. Load Spring annotation stubs before loading controllers that use them.
 
@@ -365,13 +369,11 @@ Target class uses PSI / Project?
 │         Output is a large formatted string?
 │         └── YES → also use Pattern C (ResultLoader)
 └── NO
-    ├── Has ActionContext dependency (no PSI)?
-    │   └── YES → Pattern E (ActionContextTestKit)
     ├── Is an AnAction subclass?
-    │   └── YES → Pattern D (Action Mock)
+    │   └── YES → Pattern D (Action Test — still extends IDE fixture for real Project)
     ├── Testing multiple implementations for parity?
-    │   └── YES → Pattern F (Parity Test)
-    └── Pure utility / data class?
+    │   └── YES → Pattern E (Parity Test)
+    └── Pure utility / data class / formatter?
         └── YES → Pattern A (Simple Unit Test)
 ```
 
@@ -382,5 +384,20 @@ Target class uses PSI / Project?
 - Test class: `src/test/kotlin/com/itangcent/easyapi/{package}/{ClassName}Test.kt`
 - Golden files: `src/test/resources/result/{FQN}.{name}.txt`
 - Test resources: `src/test/resources/{category}/`
-- Method names: `fun testSomeBehavior()` (no `@Test` in IDE fixture tests), `@Test fun testSomeBehavior()` in plain JUnit 4 tests
+- Method names: `fun testSomeBehavior()` (no `@Test` in IDE fixture tests — JUnit 3 style), `@Test fun testSomeBehavior()` in plain JUnit 4 tests
 - Assertion messages: always include a descriptive message as the first argument, e.g. `assertEquals("Should return same instance", a, b)`
+
+---
+
+## Step 7 — Running Tests
+
+```bash
+# Run all tests
+./gradlew test
+
+# Run a specific test class
+./gradlew test --tests "com.itangcent.easyapi.exporter.ExportOrchestratorTest"
+
+# Run a specific test method
+./gradlew test --tests "com.itangcent.easyapi.exporter.ExportOrchestratorTest.testGetInstanceReturnsSameInstance"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Project rules and guidance for AI agents working on the EasyYapi codebase.
+
+## Project Overview
+
+EasyYapi is an IntelliJ IDEA plugin (v3.0 rewrite) for API development — export API documentation to YApi/Postman/Markdown, send requests, and manage endpoints directly from source code.
+
+- **Language:** Kotlin (2.1.0+)
+- **JDK:** 17+
+- **IntelliJ Platform:** 2023.1+
+- **Build:** Gradle (`./gradlew build`)
+- **Tests:** `./gradlew test`
+- **Run Plugin:** `./gradlew runIde`
+
+## Architecture Principles
+
+1. **Kotlin Coroutines** — Use structured concurrency for all async operations
+2. **PSI Threading** — Methods accessing PSI must be `suspend` functions with internal read/write actions
+3. **Type Safety** — Use sealed classes for type hierarchies, data classes for DTOs
+4. **Dependency Injection** — Use IntelliJ `@Service` for singletons, `OperationScope` for per-operation objects
+
+## Code Style
+
+- Follow Kotlin coding conventions
+- Use meaningful variable and function names
+- Keep functions small and focused
+- Add KDoc comments for public APIs
+- Prefer expression bodies for simple functions
+
+## Project Structure
+
+```
+src/main/kotlin/com/itangcent/easyapi/
+├── core/          # Core infrastructure (events, threading, application services)
+├── psi/           # PSI utilities (adapters, doc helpers, type resolution)
+├── exporter/      # Export functionality (YApi, Postman, Markdown, cURL, gRPC)
+├── config/        # Config parsing and management
+├── rule/          # Rule engine and parsers
+├── http/          # HTTP client implementations
+├── ide/           # IDE integration (actions, dialogs, search)
+├── logging/       # Logging infrastructure
+├── dashboard/     # API Dashboard tool window
+└── script/        # Script execution support
+```
+
+## Testing
+
+- Write unit tests for new functionality
+- Use `EasyApiLightCodeInsightFixtureTestCase` for PSI/Project-aware tests
+- Use `mockito-kotlin` for mocking
+- Aim for good test coverage
+
+## Skills
+
+The following skills are available in the `.skills/` folder. Invoke the appropriate skill when the user's request matches the described conditions.
+
+| Skill | When to Use |
+|-------|-------------|
+| **[git-commit](.skills/git-commit/SKILL.md)** | User asks to write a commit message, create a commit, or needs help formatting a git commit. Generates standardized conventional commit messages. |
+| **[bug-fixer](.skills/bug-fixer/SKILL.md)** | User reports an error, test failure, or unexpected behavior that needs debugging and fixing. Provides systematic bug-fixing workflow with test-first approach. |
+| **[write-test-case](.skills/write-test-case/SKILL.md)** | User asks to write tests, add test coverage, or create test cases for any class. Guides test pattern selection (simple unit, IDE fixture, ResultLoader, action mock, etc.). |
+| **[review-commit](.skills/review-commit/SKILL.md)** | User asks to review a commit, analyze changes, or create a test coverage plan for recent changes. Generates a test plan document from a git commit. |
+
+### Skill Selection Guide
+
+- **Need to commit changes?** → `git-commit`
+- **Debugging an error or failure?** → `bug-fixer`
+- **Writing new tests?** → `write-test-case`
+- **Reviewing what tests a commit needs?** → `review-commit`


### PR DESCRIPTION
- Add new git-commit skill refactored from .agent/git-commit-rule.md
- Add AGENTS.md as project rule with skill usage guidance
- Fix write-test-case skill: remove fabricated ActionContextTestKit pattern, fix TestConfigReader API signatures (project param required), fix EasyApiLightCodeInsightFixtureTestCase API (remove non-existent actionContext/instance/customizeContext, add waitForClass/loadJDKClass), fix non-existent real examples, add same-package import gotcha and async PSI indexing notes
- Fix review-commit skill: correct com.example path to com.itangcent.easyapi, prefer Read tool, reference write-test-case skill for test patterns
- Fix bug-fixer skill: reference write-test-case skill, add gradle test commands