### PR TITLE
feat: implement enum resolution spec with @JsonValue/@EnumValue and @see support

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/extension/ExtensionConfigRegistry.kt
@@ -78,7 +78,8 @@ object ExtensionConfigRegistry : IdeaLog {
                         "field-utils",
                         "field-order-alphabetically", "field-order-alphabetically-desc",
                         "field-order-child-first", "field-order-parent-first",
-                        "jakarta-validation-strict", "javax-validation-strict"
+                        "jakarta-validation-strict", "javax-validation-strict",
+                        "mybatis-plus"
                     )
                     for (extName in knownExtensions) {
                         loader.getResourceAsStream("$EXTENSIONS_DIR/$extName.config")?.use { stream ->

--- a/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/DefaultPsiClassHelper.kt
@@ -794,11 +794,26 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             elementCounter = elementCounter
         )
         var options = resolveFieldOptions(resolvedType, docHelper)
+        // Case 2: field is not enum-typed but may have @see pointing to an enum.
+        // resolveOptionsWithType returns the enum's value-field JSON type so we
+        // can reconcile it against the declared type (Req 7, D-TYPE).
+        var reconciledModel = model
         if (options == null && psiElement != null) {
-            options = SeeTagResolver(project).resolveOptions(psiElement, docHelper)
+            val resolved = SeeTagResolver(project).resolveOptionsWithType(psiElement, docHelper)
+            if (resolved != null) {
+                options = resolved.options
+                val valueFieldJsonType = resolved.valueFieldJsonType
+                if (valueFieldJsonType != null && model is ObjectModel.Single) {
+                    val reconciledType = EnumValueResolver.getInstance(project)
+                        .reconcileType(model.type, valueFieldJsonType)
+                    if (reconciledType != model.type) {
+                        reconciledModel = ObjectModel.single(reconciledType)
+                    }
+                }
+            }
         }
         return FieldModel(
-            model = model,
+            model = reconciledModel,
             comment = comment,
             required = required,
             defaultValue = defaultValue,
@@ -822,7 +837,11 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             is ResolvedType.ClassType -> {
                 val psiClass = resolvedType.psiClass
                 if (isEnum(psiClass)) {
-                    resolveEnumOptions(psiClass, docHelper)
+                    // Delegate to EnumValueResolver (D-CENTRAL). Case 1 path:
+                    // field declared as enum type → context = null, seeMemberName = null.
+                    val resolver = EnumValueResolver.getInstance(project)
+                    val resolution = resolver.resolve(psiClass)
+                    resolver.buildOptions(psiClass, resolution, docHelper)
                 } else if (isCollection(psiClass)) {
                     resolvedType.typeArgs.firstOrNull()?.let {
                         resolveFieldOptions(it, docHelper)
@@ -837,169 +856,6 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
 
             else -> null
         }
-    }
-
-    /**
-     * Resolves the effective enum field name for a given enum class.
-     *
-     * This is used for **Case 1: field declared as enum type** (`XxxEnum field`).
-     * Frameworks like Spring serialize enums by name by default, so the fallback is `"name()"`.
-     *
-     * Resolution order:
-     * 1. Explicit `enum.use.custom` rule → use that field name directly
-     *    - `"name"` / `"name()"` → enum constant name
-     *    - `"ordinal"` / `"ordinal()"` → enum ordinal
-     *    - any other string → that instance field name (e.g. `"code"`)
-     * 2. Fallback → `"name()"` (enum constant name as String)
-     *
-     * Note: auto-match by type is NOT applied here. It only makes sense for
-     * Case 2 (normal-typed field with `@see EnumClass`), which is handled by [SeeTagResolver].
-     */
-    private suspend fun resolveEnumFieldName(
-        psiClass: PsiClass,
-        engine: RuleEngine
-    ): String {
-        val custom = engine.evaluate(RuleKeys.ENUM_USE_CUSTOM, psiClass)
-        if (!custom.isNullOrBlank()) return custom
-        return "name()"
-    }
-
-    private suspend fun resolveEnumOptions(
-        psiClass: PsiClass,
-        docHelper: DocHelper
-    ): List<FieldOption>? {
-        val constants = psiClass.fields.filterIsInstance<PsiEnumConstant>()
-        if (constants.isEmpty()) return null
-
-        val engine = RuleEngine.getInstance(project)
-        val fieldName = resolveEnumFieldName(psiClass, engine)
-
-        return resolveEnumOptionsByField(psiClass, constants, fieldName, docHelper)
-    }
-
-    /**
-     * Resolves enum options using a specific field's constructor argument values.
-     *
-     * Handles special pseudo-fields:
-     * - `"name"` / `"name()"` → enum constant name (String)
-     * - `"ordinal"` / `"ordinal()"` → enum ordinal index (Integer)
-     * - any other string → looks up that instance field's constructor argument
-     *
-     * For example, given:
-     * ```java
-     * enum UserType {
-     *     GUEST(30, "unspecified"),
-     *     ADMIN(1100, "administrator");
-     *     private final Integer code;
-     *     private final String desc;
-     * }
-     * ```
-     * With `fieldName = "code"`, produces options: `[{value=30, desc="unspecified"}, ...]`
-     */
-    private suspend fun resolveEnumOptionsByField(
-        psiClass: PsiClass,
-        constants: List<PsiEnumConstant>,
-        fieldName: String,
-        docHelper: DocHelper
-    ): List<FieldOption>? {
-        val normalizedName = fieldName.removeSuffix("()")
-
-        // Handle pseudo-fields: name and ordinal
-        if (normalizedName == "name") {
-            return constants.mapNotNull { constant ->
-                val name = constant.name ?: return@mapNotNull null
-                val desc = docHelper.getAttrOfDocComment(constant)
-                FieldOption(value = name, desc = desc)
-            }.ifEmpty { null }
-        }
-
-        if (normalizedName == "ordinal") {
-            return constants.mapIndexedNotNull { index, constant ->
-                constant.name ?: return@mapIndexedNotNull null
-                val desc = docHelper.getAttrOfDocComment(constant)
-                    ?: constant.name
-                FieldOption(value = index, desc = desc)
-            }.ifEmpty { null }
-        }
-
-        // Instance field lookup
-        val instanceFields = readSync {
-            psiClass.allFields
-                .filter { it !is PsiEnumConstant && !it.hasModifierProperty(PsiModifier.STATIC) }
-        }
-        val fieldIndex = instanceFields.indexOfFirst { it.name == normalizedName }
-        if (fieldIndex < 0) {
-            // Field not found — fall back to name
-            return constants.mapNotNull { constant ->
-                val name = constant.name ?: return@mapNotNull null
-                val desc = docHelper.getAttrOfDocComment(constant)
-                FieldOption(value = name, desc = desc)
-            }.ifEmpty { null }
-        }
-
-        return constants.mapNotNull { constant ->
-            val name = constant.name ?: return@mapNotNull null
-            val desc = docHelper.getAttrOfDocComment(constant)
-
-            val value: Any? = readSync {
-                val args = constant.argumentList?.expressions
-                if (args != null && fieldIndex < args.size) {
-                    SeeTagResolver.extractConstantValue(args[fieldIndex])
-                } else name
-            }
-
-            // Build description: prefer doc comment, then fall back to other field values
-            val effectiveDesc = desc ?: buildDescFromOtherFields(constant, instanceFields, fieldIndex)
-
-            FieldOption(value = value ?: name, desc = effectiveDesc)
-        }.ifEmpty { null }
-    }
-
-    /**
-     * Builds a description string from enum constructor arguments other than the value field.
-     */
-    private fun buildDescFromOtherFields(
-        constant: PsiEnumConstant,
-        instanceFields: List<PsiField>,
-        excludeIndex: Int
-    ): String? {
-        val args = constant.argumentList?.expressions ?: return null
-        val parts = mutableListOf<String>()
-        for ((i, field) in instanceFields.withIndex()) {
-            if (i == excludeIndex) continue
-            if (i < args.size) {
-                val value = SeeTagResolver.extractConstantValue(args[i])
-                if (value != null) {
-                    parts.add(value.toString())
-                }
-            }
-        }
-        return parts.joinToString(" ").takeIf { it.isNotBlank() }
-    }
-
-    /**
-     * Determines the JSON type for an enum based on the resolved field.
-     *
-     * - `"name"` / `"name()"` → STRING
-     * - `"ordinal"` / `"ordinal()"` → INT
-     * - instance field name → type of that field (e.g. `Integer code` → INT)
-     */
-    private fun resolveEnumJsonType(psiClass: PsiClass, fieldName: String): ObjectModel.Single {
-        val normalizedName = fieldName.removeSuffix("()")
-
-        if (normalizedName == "name") return ObjectModel.single(JsonType.STRING)
-        if (normalizedName == "ordinal") return ObjectModel.single(JsonType.INT)
-
-        val field = readSync {
-            psiClass.allFields.firstOrNull {
-                it !is PsiEnumConstant && it.name == normalizedName
-            }
-        }
-        if (field != null) {
-            val typeName = readSync { field.type.canonicalText }
-            return ObjectModel.single(JsonType.fromJavaType(typeName))
-        }
-        return ObjectModel.single(JsonType.STRING)
     }
 
     private suspend fun buildFieldValue(
@@ -1066,8 +922,11 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
                     } else ObjectModel.single(JsonType.OBJECT)
                     ObjectModel.map(keyModel, valueModel)
                 } else if (isEnum(psiClass)) {
-                    val fieldName = resolveEnumFieldName(psiClass, engine)
-                    resolveEnumJsonType(psiClass, fieldName)
+                    // Delegate JSON type resolution to EnumValueResolver (D-CENTRAL).
+                    val resolver = EnumValueResolver.getInstance(project)
+                    val resolution = resolver.resolve(psiClass)
+                    val jsonType = resolver.resolveJsonType(psiClass, resolution)
+                    ObjectModel.single(jsonType)
                 } else {
                     val nestedContext = if (resolvedType.typeArgs.isNotEmpty()) {
                         GenericContext(TypeResolver.resolveGenericParams(psiClass, resolvedType.typeArgs))

--- a/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
@@ -1,0 +1,558 @@
+package com.itangcent.easyapi.psi
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.psi.helper.DocHelper
+import com.itangcent.easyapi.psi.model.FieldOption
+import com.itangcent.easyapi.psi.type.JsonType
+import com.itangcent.easyapi.rule.RuleKeys
+import com.itangcent.easyapi.rule.engine.RuleEngine
+import com.itangcent.easyapi.settings.SettingBinder
+
+/**
+ * Shared value-field resolver for enum usages, used by both Case 1
+ * (`DefaultPsiClassHelper` — field declared as enum type) and Case 2
+ * (`SeeTagResolver` — normal-typed field with `@see EnumClass`).
+ *
+ * ## Resolution Algorithm (canonical priority order)
+ *
+ * 1. **`enum.use.custom` rule result** (includes annotation-driven config
+ *    recipes such as `jackson.config`'s `@JsonValue` detection and
+ *    `mybatis-plus.config`'s `@EnumValue` detection). The rule result
+ *    always wins per Req 2.4; there is no fall-through to step 2/3.
+ *    - `"name()"` → [ValueField.Name] (pseudo-field, unambiguous)
+ *    - `"ordinal()"` → [ValueField.Ordinal]
+ *    - bare `"name"` / `"ordinal"` → [ValueField.Name] / [ValueField.Ordinal]
+ *      **unless** a same-named instance field exists (issue #1383 — then
+ *      [ValueField.Instance] wins)
+ *    - any other string → [ValueField.Instance] for the matching field,
+ *      or [ValueField.Name] fallback if no such field exists
+ * 2. **Explicit `@see` member** (Case 2 only, `seeMemberName != null`):
+ *    same `name()`/`name` disambiguation as step 1; for any other member
+ *    ending in `()` (e.g. `"getCode()"`), strip the `()` then apply
+ *    [LinkResolver.getterToPropertyName] to map getters to properties.
+ * 3. **`INTELLIGENT` heuristics** (mode-gated):
+ *    - Case 1 (`context == null`): exactly one non-static non-enum instance
+ *      field → [ValueField.Instance]
+ *    - Case 2 (`context != null`): adapt `findEnumFieldByType` logic
+ *      (type + name coincidence)
+ * 4. **Fallback** → [ValueField.Name] (Spring default).
+ *
+ * Annotation intent enters at step 1 *via config* (D-GATE/D-RULE), so it
+ * keeps top priority among non-`@see` signals. The `NAME`/`INTELLIGENT`
+ * CODE heuristics (single-field, type-match) stay mode-gated for the cases
+ * where no annotation exists.
+ *
+ * ## Threading
+ * All PSI access occurs inside `readSync { }` per `AGENTS.md` threading rules.
+ */
+@Service(Service.Level.PROJECT)
+class EnumValueResolver(private val project: Project) : IdeaLog {
+
+    /**
+     * The resolved value field of an enum.
+     *
+     * - [Name] is the pseudo-field `name()` — the enum constant name.
+     * - [Ordinal] is the pseudo-field `ordinal()` — the enum constant ordinal.
+     * - [Instance] is a real instance field whose constructor argument
+     *   (or static initializer) becomes the option value.
+     */
+    sealed interface ValueField {
+        /** Pseudo-field: enum constant name → JSON type STRING. */
+        object Name : ValueField
+
+        /** Pseudo-field: enum constant ordinal → JSON type INT. */
+        object Ordinal : ValueField
+
+        /**
+         * Real instance field → JSON type = the field's type.
+         * The constant's constructor argument at this field's position
+         * (or the field's static initializer) becomes the option value.
+         */
+        data class Instance(val field: PsiField) : ValueField
+    }
+
+    /**
+     * How the value field was chosen — for logging/debugging.
+     *
+     * Note: there is no `ANNOTATION` source. Annotation detection rides
+     * the `enum.use.custom` rule (D-RULE), so its source is
+     * [ENUM_USE_CUSTOM_RULE].
+     */
+    enum class Source {
+        /** Explicit `enum.use.custom` rule (incl. annotation-driven config recipes). */
+        ENUM_USE_CUSTOM_RULE,
+
+        /** Explicit `@see Enum#member` (Case 2 only). */
+        SEE_MEMBER,
+
+        /** INTELLIGENT mode + exactly one instance field (Case 1). */
+        INTELLIGENT_SINGLE,
+
+        /** INTELLIGENT mode + Case 2 type match. */
+        INTELLIGENT_TYPE_MATCH,
+
+        /** Safe default: enum constant name (Spring default). */
+        FALLBACK_NAME
+    }
+
+    /**
+     * The result of resolving an enum's value field.
+     *
+     * @param valueField The resolved [ValueField].
+     * @param source How it was chosen — for logging/debugging.
+     */
+    data class Resolution(val valueField: ValueField, val source: Source)
+
+    /**
+     * Reads `enumFieldAutoInferEnabled` from settings.
+     *
+     * When `true`, auto-inference is enabled for ambiguous references
+     * (Case 1 single-field heuristic, Case 2 type-match heuristic).
+     * Defaults to `false` (fall back to enum constant name).
+     */
+    private fun readAutoInferEnabled(): Boolean =
+        runCatching {
+            SettingBinder.getInstance(project).read().enumFieldAutoInferEnabled
+        }.getOrNull() ?: false
+
+    /**
+     * Core decision. See [Resolution Algorithm][EnumValueResolver] above.
+     *
+     * @param enumClass The enum class to resolve.
+     * @param context The referencing element (Case 2 declaring field/method),
+     *        or null for Case 1.
+     * @param seeMemberName The parsed `@see` member (`"code"`, `"getCode()"`,
+     *        `"name()"`, …), or null for Case 1 / class-only `@see`.
+     * @param autoInferEnabled Whether auto-inference is enabled for ambiguous
+     *        references; defaults to [readAutoInferEnabled].
+     */
+    suspend fun resolve(
+        enumClass: PsiClass,
+        context: PsiElement? = null,
+        seeMemberName: String? = null,
+        autoInferEnabled: Boolean = readAutoInferEnabled()
+    ): Resolution {
+        // Step 1: enum.use.custom rule (includes annotation-driven config recipes).
+        val engine = RuleEngine.getInstance(project)
+        val ruleResult = engine.evaluate(RuleKeys.ENUM_USE_CUSTOM, enumClass)
+        if (!ruleResult.isNullOrBlank()) {
+            val resolved = parseRuleMember(enumClass, ruleResult)
+            // Multi-annotation warning (Req 2.5): best-effort FQN-based scan.
+            warnIfMultipleAnnotatedMembers(enumClass)
+            return Resolution(resolved, Source.ENUM_USE_CUSTOM_RULE)
+        }
+
+        // Step 2: explicit @see member (Case 2 only).
+        if (seeMemberName != null) {
+            val resolved = parseSeeMember(enumClass, seeMemberName)
+            if (resolved != null) {
+                return Resolution(resolved, Source.SEE_MEMBER)
+            }
+        }
+
+        // Step 3: auto-inference heuristics (setting-gated).
+        if (autoInferEnabled) {
+            // Case 1: context == null → single-field heuristic.
+            if (context == null) {
+                val instanceFields = instanceFields(enumClass)
+                if (instanceFields.size == 1) {
+                    return Resolution(ValueField.Instance(instanceFields.first()), Source.INTELLIGENT_SINGLE)
+                }
+            } else {
+                // Case 2: context != null → type-match heuristic.
+                val matched = findEnumFieldByType(enumClass, context)
+                if (matched != null) {
+                    return Resolution(ValueField.Instance(matched), Source.INTELLIGENT_TYPE_MATCH)
+                }
+            }
+        }
+
+        // Step 4: fallback → Name (Spring default).
+        return Resolution(ValueField.Name, Source.FALLBACK_NAME)
+    }
+
+    /**
+     * Parse a rule result (`enum.use.custom`) into a [ValueField].
+     *
+     * - `"name()"` → [ValueField.Name] (parenthesized = pseudo-field wins)
+     * - `"ordinal()"` → [ValueField.Ordinal]
+     * - bare `"name"` / `"ordinal"` → [ValueField.Name] / [ValueField.Ordinal]
+     *   **unless** a same-named instance field exists (issue #1383)
+     * - any other string → [ValueField.Instance] for the matching field,
+     *   or [ValueField.Name] fallback if no such field exists
+     *
+     * The rule result always wins per Req 2.4; there is no fall-through.
+     */
+    private fun parseRuleMember(enumClass: PsiClass, ruleResult: String): ValueField {
+        val normalized = ruleResult.removeSuffix("()")
+        val isPseudoCall = ruleResult.endsWith("()")
+        val instanceFields = instanceFields(enumClass)
+        val hasInstanceFieldWithName = instanceFields.any { it.name == normalized }
+
+        if (normalized == "name" && (isPseudoCall || !hasInstanceFieldWithName)) {
+            return ValueField.Name
+        }
+        if (normalized == "ordinal" && (isPseudoCall || !hasInstanceFieldWithName)) {
+            return ValueField.Ordinal
+        }
+        // Instance field lookup (rule result always wins; no fall-through).
+        val field = instanceFields.firstOrNull { it.name == normalized }
+        return field?.let { ValueField.Instance(it) } ?: ValueField.Name
+    }
+
+    /**
+     * Parse a `@see` member into a [ValueField], or null if it cannot be resolved
+     * (so the caller can fall through to step 3/4).
+     *
+     * - `"name()"` / `"ordinal()"` (with parens, preserved by `parseLinkReference`)
+     *   → [ValueField.Name] / [ValueField.Ordinal]
+     * - bare `"name"` / `"ordinal"` → [ValueField.Name] / [ValueField.Ordinal]
+     *   **unless** a same-named instance field exists (issue #1383 parity with step 1)
+     * - any other member ending in `()` (e.g. `"getCode()"`): strip the `()` first,
+     *   then apply [LinkResolver.getterToPropertyName] (`getCode` → `code`,
+     *   `isAlive` → `active`) and select the matching instance field
+     * - otherwise (no trailing `()`, not a getter): literal field name →
+     *   [ValueField.Instance] if found, else null
+     */
+    private fun parseSeeMember(enumClass: PsiClass, seeMemberName: String): ValueField? {
+        val instanceFields = instanceFields(enumClass)
+
+        // Pseudo-field forms (with parens preserved by parseLinkReference).
+        if (seeMemberName == "name()") return ValueField.Name
+        if (seeMemberName == "ordinal()") return ValueField.Ordinal
+
+        // Bare name/ordinal — yield to a same-named instance field if present (issue #1383).
+        if (seeMemberName == "name" || seeMemberName == "ordinal") {
+            val hasInstanceFieldWithName = instanceFields.any { it.name == seeMemberName }
+            if (!hasInstanceFieldWithName) {
+                return if (seeMemberName == "name") ValueField.Name else ValueField.Ordinal
+            }
+            val field = instanceFields.first { it.name == seeMemberName }
+            return ValueField.Instance(field)
+        }
+
+        // Getter form: `getCode()` → strip `()` → `getCode` → `code`.
+        if (seeMemberName.endsWith("()")) {
+            val methodName = seeMemberName.removeSuffix("()")
+            val derived = LinkResolver.getterToPropertyName(methodName) ?: methodName
+            val field = instanceFields.firstOrNull { it.name == derived }
+            return field?.let { ValueField.Instance(it) }
+        }
+
+        // Plain field name.
+        val field = instanceFields.firstOrNull { it.name == seeMemberName }
+        return field?.let { ValueField.Instance(it) }
+    }
+
+    /**
+     * Find an enum instance field whose type matches the referencing element's
+     * declared type (Case 2 INTELLIGENT type-match).
+     *
+     * When multiple fields match, prefers the one whose name matches the
+     * referencing field name.
+     */
+    private fun findEnumFieldByType(enumClass: PsiClass, contextElement: PsiElement): PsiField? {
+        val targetCanonical = readSync {
+            when (contextElement) {
+                is PsiField -> contextElement.type.canonicalText
+                is PsiMethod -> contextElement.returnType?.canonicalText
+                is PsiParameter -> contextElement.type.canonicalText
+                else -> null
+            }
+        } ?: return null
+
+        val instanceFields = instanceFields(enumClass)
+        val candidates = instanceFields.filter { field ->
+            isTypeCompatible(field.type.canonicalText, targetCanonical)
+        }
+
+        if (candidates.isEmpty()) return null
+        if (candidates.size == 1) return candidates.first()
+
+        // Multiple candidates: prefer the one whose name matches the referencing field.
+        val contextName = readSync {
+            when (contextElement) {
+                is PsiField -> contextElement.name
+                is PsiMethod -> LinkResolver.getterToPropertyName(contextElement.name) ?: contextElement.name
+                is PsiParameter -> contextElement.name
+                else -> null
+            }
+        }
+        if (contextName != null) {
+            candidates.firstOrNull { it.name == contextName }?.let { return it }
+        }
+        return candidates.first()
+    }
+
+    /**
+     * Best-effort multi-annotation warning (Req 2.5).
+     *
+     * The groovy recipe returns the first `find` hit and cannot emit warnings
+     * (it returns a string). This method does a separate FQN-based scan of the
+     * enum's fields and methods (NFR-3: `PsiAnnotation` qualified-name match,
+     * no class-load) counting members annotated with any recognized annotation
+     * FQN (`@JsonValue`, `@EnumValue`). If >1, logs a warning. The scan is
+     * best-effort — failures are silently ignored.
+     */
+    private fun warnIfMultipleAnnotatedMembers(enumClass: PsiClass) {
+        runCatching {
+            val recognizedFqns = setOf(
+                "com.fasterxml.jackson.annotation.JsonValue",
+                "com.baomidou.mybatisplus.annotation.EnumValue"
+            )
+            val annotatedCount = readSync {
+                val fields = enumClass.fields.filter { it !is PsiEnumConstant }
+                val methods = enumClass.methods
+                val annotatedFields = fields.count { field ->
+                    field.annotations.any { it.qualifiedName in recognizedFqns }
+                }
+                val annotatedMethods = methods.count { method ->
+                    method.annotations.any { it.qualifiedName in recognizedFqns }
+                }
+                annotatedFields + annotatedMethods
+            }
+            if (annotatedCount > 1) {
+                LOG.warn(
+                    "Enum ${enumClass.qualifiedName ?: enumClass.name} has $annotatedCount members " +
+                        "annotated with a recognized value annotation (@JsonValue/@EnumValue). " +
+                        "Selecting the first by declaration order; please remove the extra annotations."
+                )
+            }
+        }
+    }
+
+    /**
+     * Build options from enum constants per the resolved [ValueField].
+     *
+     * Description logic per Req 8:
+     * 1. `docHelper.getAttrOfDocComment(constant)` (NOT `SeeTagResolver.extractDocText` —
+     *    unifies Case 1/Case 2 per Req 6.2; changes Case 2 behavior, acceptable per NFR-1)
+     * 2. else if the enum has an instance field in the preferred set
+     *    (`desc`, `description`, `label`, `text`, `remark`, `message`) → use that
+     *    field's value for the constant
+     * 3. else join remaining instance-field values (current behavior)
+     *
+     * @param enumClass The enum class.
+     * @param resolution The resolved [Resolution] from [resolve].
+     * @param docHelper The [DocHelper] for doc-comment extraction.
+     */
+    suspend fun buildOptions(
+        enumClass: PsiClass,
+        resolution: Resolution,
+        docHelper: DocHelper
+    ): List<FieldOption>? {
+        val constants = readSync { enumClass.fields.filterIsInstance<PsiEnumConstant>() }
+        if (constants.isEmpty()) return null
+
+        val instanceFields = instanceFields(enumClass)
+        val preferredDescFields = listOf("desc", "description", "label", "text", "remark", "message")
+
+        return constants.mapIndexedNotNull { index, constant ->
+            val name = constant.name ?: return@mapIndexedNotNull null
+            val desc = docHelper.getAttrOfDocComment(constant)
+
+            val value: Any? = when (val vf = resolution.valueField) {
+                is ValueField.Name -> name
+                is ValueField.Ordinal -> index
+                is ValueField.Instance -> readSync {
+                    val fieldIndex = instanceFields.indexOfFirst { it.name == vf.field.name }
+                    if (fieldIndex >= 0) {
+                        val args = constant.argumentList?.expressions
+                        if (args != null && fieldIndex < args.size) {
+                            SeeTagResolver.extractConstantValue(args[fieldIndex])
+                        } else {
+                            // Fall back to the field's static initializer if no constructor arg.
+                            SeeTagResolver.extractConstantValue(vf.field.initializer)
+                        }
+                    } else {
+                        name
+                    }
+                }
+            }
+
+            // Description: (1) doc comment, (2) preferred-name field, (3) join remaining.
+            val effectiveDesc = desc ?: buildDescForConstant(constant, instanceFields, resolution.valueField, preferredDescFields)
+
+            FieldOption(value = value ?: name, desc = effectiveDesc)
+        }.ifEmpty { null }
+    }
+
+    /**
+     * Build a description for a constant when no doc comment is present.
+     *
+     * 1. If the enum has an instance field in the preferred set
+     *    (`desc`, `description`, `label`, `text`, `remark`, `message`) → use that
+     *    field's value for the constant (Req 8.2). First in the preferred set wins.
+     * 2. Else join remaining instance-field values (current behavior, Req 8.3).
+     */
+    private fun buildDescForConstant(
+        constant: PsiEnumConstant,
+        instanceFields: List<PsiField>,
+        valueField: ValueField,
+        preferredDescFields: List<String>
+    ): String? {
+        val args = constant.argumentList?.expressions ?: return null
+
+        // (1) Preferred-name field.
+        for (preferredName in preferredDescFields) {
+            val preferredIndex = instanceFields.indexOfFirst { it.name == preferredName }
+            if (preferredIndex >= 0 && preferredIndex < args.size) {
+                val value = SeeTagResolver.extractConstantValue(args[preferredIndex])
+                if (value != null) return value.toString()
+            }
+        }
+
+        // (2) Join remaining instance-field values (excluding the value field).
+        val excludeIndex = when (valueField) {
+            is ValueField.Instance -> instanceFields.indexOfFirst { it.name == valueField.field.name }
+            else -> -1
+        }
+        val parts = mutableListOf<String>()
+        for ((i, _) in instanceFields.withIndex()) {
+            if (i == excludeIndex) continue
+            if (i < args.size) {
+                val value = SeeTagResolver.extractConstantValue(args[i])
+                if (value != null) parts.add(value.toString())
+            }
+        }
+        return parts.joinToString(" ").takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Derive the JSON type for the resolved [ValueField].
+     *
+     * Returns the JSON type as a `String` (e.g. [JsonType.STRING], [JsonType.INT]).
+     * Callers wrap the result in `ObjectModel.single(...)`.
+     *
+     * - [ValueField.Name] → [JsonType.STRING]
+     * - [ValueField.Ordinal] → [JsonType.INT]
+     * - [ValueField.Instance] → [JsonType.fromJavaType] of the field's PSI type
+     */
+    fun resolveJsonType(enumClass: PsiClass, resolution: Resolution): String {
+        return when (val vf = resolution.valueField) {
+            is ValueField.Name -> JsonType.STRING
+            is ValueField.Ordinal -> JsonType.INT
+            is ValueField.Instance -> {
+                val typeName = readSync { vf.field.type.canonicalText }
+                JsonType.fromJavaType(typeName)
+            }
+        }
+    }
+
+    /**
+     * Reconcile a Case 2 declaring type against the value-field type.
+     *
+     * Takes the already-computed value-field JSON type (from [resolveJsonType])
+     * rather than re-accessing PSI — this keeps the function non-suspend and
+     * avoids a redundant read action.
+     *
+     * Per design.md D-TYPE compatibility table:
+     * - primitive↔boxed → boxed canonical
+     * - same type → that type
+     * - numeric widening/narrowing → narrower (value-field)
+     * - `Object`/`Serializable`/`Comparable` → value-field type
+     * - `String`↔numeric → value-field type
+     * - default → value-field type (values are authoritative)
+     *
+     * Logs at DEBUG when a reconciliation changes the declared type (Req 7.3).
+     */
+    fun reconcileType(declared: String, valueFieldJsonType: String): String {
+        if (declared == valueFieldJsonType) return declared
+
+        val normalizedDeclared = normalizeJsonType(declared)
+        val normalizedValue = normalizeJsonType(valueFieldJsonType)
+
+        if (normalizedDeclared == normalizedValue) {
+            // primitive↔boxed normalization — keep the value-field's form.
+            if (declared != valueFieldJsonType) {
+                LOG.debug("Reconciled enum JSON type: $declared → $valueFieldJsonType (primitive↔boxed)")
+            }
+            return valueFieldJsonType
+        }
+
+        // Declared is wider/uninformative → value-field wins.
+        val widerTypes = setOf(JsonType.OBJECT, "object")
+        if (normalizedDeclared in widerTypes) {
+            LOG.debug("Reconciled enum JSON type: $declared → $valueFieldJsonType (declared is Object/uninformative)")
+            return valueFieldJsonType
+        }
+
+        // Numeric widening/narrowing → narrower (value-field).
+        if (JsonType.isNumber(normalizedDeclared) && JsonType.isNumber(normalizedValue)) {
+            LOG.debug("Reconciled enum JSON type: $declared → $valueFieldJsonType (numeric narrowing)")
+            return valueFieldJsonType
+        }
+
+        // String↔numeric → value-field wins (incompatible; values authoritative).
+        // Default → value-field wins.
+        LOG.debug("Reconciled enum JSON type: $declared → $valueFieldJsonType (value-field authoritative)")
+        return valueFieldJsonType
+    }
+
+    /**
+     * Normalize a JSON type string for comparison (handles primitive↔boxed).
+     */
+    private fun normalizeJsonType(type: String): String {
+        return when (type) {
+            "int", "integer", "java.lang.Integer" -> JsonType.INT
+            "long", "java.lang.Long" -> JsonType.LONG
+            "short", "java.lang.Short" -> JsonType.SHORT
+            "byte", "java.lang.Byte" -> JsonType.INT
+            "float", "java.lang.Float" -> JsonType.FLOAT
+            "double", "java.lang.Double" -> JsonType.DOUBLE
+            "boolean", "java.lang.Boolean" -> JsonType.BOOLEAN
+            "char", "character", "java.lang.Character" -> JsonType.STRING
+            "string", "java.lang.String" -> JsonType.STRING
+            else -> type
+        }
+    }
+
+    /**
+     * Get the non-static, non-enum instance fields of an enum class.
+     */
+    private fun instanceFields(enumClass: PsiClass): List<PsiField> = readSync {
+        enumClass.allFields.filter {
+            it !is PsiEnumConstant && !it.hasModifierProperty(PsiModifier.STATIC)
+        }
+    }
+
+    /**
+     * Check whether two type canonical texts are compatible (same or
+     * primitive↔boxed of the same kind).
+     */
+    private fun isTypeCompatible(fieldType: String, targetType: String): Boolean {
+        if (fieldType == targetType) return true
+        return normalizeBoxedType(fieldType) == normalizeBoxedType(targetType)
+    }
+
+    /**
+     * Normalize a canonical type text to its boxed form for comparison.
+     */
+    private fun normalizeBoxedType(type: String): String {
+        return when (type) {
+            "int", "Integer", "java.lang.Integer" -> "java.lang.Integer"
+            "long", "Long", "java.lang.Long" -> "java.lang.Long"
+            "short", "Short", "java.lang.Short" -> "java.lang.Short"
+            "byte", "Byte", "java.lang.Byte" -> "java.lang.Byte"
+            "float", "Float", "java.lang.Float" -> "java.lang.Float"
+            "double", "Double", "java.lang.Double" -> "java.lang.Double"
+            "boolean", "Boolean", "java.lang.Boolean" -> "java.lang.Boolean"
+            "char", "Character", "java.lang.Character" -> "java.lang.Character"
+            else -> type
+        }
+    }
+
+    companion object {
+        /**
+         * Get the [EnumValueResolver] instance for a project.
+         *
+         * Needed by [SeeTagResolver], which is not a `@Service` itself.
+         */
+        fun getInstance(project: Project): EnumValueResolver = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/psi/LinkResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/LinkResolver.kt
@@ -5,9 +5,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.itangcent.easyapi.psi.helper.SourceHelper
+import org.jetbrains.kotlin.asJava.elements.KtLightElement
+import org.jetbrains.kotlin.psi.KtFile
 
 /**
  * Utility for resolving link references in documentation and scripts.
@@ -62,9 +65,12 @@ class LinkResolver(private val project: Project) {
      * - `ClassName` → (ClassName, null)
      * - `com.example.ClassName` → (com.example.ClassName, null)
      * - `ClassName#field` → (ClassName, field)
-     * - `com.example.ClassName#method()` → (com.example.ClassName, method)
+     * - `com.example.ClassName#method()` → (com.example.ClassName, method())
      * - `ClassName.field` → (ClassName, field)
-     * - `com.example.ClassName.method()` → (com.example.ClassName, method)
+     * - `com.example.ClassName.method()` → (com.example.ClassName, method())
+     *
+     * Note: trailing `()` on a member is preserved so the resolver can distinguish
+     * `name()` (pseudo-field) from `name` (instance field) — issue #1383.
      */
     fun parseLinkReference(linkRef: String): LinkReference? = Companion.parseLinkReference(linkRef)
 
@@ -172,10 +178,23 @@ class LinkResolver(private val project: Project) {
         facade: JavaPsiFacade,
         scope: GlobalSearchScope
     ): PsiClass? {
-        val containingFile = contextElement.containingFile as? PsiJavaFile ?: return null
-        val packageName = containingFile.packageName
-        if (packageName.isBlank()) return null
-        return facade.findClass("$packageName.$className", scope)
+        val containingFile = resolveContainingFile(contextElement) ?: return null
+
+        // Java files
+        if (containingFile is PsiJavaFile) {
+            val packageName = containingFile.packageName
+            if (packageName.isBlank()) return null
+            return facade.findClass("$packageName.$className", scope)
+        }
+
+        // Kotlin files
+        if (containingFile is KtFile) {
+            val packageName = containingFile.packageFqName?.asString() ?: return null
+            if (packageName.isBlank()) return null
+            return facade.findClass("$packageName.$className", scope)
+        }
+
+        return null
     }
 
     private fun resolveClassFromImports(
@@ -184,11 +203,18 @@ class LinkResolver(private val project: Project) {
         facade: JavaPsiFacade,
         scope: GlobalSearchScope
     ): PsiClass? {
-        val containingFile = contextElement.containingFile as? PsiJavaFile ?: return null
-        val imports = containingFile.importList?.importStatements ?: return null
+        val containingFile = resolveContainingFile(contextElement) ?: return null
 
-        for (importStmt in imports) {
-            val importRef = importStmt.qualifiedName ?: continue
+        val importRefs: List<String> = when (containingFile) {
+            is PsiJavaFile -> containingFile.importList?.importStatements
+                ?.mapNotNull { it.qualifiedName }
+                ?: emptyList()
+            is KtFile -> containingFile.importDirectives
+                .mapNotNull { it.importedFqName?.asString() }
+            else -> return null
+        }
+
+        for (importRef in importRefs) {
             val candidate = when {
                 importRef.endsWith(".$className") -> importRef
                 importRef.endsWith(".*") -> importRef.removeSuffix("*") + className
@@ -196,6 +222,41 @@ class LinkResolver(private val project: Project) {
             }
             facade.findClass(candidate, scope)?.let { return it }
         }
+
+        return null
+    }
+
+    /**
+     * Resolve the containing file for import/package lookup.
+     *
+     * For Kotlin light PSI elements (e.g., `KtLightField`), the `containingFile`
+     * is a synthetic `SymbolFakeFile` with language "JAVA" that has no package or
+     * import information. This method walks up the PSI tree to find a
+     * [KtLightElement] with a `kotlinOrigin`, then navigates to the real [KtFile].
+     */
+    private fun resolveContainingFile(contextElement: PsiElement): PsiFile? {
+        // For Kotlin light PSI elements, walk up the tree to find a KtLightElement
+        // whose kotlinOrigin gives us the original KtFile. Do this BEFORE checking
+        // the containingFile, because the containingFile of a KtLightElement is a
+        // synthetic SymbolFakeFile that implements PsiJavaFile but has no real
+        // package or import information.
+        var element: PsiElement? = contextElement
+        while (element != null) {
+            if (element is KtLightElement<*, *>) {
+                val kotlinOrigin = element.kotlinOrigin
+                if (kotlinOrigin != null) {
+                    val originFile = kotlinOrigin.containingFile
+                    if (originFile is KtFile) return originFile
+                }
+            }
+            element = element.parent
+        }
+
+        val containingFile = contextElement.containingFile ?: return null
+
+        // If it's a real Java or Kotlin file, use it directly
+        if (containingFile is KtFile) return containingFile
+        if (containingFile is PsiJavaFile) return containingFile
 
         return null
     }
@@ -209,11 +270,14 @@ class LinkResolver(private val project: Project) {
          * - `ClassName` → (ClassName, null)
          * - `com.example.ClassName` → (com.example.ClassName, null)
          * - `ClassName#field` → (ClassName, field)
-         * - `com.example.ClassName#method()` → (com.example.ClassName, method)
+         * - `com.example.ClassName#method()` → (com.example.ClassName, method())
          * - `ClassName.field` → (ClassName, field)
-         * - `com.example.ClassName.method()` → (com.example.ClassName, method)
+         * - `com.example.ClassName.method()` → (com.example.ClassName, method())
          * - `{@link ClassName}` → (ClassName, null)
          * - `[ClassName]` → (ClassName, null)
+         *
+         * Note: trailing `()` on a member is preserved so the resolver can distinguish
+         * `name()` (pseudo-field) from `name` (instance field) — issue #1383.
          */
         fun parseLinkReference(linkRef: String): LinkReference? {
             var ref = linkRef.trim()
@@ -236,8 +300,9 @@ class LinkResolver(private val project: Project) {
             // Split on '#' first (standard javadoc separator)
             if (ref.contains('#')) {
                 val className = ref.substringBefore('#').trim()
+                // Preserve trailing `()` on the member so the resolver can distinguish
+                // `name()` (pseudo-field) from `name` (instance field) — issue #1383.
                 val member = ref.substringAfter('#').trim()
-                    .removeSuffix("()")
                     .takeIf { it.isNotBlank() }
                 if (className.isNotBlank()) {
                     return LinkReference(className, member)
@@ -252,7 +317,8 @@ class LinkResolver(private val project: Project) {
                 val afterDot = ref.substring(lastDot + 1)
                 if (afterDot.isNotBlank() && afterDot[0].isLowerCase()) {
                     val className = ref.substring(0, lastDot).trim()
-                    val member = afterDot.trim().removeSuffix("()")
+                    // Preserve trailing `()` for consistency with the `#`-branch.
+                    val member = afterDot.trim()
                     if (className.isNotBlank()) {
                         return LinkReference(className, member)
                     }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/SeeTagResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/SeeTagResolver.kt
@@ -62,6 +62,8 @@ class SeeTagResolver(
 
     private val linkResolver: LinkResolver by lazy { LinkResolver.getInstance(project) }
 
+    private val enumValueResolver: EnumValueResolver by lazy { EnumValueResolver.getInstance(project) }
+
     /**
      * Resolve options from all `@see` tags on the given PSI element.
      * Returns options from the first `@see` tag that successfully resolves, or null.
@@ -72,199 +74,97 @@ class SeeTagResolver(
     ): List<FieldOption>? {
         val seeTags = docHelper.findDocsByTag(psiElement, "see") ?: return null
         for (seeTag in seeTags) {
-            val options = resolveFromSeeText(seeTag.trim(), psiElement)
+            val options = resolveFromSeeText(seeTag.trim(), psiElement, docHelper)
             if (!options.isNullOrEmpty()) return options
         }
         return null
     }
 
     /**
+     * Resolve options from all `@see` tags on the given PSI element, along with
+     * the resolved enum's value-field JSON type (for Case 2 type reconciliation).
+     *
+     * The `valueFieldJsonType` is non-null only when the `@see` target is an enum;
+     * it is null for static-constant classes or when no `@see` tag resolves.
+     * Callers use it with [EnumValueResolver.reconcileType] to adjust the
+     * declared field type against the actual enum value type (Req 7, D-TYPE).
+     */
+    suspend fun resolveOptionsWithType(
+        psiElement: PsiElement,
+        docHelper: DocHelper
+    ): ResolvedSeeOptions? {
+        val seeTags = docHelper.findDocsByTag(psiElement, "see") ?: return null
+        for (seeTag in seeTags) {
+            val resolved = resolveFromSeeTextWithType(seeTag.trim(), psiElement, docHelper)
+            if (resolved != null) return resolved
+        }
+        return null
+    }
+
+    /**
+     * Result of resolving a `@see` tag: the options plus the resolved enum's
+     * value-field JSON type (null for non-enum / static-constant targets).
+     */
+    data class ResolvedSeeOptions(
+        val options: List<FieldOption>,
+        val valueFieldJsonType: String?
+    )
+
+    /**
      * Resolve options from a single `@see` tag text.
      *
      * @param seeText the raw text after `@see`, e.g. `{@link com.example.UserType#type}`
      * @param context the PSI element where the tag appears (used for import resolution and type matching)
+     * @param docHelper the [DocHelper] for doc-comment extraction (Req 6.2 — unifies Case 1/Case 2)
      */
     suspend fun resolveFromSeeText(
         seeText: String,
-        context: PsiElement
-    ): List<FieldOption>? {
+        context: PsiElement,
+        docHelper: DocHelper
+    ): List<FieldOption>? =
+        resolveFromSeeTextWithType(seeText, context, docHelper)?.options
+
+    /**
+     * Resolve options from a single `@see` tag text, along with the resolved
+     * enum's value-field JSON type (for Case 2 type reconciliation).
+     *
+     * @param seeText the raw text after `@see`, e.g. `{@link com.example.UserType#type}`
+     * @param context the PSI element where the tag appears (used for import resolution and type matching)
+     * @param docHelper the [DocHelper] for doc-comment extraction (Req 6.2 — unifies Case 1/Case 2)
+     * @return [ResolvedSeeOptions] with options and the enum's value-field JSON type
+     *         (null for non-enum targets or when resolution fails)
+     */
+    suspend fun resolveFromSeeTextWithType(
+        seeText: String,
+        context: PsiElement,
+        docHelper: DocHelper
+    ): ResolvedSeeOptions? {
         val parsed = linkResolver.parseLinkReference(seeText) ?: return null
-        val psiClass = linkResolver.resolveClass(parsed.className, context) ?: return null
 
         return withContext(IdeDispatchers.ReadAction) {
+            // resolveClass accesses PSI (imports, containingFile) and must be
+            // inside a read action — otherwise it can intermittently return null
+            // when the PSI index is not ready, causing NPEs in callers.
+            val psiClass = linkResolver.resolveClass(parsed.className, context) ?: return@withContext null
+
             if (psiClass.isEnum) {
-                resolveEnumOptions(psiClass, parsed.memberName, context)
+                // Delegate to EnumValueResolver (D-CENTRAL).
+                // `parsed.memberName` carries the preserved `()` from `parseLinkReference`
+                // so the resolver can distinguish `name()` (pseudo-field) from `name`
+                // (instance field) — issue #1383.
+                val resolution = enumValueResolver.resolve(
+                    enumClass = psiClass,
+                    context = context,
+                    seeMemberName = parsed.memberName
+                )
+                val options = enumValueResolver.buildOptions(psiClass, resolution, docHelper)
+                val jsonType = enumValueResolver.resolveJsonType(psiClass, resolution)
+                if (options != null) ResolvedSeeOptions(options, jsonType) else null
             } else {
-                resolveStaticOptions(psiClass)
+                val staticOptions = resolveStaticOptions(psiClass)
+                if (staticOptions != null) ResolvedSeeOptions(staticOptions, null) else null
             }
         }
-    }
-
-    /**
-     * Resolve enum constants as options.
-     *
-     * When [propertyName] is specified (e.g. `@see UserType#type`), uses that field's
-     * constructor argument as the value.
-     *
-     * When [propertyName] is null (e.g. `@see UserType`), auto-matches by comparing
-     * the referencing field's type against the enum's instance fields. For example,
-     * if `private int type` references `UserType` which has `Integer code`, the `code`
-     * field is selected automatically.
-     *
-     * Falls back to enum constant names if no match is found.
-     *
-     * Supports both field names and getter method names:
-     * - `type` → matches field `type` directly
-     * - `getType` / `getType()` → converted to field `type`
-     * - `isActive` / `isActive()` → converted to field `active`
-     */
-    private fun resolveEnumOptions(
-        psiClass: PsiClass,
-        propertyName: String?,
-        context: PsiElement
-    ): List<FieldOption>? {
-        val constants = psiClass.fields.filterIsInstance<PsiEnumConstant>()
-        if (constants.isEmpty()) return null
-
-        val resolvedFieldName = if (propertyName != null) {
-            // Explicit member: @see UserType#type or @see UserType#getType()
-            resolveFieldName(psiClass, propertyName)
-        } else {
-            // No member: @see UserType → auto-match by type
-            findEnumFieldByType(psiClass, context)
-        }
-
-        val instanceFields = psiClass.allFields
-            .filter { it !is PsiEnumConstant && !it.hasModifierProperty(PsiModifier.STATIC) }
-        val valueFieldIndex = if (resolvedFieldName != null) {
-            instanceFields.indexOfFirst { it.name == resolvedFieldName }
-        } else -1
-
-        return constants.mapNotNull { constant ->
-            val name = constant.name ?: return@mapNotNull null
-            val desc = constant.docComment?.let { extractDocText(it) }
-
-            val value: Any? = if (valueFieldIndex >= 0) {
-                val args = constant.argumentList?.expressions
-                if (args != null && valueFieldIndex < args.size) {
-                    extractConstantValue(args[valueFieldIndex])
-                } else name
-            } else name
-
-            // When using a custom field, build description from other fields if no doc comment
-            val effectiveDesc = if (valueFieldIndex >= 0 && desc == null) {
-                buildDescFromOtherFields(constant, instanceFields, valueFieldIndex) ?: name
-            } else {
-                desc
-            }
-
-            FieldOption(value = value, desc = effectiveDesc)
-        }.ifEmpty { null }
-    }
-
-    /**
-     * Finds an enum instance field whose type matches the referencing element's declared type.
-     *
-     * For example, if `private int type` references `UserType` which has
-     * `private final Integer code`, this returns `"code"`.
-     *
-     * When multiple fields match, prefers the one whose name matches the referencing field name.
-     */
-    private fun findEnumFieldByType(psiClass: PsiClass, contextElement: PsiElement): String? {
-        val targetCanonical = when (contextElement) {
-            is PsiField -> contextElement.type.canonicalText
-            is PsiMethod -> contextElement.returnType?.canonicalText
-            is PsiParameter -> contextElement.type.canonicalText
-            else -> null
-        } ?: return null
-
-        val instanceFields = psiClass.allFields.filter {
-            it !is PsiEnumConstant && !it.hasModifierProperty(PsiModifier.STATIC)
-        }
-
-        val candidates = instanceFields.filter { field ->
-            isTypeCompatible(field.type.canonicalText, targetCanonical)
-        }
-
-        if (candidates.isEmpty()) return null
-        if (candidates.size == 1) return candidates.first().name
-
-        // Multiple candidates: prefer the one whose name matches the referencing field
-        val contextName = when (contextElement) {
-            is PsiField -> contextElement.name
-            is PsiMethod -> LinkResolver.getterToPropertyName(contextElement.name) ?: contextElement.name
-            is PsiParameter -> contextElement.name
-            else -> null
-        }
-        if (contextName != null) {
-            candidates.firstOrNull { it.name == contextName }?.let { return it.name }
-        }
-        return candidates.first().name
-    }
-
-    /**
-     * Builds a description string from enum constructor arguments other than the value field.
-     */
-    private fun buildDescFromOtherFields(
-        constant: PsiEnumConstant,
-        instanceFields: List<PsiField>,
-        excludeIndex: Int
-    ): String? {
-        val args = constant.argumentList?.expressions ?: return null
-        val parts = mutableListOf<String>()
-        for ((i, _) in instanceFields.withIndex()) {
-            if (i == excludeIndex) continue
-            if (i < args.size) {
-                val value = extractConstantValue(args[i])
-                if (value != null) {
-                    parts.add(value.toString())
-                }
-            }
-        }
-        return parts.joinToString(" ").takeIf { it.isNotBlank() }
-    }
-
-    private fun isTypeCompatible(fieldType: String, targetType: String): Boolean {
-        if (fieldType == targetType) return true
-        return normalizeBoxedType(fieldType) == normalizeBoxedType(targetType)
-    }
-
-    private fun normalizeBoxedType(type: String): String {
-        return when (type) {
-            "int", "Integer", "java.lang.Integer" -> "java.lang.Integer"
-            "long", "Long", "java.lang.Long" -> "java.lang.Long"
-            "short", "Short", "java.lang.Short" -> "java.lang.Short"
-            "byte", "Byte", "java.lang.Byte" -> "java.lang.Byte"
-            "float", "Float", "java.lang.Float" -> "java.lang.Float"
-            "double", "Double", "java.lang.Double" -> "java.lang.Double"
-            "boolean", "Boolean", "java.lang.Boolean" -> "java.lang.Boolean"
-            "char", "Character", "java.lang.Character" -> "java.lang.Character"
-            else -> type
-        }
-    }
-
-    /**
-     * Resolve a property name that may be a getter method name to the actual field name.
-     * Tries direct match first, then getter-to-property conversion.
-     */
-    private fun resolveFieldName(psiClass: PsiClass, propertyName: String?): String? {
-        if (propertyName == null) return null
-
-        val instanceFields = psiClass.allFields
-            .filter { it !is PsiEnumConstant && !it.hasModifierProperty(PsiModifier.STATIC) }
-
-        // Direct field name match
-        if (instanceFields.any { it.name == propertyName }) {
-            return propertyName
-        }
-
-        // Try getter-to-property conversion: getXxx → xxx, isXxx → xxx
-        val derived = LinkResolver.getterToPropertyName(propertyName)
-        if (derived != null && instanceFields.any { it.name == derived }) {
-            return derived
-        }
-
-        return propertyName
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/psi/adapter/KotlinPsiAdapter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/adapter/KotlinPsiAdapter.kt
@@ -99,12 +99,26 @@ class KotlinPsiAdapter : PsiLanguageAdapter {
                 val name = tag.name ?: continue
                 val subjectName = tag.getSubjectName()
                 val content = tag.contentOrLink() ?: ""
-                // Include subject name in value to match Javadoc convention:
+                // For most tags, include subject name in value to match Javadoc convention:
                 // @param id the user ID → DocTag("param", "id the user ID")
-                val value = if (subjectName != null && content.isNotEmpty()) {
-                    "$subjectName $content"
-                } else {
-                    subjectName ?: content
+                //
+                // For @see tags, the subject name is the class part of a reference
+                // (e.g., "UserType" in "UserType#code") and must be combined with the
+                // content WITHOUT a space to preserve the reference syntax.
+                val value = when {
+                    name == "see" -> {
+                        val trimmedContent = content.trim()
+                        when {
+                            subjectName != null && trimmedContent.isNotEmpty()
+                                && trimmedContent != subjectName ->
+                                "$subjectName$trimmedContent"
+                            subjectName != null -> subjectName
+                            else -> content
+                        }
+                    }
+                    subjectName != null && content.isNotEmpty() ->
+                        "$subjectName $content"
+                    else -> subjectName ?: content
                 }
                 tags.add(DocTag(name, value))
             }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/ScriptPsiContexts.kt
@@ -91,6 +91,17 @@ interface MethodContext {
     fun isAbstract(): Boolean
     fun isSynchronized(): Boolean
     fun isNative(): Boolean
+    /**
+     * Returns the underlying field name derived from this method's name.
+     *
+     * - `getCode` → `code`
+     * - `isActive` → `active`
+     * - `name` (or any non-getter/non-is method) → returned as-is
+     *
+     * Useful for mapping getter methods to their backing instance fields
+     * (e.g. Jackson `@JsonValue` on a getter).
+     */
+    fun fieldName(): String
 }
 
 /**
@@ -393,6 +404,15 @@ open class ScriptPsiMethodContext(context: RuleContext) : ScriptItContext(contex
         readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.SYNCHRONIZED) }
 
     override fun isNative(): Boolean = readSync { psiMethod().hasModifierProperty(com.intellij.psi.PsiModifier.NATIVE) }
+
+    override fun fieldName(): String {
+        val n = name()
+        return when {
+            n.startsWith("get") && n.length > 3 -> n.substring(3, 4).lowercase() + n.substring(4)
+            n.startsWith("is") && n.length > 2 -> n.substring(2, 3).lowercase() + n.substring(3)
+            else -> n
+        }
+    }
 
     override fun canonicalText(): String {
         val cls = readSync { psiMethod().containingClass?.qualifiedName } ?: ""

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -63,7 +63,8 @@ data class Settings(
     override var concurrentScanEnabled: Boolean = false,
     override var gutterIconEnabled: Boolean = true,
     override var projectEnvironments: String = "",
-    override var globalEnvironments: String = ""
+    override var globalEnvironments: String = "",
+    override var enumFieldAutoInferEnabled: Boolean = false
 ) : ProjectSettingsSupport, ApplicationSettingsSupport {
 
     companion object {
@@ -120,6 +121,7 @@ data class Settings(
         if (gutterIconEnabled != other.gutterIconEnabled) return false
         if (projectEnvironments != other.projectEnvironments) return false
         if (globalEnvironments != other.globalEnvironments) return false
+        if (enumFieldAutoInferEnabled != other.enumFieldAutoInferEnabled) return false
 
         return true
     }
@@ -167,6 +169,7 @@ data class Settings(
         result = 31 * result + gutterIconEnabled.hashCode()
         result = 31 * result + projectEnvironments.hashCode()
         result = 31 * result + globalEnvironments.hashCode()
+        result = 31 * result + enumFieldAutoInferEnabled.hashCode()
         return result
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -64,7 +64,8 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var grpcRepositories: Array<String> = emptyArray(),
         override var concurrentScanEnabled: Boolean = false,
         override var gutterIconEnabled: Boolean = true,
-        override var globalEnvironments: String = ""
+        override var globalEnvironments: String = "",
+        override var enumFieldAutoInferEnabled: Boolean = false
     ) : ApplicationSettingsSupport {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -109,6 +110,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (concurrentScanEnabled != other.concurrentScanEnabled) return false
             if (gutterIconEnabled != other.gutterIconEnabled) return false
             if (globalEnvironments != other.globalEnvironments) return false
+            if (enumFieldAutoInferEnabled != other.enumFieldAutoInferEnabled) return false
 
             return true
         }
@@ -151,6 +153,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + concurrentScanEnabled.hashCode()
             result = 31 * result + gutterIconEnabled.hashCode()
             result = 31 * result + globalEnvironments.hashCode()
+            result = 31 * result + enumFieldAutoInferEnabled.hashCode()
             return result
         }
     }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
@@ -76,6 +76,16 @@ interface ApplicationSettingsSupport {
     /** When true, show gutter icon on API methods for opening in API Dashboard */
     var gutterIconEnabled: Boolean
     var globalEnvironments: String
+    /**
+     * When true, auto-infer the enum value field for ambiguous references
+     * (e.g. `@see XxxEnum` without a specific field, or enum-typed fields
+     * with a single instance field). When false, always fall back to the
+     * enum constant name.
+     *
+     * Explicit references (`@see Xxx#code`, `@JsonValue`, `enum.use.custom`)
+     * are always resolved regardless of this setting.
+     */
+    var enumFieldAutoInferEnabled: Boolean
 
     fun copyTo(newSetting: ApplicationSettingsSupport) {
         newSetting.postmanToken = this.postmanToken
@@ -115,6 +125,7 @@ interface ApplicationSettingsSupport {
         newSetting.concurrentScanEnabled = this.concurrentScanEnabled
         newSetting.gutterIconEnabled = this.gutterIconEnabled
         newSetting.globalEnvironments = this.globalEnvironments
+        newSetting.enumFieldAutoInferEnabled = this.enumFieldAutoInferEnabled
     }
 }
 

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -779,6 +779,13 @@ class IntelligentSettingsPanel : SettingsPanel {
         toolTipText = "Use RFC 6570 URI template syntax for path variables in exported URLs (e.g., /users/{id})"
     }
     private val pathMultiCombo = ComboBox(PathSelector.values().map { it.name }.toTypedArray())
+    private val enumFieldAutoInferEnabled = JBCheckBox("Auto-infer enum value field for ambiguous references", false).apply {
+        toolTipText = buildString {
+            append("When enabled, auto-infer the enum value field for ambiguous references: ")
+            append("enum-typed fields with a single instance field, or @see references without a specific field. ")
+            append("Explicit references (@see Enum#field, @JsonValue, enum.use.custom) always work regardless of this setting.")
+        }
+    }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
         .addComponent(queryExpanded)
@@ -786,6 +793,7 @@ class IntelligentSettingsPanel : SettingsPanel {
         .addComponent(inferReturnMain)
         .addComponent(enableUrlTemplating)
         .addLabeledComponent("Path multi-select strategy:", pathMultiCombo)
+        .addComponent(enumFieldAutoInferEnabled)
         .addComponentFillVertically(JPanel(), 0)
         .panel
 
@@ -795,6 +803,7 @@ class IntelligentSettingsPanel : SettingsPanel {
         inferReturnMain.isSelected = settings?.inferReturnMain ?: true
         enableUrlTemplating.isSelected = settings?.enableUrlTemplating ?: true
         pathMultiCombo.selectedItem = settings?.pathMulti ?: "ALL"
+        enumFieldAutoInferEnabled.isSelected = settings?.enumFieldAutoInferEnabled ?: false
     }
 
     override fun applyTo(settings: Settings) {
@@ -803,6 +812,7 @@ class IntelligentSettingsPanel : SettingsPanel {
         settings.inferReturnMain = inferReturnMain.isSelected
         settings.enableUrlTemplating = enableUrlTemplating.isSelected
         settings.pathMulti = pathMultiCombo.selectedItem?.toString() ?: "ALL"
+        settings.enumFieldAutoInferEnabled = enumFieldAutoInferEnabled.isSelected
     }
 
     override fun isModified(settings: Settings?): Boolean {
@@ -811,7 +821,8 @@ class IntelligentSettingsPanel : SettingsPanel {
                 formExpanded.isSelected != s.formExpanded ||
                 inferReturnMain.isSelected != s.inferReturnMain ||
                 enableUrlTemplating.isSelected != s.enableUrlTemplating ||
-                pathMultiCombo.selectedItem?.toString() != s.pathMulti
+                pathMultiCombo.selectedItem?.toString() != s.pathMulti ||
+                enumFieldAutoInferEnabled.isSelected != s.enumFieldAutoInferEnabled
     }
 }
 

--- a/src/main/resources/extensions/jackson.config
+++ b/src/main/resources/extensions/jackson.config
@@ -145,3 +145,23 @@ field.ignore=groovy:```
     }
     return false
 ```
+
+# @JsonValue: serialize enum by the annotated member's value.
+# Detects @JsonValue on a non-static getter (getCode → code, isActive → active)
+# or directly on a non-static instance field. Returns the underlying field name
+# so the existing enum.use.custom consumer can build options from it.
+# Returns null when no annotated member is found so other resolution steps can fire.
+enum.use.custom=groovy:```
+    if (!it.isEnum()) return null
+    def m = it.methods().find {
+        it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.hasModifier("static")
+    }
+    if (m != null) {
+        def derived = m.fieldName()
+        // Verify the derived name matches an instance field; otherwise return null
+        // so step 2/3 of the resolution algorithm can fire.
+        return it.fields().any { it.name() == derived && !it.isStatic() && !it.isEnumField() } ? derived : null
+    }
+    def f = it.fields().find { it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.isStatic() && !it.isEnumField() }
+    return f?.name()
+```

--- a/src/main/resources/extensions/mybatis-plus.config
+++ b/src/main/resources/extensions/mybatis-plus.config
@@ -1,0 +1,17 @@
+---
+code: mybatis-plus
+description: MyBatis-Plus enum value annotation support
+on-class: com.baomidou.mybatisplus.annotation.EnumValue
+default-enabled: true
+---
+
+# @EnumValue: serialize enum by the annotated field's value.
+# MyBatis-Plus places @EnumValue on a non-static instance field (not a getter).
+# Returns the field name so the existing enum.use.custom consumer can build
+# options from it. Returns null when no annotated field is found so other
+# resolution steps can fire.
+enum.use.custom=groovy:```
+    if (!it.isEnum()) return null
+    def f = it.fields().find { it.hasAnn("com.baomidou.mybatisplus.annotation.EnumValue") && !it.isStatic() && !it.isEnumField() }
+    return f?.name()
+```

--- a/src/test/kotlin/com/itangcent/easyapi/psi/ComprehensiveEnumCasesTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/ComprehensiveEnumCasesTest.kt
@@ -1,0 +1,252 @@
+package com.itangcent.easyapi.psi
+
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.type.JsonType
+import com.itangcent.easyapi.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.AssumptionViolatedException
+
+/**
+ * Comprehensive test that loads a Java DTO and a Kotlin DTO — each with fields
+ * covering all enum resolution cases from the enum-resolution spec — and verifies
+ * that every field in the resulting [ObjectModel] has the expected options.
+ *
+ * Cases covered (see `.spec/enum-resolution/requirements.md`):
+ * - Case 1a: enum-typed field, default name serialization → STRING, constant names
+ * - Case 1b: @JsonValue on getter → field's type, field's values
+ * - Case 1b: @EnumValue on field → field's type, field's values
+ * - Case 2: @see Enum#field → field's type, field's values
+ * - Case 2: @see Enum#getField() → field's type, field's values
+ * - Case 2: @see Enum#name() → STRING, constant names
+ * - Case 2: @see Enum (class-only, auto-match by type) → matched field's type, values
+ *
+ * The test enables `enumFieldAutoInferEnabled` so the class-only `@see` case
+ * can auto-match by type. The config carries the combined `@JsonValue` +
+ * `@EnumValue` groovy recipe so annotation-based resolution works.
+ */
+class ComprehensiveEnumCasesTest {
+
+    companion object {
+        /**
+         * Combined `enum.use.custom` groovy rule that detects both `@JsonValue`
+         * (on getter or field) and `@EnumValue` (on field). This mirrors the
+         * recipes shipped in `jackson.config` and `mybatis-plus.config`.
+         */
+        const val COMBINED_CONFIG_TEXT = """
+enum.use.custom=groovy:```
+    if (!it.isEnum()) return null
+    def m = it.methods().find {
+        it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.hasModifier("static")
+    }
+    if (m != null) {
+        def n = m.name()
+        def derived = n.startsWith("get") ? n.substring(3,4).toLowerCase() + n.substring(4)
+                    : n.startsWith("is")  ? n.substring(2,3).toLowerCase() + n.substring(3)
+                    : n
+        return it.fields().any { it.name() == derived && !it.isStatic() && !it.isEnumField() } ? derived : null
+    }
+    def f = it.fields().find { it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.isStatic() && !it.isEnumField() }
+    if (f != null) return f.name()
+    f = it.fields().find { it.hasAnn("com.baomidou.mybatisplus.annotation.EnumValue") && !it.isStatic() && !it.isEnumField() }
+    return f?.name()
+```
+"""
+
+        /**
+         * Paths of all supporting files (annotation stubs + enums) that must be
+         * loaded into the test fixture before loading the DTO under test.
+         */
+        val SUPPORTING_FILE_PATHS: List<String> = listOf(
+            // Annotation stubs (at their real FQN paths so the groovy rule can match by FQN)
+            "com/fasterxml/jackson/annotation/JsonValue.java",
+            "com/baomidou/mybatisplus/annotation/EnumValue.java",
+            // Enum classes
+            "enumcases/constant/SimpleStatus.java",
+            "enumcases/constant/UserType.java",
+            "enumcases/constant/JacksonStatus.java",
+            "enumcases/constant/MyBatisStatus.java",
+            "enumcases/constant/NameConflictEnum.java"
+        )
+
+        /**
+         * Verifies every field in the given [ObjectModel.Object] has the expected
+         * JSON type and option values. Shared by the Java and Kotlin DTO tests.
+         */
+        fun assertAllFieldsHaveExpectedOptions(result: ObjectModel?) {
+            assertNotNull("buildObjectModel should return a result", result)
+            assertTrue("Result should be Object", result is ObjectModel.Object)
+            val fields = (result as ObjectModel.Object).fields
+
+            // ---- Case 1a: simpleStatus — default name serialization ----
+            val simpleStatus = fields["simpleStatus"]
+            assertNotNull("Should have 'simpleStatus' field", simpleStatus)
+            assertEquals(
+                "Case 1a: simpleStatus should be STRING",
+                JsonType.STRING, (simpleStatus!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 1a: simpleStatus should have options", simpleStatus.options)
+            assertEquals(
+                "Case 1a: simpleStatus options should be constant names",
+                listOf("ACTIVE", "INACTIVE", "PENDING"),
+                simpleStatus.options!!.map { it.value }
+            )
+
+            // ---- Case 1b: jacksonStatus — @JsonValue on getter ----
+            val jacksonStatus = fields["jacksonStatus"]
+            assertNotNull("Should have 'jacksonStatus' field", jacksonStatus)
+            assertEquals(
+                "Case 1b @JsonValue: jacksonStatus should be INT",
+                JsonType.INT, (jacksonStatus!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 1b @JsonValue: jacksonStatus should have options", jacksonStatus.options)
+            assertEquals(
+                "Case 1b @JsonValue: jacksonStatus options should use code field values",
+                listOf(30, 1100, 1200),
+                jacksonStatus.options!!.map { it.value }
+            )
+
+            // ---- Case 1b: myBatisStatus — @EnumValue on field ----
+            val myBatisStatus = fields["myBatisStatus"]
+            assertNotNull("Should have 'myBatisStatus' field", myBatisStatus)
+            assertEquals(
+                "Case 1b @EnumValue: myBatisStatus should be INT",
+                JsonType.INT, (myBatisStatus!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 1b @EnumValue: myBatisStatus should have options", myBatisStatus.options)
+            assertEquals(
+                "Case 1b @EnumValue: myBatisStatus options should use code field values",
+                listOf(10, 20, 30),
+                myBatisStatus.options!!.map { it.value }
+            )
+
+            // ---- Case 2: userCode — @see Enum#field ----
+            val userCode = fields["userCode"]
+            assertNotNull("Should have 'userCode' field", userCode)
+            assertEquals(
+                "Case 2 @see#field: userCode should be INT",
+                JsonType.INT, (userCode!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 2 @see#field: userCode should have options", userCode.options)
+            assertEquals(
+                "Case 2 @see#field: userCode options should use code field values",
+                listOf(30, 1100, 1200),
+                userCode.options!!.map { it.value }
+            )
+
+            // ---- Case 2: userDesc — @see Enum#getField() ----
+            val userDesc = fields["userDesc"]
+            assertNotNull("Should have 'userDesc' field", userDesc)
+            assertEquals(
+                "Case 2 @see#getter: userDesc should be STRING",
+                JsonType.STRING, (userDesc!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 2 @see#getter: userDesc should have options", userDesc.options)
+            assertEquals(
+                "Case 2 @see#getter: userDesc options should use desc field values",
+                listOf("unspecified", "administrator", "developer"),
+                userDesc.options!!.map { it.value }
+            )
+
+            // ---- Case 2: constantName — @see Enum#name() ----
+            val constantName = fields["constantName"]
+            assertNotNull("Should have 'constantName' field", constantName)
+            assertEquals(
+                "Case 2 @see#name(): constantName should be STRING",
+                JsonType.STRING, (constantName!!.model as ObjectModel.Single).type
+            )
+            assertNotNull("Case 2 @see#name(): constantName should have options", constantName.options)
+            assertEquals(
+                "Case 2 @see#name(): constantName options should be constant names",
+                listOf("ONE", "TWO", "THREE"),
+                constantName.options!!.map { it.value }
+            )
+
+            // ---- Case 2: autoMatchedCode — @see Enum (class-only, auto-match) ----
+            val autoMatchedCode = fields["autoMatchedCode"]
+            assertNotNull("Should have 'autoMatchedCode' field", autoMatchedCode)
+            assertEquals(
+                "Case 2 @see class-only: autoMatchedCode should be INT",
+                JsonType.INT, (autoMatchedCode!!.model as ObjectModel.Single).type
+            )
+            assertNotNull(
+                "Case 2 @see class-only: autoMatchedCode should have options",
+                autoMatchedCode.options
+            )
+            assertEquals(
+                "Case 2 @see class-only: autoMatchedCode options should use code field values (int → Integer code)",
+                listOf(30, 1100, 1200),
+                autoMatchedCode.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Java DTO test
+    // ================================================================
+
+    class WithJavaDto : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            COMBINED_CONFIG_TEXT
+        )
+
+        override fun setUp() {
+            super.setUp()
+            // Enable auto-infer so class-only @see can auto-match by type.
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+            SUPPORTING_FILE_PATHS.forEach { loadFile(it) }
+        }
+
+        fun testJavaDtoAllFieldsHaveOptions() = runBlocking {
+            loadFile("enumcases/model/ComprehensiveEnumCasesDto.java")
+            val psiClass = findClass("enumcases.model.ComprehensiveEnumCasesDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            assertAllFieldsHaveExpectedOptions(result)
+        }
+    }
+
+    // ================================================================
+    //  Kotlin DTO test
+    // ================================================================
+
+    class WithKotlinDto : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            COMBINED_CONFIG_TEXT
+        )
+
+        override fun setUp() {
+            super.setUp()
+            try {
+                Class.forName("org.jetbrains.kotlin.idea.KotlinLanguage")
+            } catch (e: ClassNotFoundException) {
+                throw AssumptionViolatedException("Kotlin plugin not available")
+            }
+            // Enable auto-infer so class-only @see can auto-match by type.
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+            SUPPORTING_FILE_PATHS.forEach { loadFile(it) }
+        }
+
+        fun testKotlinDtoAllFieldsHaveOptions() = runBlocking {
+            loadFile("enumcases/model/ComprehensiveEnumCasesDto.kt")
+            val psiClass = findClass("enumcases.model.ComprehensiveEnumCasesDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            assertAllFieldsHaveExpectedOptions(result)
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/EnumResolutionTest.kt
@@ -1,10 +1,8 @@
 package com.itangcent.easyapi.psi
 
-import com.itangcent.easyapi.psi.model.FieldModel
-import com.itangcent.easyapi.psi.model.FieldOption
 import com.itangcent.easyapi.psi.model.ObjectModel
-import com.itangcent.easyapi.psi.model.ObjectModelValueConverter
 import com.itangcent.easyapi.psi.type.JsonType
+import com.itangcent.easyapi.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import kotlinx.coroutines.runBlocking
@@ -62,6 +60,48 @@ class EnumResolutionTest {
                 INACTIVE,
                 /** Pending review */
                 PENDING
+            }
+        """
+
+        /** Enum that declares an instance field literally named `name` (issue #1383). */
+        const val NAME_CONFLICT_ENUM = """
+            package constant;
+            public enum NameConflict {
+                /** first */
+                ONE(1),
+                /** second */
+                TWO(2),
+                /** third */
+                THREE(3);
+
+                private final Integer name;
+
+                NameConflict(Integer name) {
+                    this.name = name;
+                }
+
+                public Integer getName() { return name; }
+            }
+        """
+
+        /** Enum with a single instance field — used to test INTELLIGENT mode in Case 1. */
+        const val SINGLE_FIELD_ENUM = """
+            package constant;
+            public enum SingleField {
+                /** guest */
+                GUEST(30),
+                /** admin */
+                ADMIN(1100),
+                /** developer */
+                DEVELOPER(1200);
+
+                private final Integer type;
+
+                SingleField(Integer type) {
+                    this.type = type;
+                }
+
+                public Integer getType() { return type; }
             }
         """
     }
@@ -491,6 +531,14 @@ class EnumResolutionTest {
 
         override fun createConfigReader() = TestConfigReader.empty(project)
 
+        override fun setUp() {
+            super.setUp()
+            // Auto-match by type is only performed in INTELLIGENT mode (issue #1383).
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+        }
+
         fun testSeeEnumAutoMatchByIntType() = runBlocking {
             myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
             myFixture.addFileToProject(
@@ -641,6 +689,816 @@ class EnumResolutionTest {
             assertEquals(30, firstOption.value)
             // Description should be from doc comment ("who is not logged in") or from other fields ("unspecified")
             assertNotNull("Option should have a description", firstOption.desc)
+        }
+    }
+
+    // ================================================================
+    //  Issue #1383 — name/name() ambiguity (Case 1)
+    //  An enum with an instance field literally named `name` should
+    //  use that field's values when `enum.use.custom=name`, while
+    //  `enum.use.custom=name()` still resolves to the pseudo-field.
+    // ================================================================
+
+    class Case1_NameFieldConflict : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "enum.use.custom" to "name"
+        )
+
+        fun testCustomNameResolvesToInstanceField() = runBlocking {
+            myFixture.addFileToProject("constant/NameConflict.java", NAME_CONFLICT_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/NameConflictDto.java", """
+                package model;
+                import constant.NameConflict;
+                public class NameConflictDto {
+                    public NameConflict value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.NameConflictDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            // `name` resolves to the Integer instance field, not the pseudo-field
+            assertEquals(
+                "enum.use.custom=name with instance field `name` should produce INT type",
+                JsonType.INT, (field.model as ObjectModel.Single).type
+            )
+            assertNotNull(field.options)
+            assertEquals(
+                "Options should use the `name` instance field values",
+                listOf(1, 2, 3),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    class Case1_NameCallPseudoField : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "enum.use.custom" to "name()"
+        )
+
+        fun testCustomNameCallResolvesToPseudoField() = runBlocking {
+            myFixture.addFileToProject("constant/NameConflict.java", NAME_CONFLICT_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/NameConflictDto.java", """
+                package model;
+                import constant.NameConflict;
+                public class NameConflictDto {
+                    public NameConflict value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.NameConflictDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            // `name()` is unambiguous → pseudo-field → STRING
+            assertEquals(
+                "enum.use.custom=name() should produce STRING type",
+                JsonType.STRING, (field.model as ObjectModel.Single).type
+            )
+            assertNotNull(field.options)
+            assertEquals(
+                "Options should be enum constant names",
+                listOf("ONE", "TWO", "THREE"),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Issue #1383 — INTELLIGENT mode for Case 1
+    //  When the enum has exactly one instance field, that field is
+    //  auto-selected without requiring `enum.use.custom`.
+    // ================================================================
+
+    class Case1_IntelligentMode : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        override fun setUp() {
+            super.setUp()
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+        }
+
+        fun testIntelligentModeSelectsSingleInstanceField() = runBlocking {
+            myFixture.addFileToProject("constant/SingleField.java", SINGLE_FIELD_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SingleFieldDto.java", """
+                package model;
+                import constant.SingleField;
+                public class SingleFieldDto {
+                    public SingleField value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SingleFieldDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            assertEquals(
+                "INTELLIGENT mode should pick the single Integer field → INT",
+                JsonType.INT, (field.model as ObjectModel.Single).type
+            )
+            assertNotNull(field.options)
+            assertEquals(
+                "Options should use the single instance field values",
+                listOf(30, 1100, 1200),
+                field.options!!.map { it.value }
+            )
+        }
+
+        fun testIntelligentModeFallsBackToNameForMultiFieldEnum() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/UserDto.java", """
+                package model;
+                import constant.UserType;
+                public class UserDto {
+                    public UserType type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.UserDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            // UserType has two instance fields (code, desc) → fall back to name()
+            assertEquals(
+                "INTELLIGENT mode should fall back to STRING when multiple instance fields exist",
+                JsonType.STRING, (field.model as ObjectModel.Single).type
+            )
+            assertEquals(
+                "Options should be enum constant names",
+                listOf("GUEST", "ADMIN", "DEVELOPER"),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    class Case1_NameModeIgnoresSingleField : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        override fun setUp() {
+            super.setUp()
+            settingBinder.update {
+                enumFieldAutoInferEnabled = false
+            }
+        }
+
+        fun testNameModeDoesNotAutoSelectSingleInstanceField() = runBlocking {
+            myFixture.addFileToProject("constant/SingleField.java", SINGLE_FIELD_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SingleFieldDto.java", """
+                package model;
+                import constant.SingleField;
+                public class SingleFieldDto {
+                    public SingleField value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SingleFieldDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            // NAME mode → always enum constant name, even with a single instance field
+            assertEquals(
+                "NAME mode should produce STRING type",
+                JsonType.STRING, (field.model as ObjectModel.Single).type
+            )
+            assertEquals(
+                "Options should be enum constant names",
+                listOf("GUEST", "ADMIN", "DEVELOPER"),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Issue #1383 — INTELLIGENT mode for Case 2 (@see auto-match)
+    //  In NAME mode, a class-only @see falls back to enum constant
+    //  names. In INTELLIGENT mode, type-based auto-match is applied.
+    // ================================================================
+
+    class Case2_NameModeIgnoresAutoMatch : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        override fun setUp() {
+            super.setUp()
+            settingBinder.update {
+                enumFieldAutoInferEnabled = false
+            }
+        }
+
+        fun testNameModeFallsBackToConstantNames() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/UserDto.java", """
+                package model;
+                import constant.UserType;
+                public class UserDto {
+                    /**
+                     * @see UserType
+                     */
+                    public int type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.UserDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            assertNotNull(field.options)
+            // NAME mode → no auto-match → enum constant names
+            assertEquals(
+                "NAME mode should fall back to enum constant names for class-only @see",
+                listOf("GUEST", "ADMIN", "DEVELOPER"),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    class Case2_IntelligentModeAutoMatch : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        override fun setUp() {
+            super.setUp()
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+        }
+
+        fun testIntelligentModeAutoMatchesByType() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/UserDto.java", """
+                package model;
+                import constant.UserType;
+                public class UserDto {
+                    /**
+                     * @see UserType
+                     */
+                    public int type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.UserDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            assertNotNull(field.options)
+            // INTELLIGENT mode → int matches Integer code
+            assertEquals(
+                "INTELLIGENT mode should auto-match by type to the `code` field",
+                listOf(30, 1100, 1200),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 1.3 — Simple enum with zero instance fields
+    // ================================================================
+
+    class Case1_SimpleEnum : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        fun testSimpleEnumUsesConstantNamesInNameMode() = runBlocking {
+            myFixture.addFileToProject("constant/SimpleStatus.java", SIMPLE_STATUS_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SimpleDto.java", """
+                package model;
+                import constant.SimpleStatus;
+                public class SimpleDto {
+                    public SimpleStatus status;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SimpleDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["status"]!!
+            assertEquals(JsonType.STRING, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf("ACTIVE", "INACTIVE", "PENDING"),
+                field.options!!.map { it.value }
+            )
+        }
+
+        fun testSimpleEnumUsesConstantNamesInIntelligentMode() = runBlocking {
+            settingBinder.update {
+                enumFieldAutoInferEnabled = true
+            }
+            myFixture.addFileToProject("constant/SimpleStatus.java", SIMPLE_STATUS_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SimpleDto.java", """
+                package model;
+                import constant.SimpleStatus;
+                public class SimpleDto {
+                    public SimpleStatus status;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SimpleDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["status"]!!
+            // No instance fields → falls back to name regardless of mode
+            assertEquals(JsonType.STRING, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf("ACTIVE", "INACTIVE", "PENDING"),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 2 — @JsonValue annotation detection (Case 1b)
+    // ================================================================
+
+    class Case1_JsonValueOnGetter : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private val jsonValueAnnotation = """
+            package com.fasterxml.jackson.annotation;
+            public @interface JsonValue {
+            }
+        """.trimIndent()
+
+        val enumWithJsonValue = """
+            package constant;
+            import com.fasterxml.jackson.annotation.JsonValue;
+            public enum StatusWithJsonValue {
+                /** guest */
+                GUEST(30),
+                /** admin */
+                ADMIN(1100),
+                /** developer */
+                DEVELOPER(1200);
+
+                private final Integer code;
+
+                StatusWithJsonValue(Integer code) {
+                    this.code = code;
+                }
+
+                @JsonValue
+                public Integer getCode() { return code; }
+            }
+        """.trimIndent()
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            enum.use.custom=groovy:```
+                if (!it.isEnum()) return null
+                def m = it.methods().find {
+                    it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.hasModifier("static")
+                }
+                if (m != null) {
+                    def n = m.name()
+                    def derived = n.startsWith("get") ? n.substring(3,4).toLowerCase() + n.substring(4)
+                                : n.startsWith("is")  ? n.substring(2,3).toLowerCase() + n.substring(3)
+                                : n
+                    return it.fields().any { it.name() == derived && !it.isStatic() && !it.isEnumField() } ? derived : null
+                }
+                def f = it.fields().find { it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.isStatic() && !it.isEnumField() }
+                return f?.name()
+            ```
+            """.trimIndent()
+        )
+
+        fun testJsonValueOnGetterUsesCodeField() = runBlocking {
+            myFixture.addFileToProject("com/fasterxml/jackson/annotation/JsonValue.java", jsonValueAnnotation)
+            myFixture.addFileToProject("constant/StatusWithJsonValue.java", enumWithJsonValue)
+            myFixture.addFileToProject(
+                "model/StatusDto.java", """
+                package model;
+                import constant.StatusWithJsonValue;
+                public class StatusDto {
+                    public StatusWithJsonValue status;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.StatusDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["status"]!!
+            // @JsonValue on getCode() → code field → INT type, code values
+            assertEquals(JsonType.INT, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf(30, 1100, 1200),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    class Case1_JsonValueOnField : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private val jsonValueAnnotation = """
+            package com.fasterxml.jackson.annotation;
+            public @interface JsonValue {
+            }
+        """.trimIndent()
+
+        val enumWithJsonValueOnField = """
+            package constant;
+            import com.fasterxml.jackson.annotation.JsonValue;
+            public enum StatusWithJsonValueField {
+                /** guest */
+                GUEST(30),
+                /** admin */
+                ADMIN(1100);
+
+                private final Integer code;
+
+                StatusWithJsonValueField(Integer code) {
+                    this.code = code;
+                }
+
+                @JsonValue
+                private final Integer code;
+            }
+        """.trimIndent()
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            enum.use.custom=groovy:```
+                if (!it.isEnum()) return null
+                def m = it.methods().find {
+                    it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.hasModifier("static")
+                }
+                if (m != null) {
+                    def n = m.name()
+                    def derived = n.startsWith("get") ? n.substring(3,4).toLowerCase() + n.substring(4)
+                                : n.startsWith("is")  ? n.substring(2,3).toLowerCase() + n.substring(3)
+                                : n
+                    return it.fields().any { it.name() == derived && !it.isStatic() && !it.isEnumField() } ? derived : null
+                }
+                def f = it.fields().find { it.hasAnn("com.fasterxml.jackson.annotation.JsonValue") && !it.isStatic() && !it.isEnumField() }
+                return f?.name()
+            ```
+            """.trimIndent()
+        )
+
+        fun testJsonValueOnFieldUsesThatField() = runBlocking {
+            myFixture.addFileToProject("com/fasterxml/jackson/annotation/JsonValue.java", jsonValueAnnotation)
+            myFixture.addFileToProject("constant/StatusWithJsonValueField.java", enumWithJsonValueOnField)
+            myFixture.addFileToProject(
+                "model/StatusDto2.java", """
+                package model;
+                import constant.StatusWithJsonValueField;
+                public class StatusDto2 {
+                    public StatusWithJsonValueField status;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.StatusDto2")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["status"]!!
+            assertEquals(JsonType.INT, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf(30, 1100),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 2 — @EnumValue annotation detection (Case 1b)
+    // ================================================================
+
+    class Case1_EnumValue : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private val enumValueAnnotation = """
+            package com.baomidou.mybatisplus.annotation;
+            public @interface EnumValue {
+            }
+        """.trimIndent()
+
+        val enumWithEnumValue = """
+            package constant;
+            import com.baomidou.mybatisplus.annotation.EnumValue;
+            public enum StatusWithEnumValue {
+                /** guest */
+                GUEST(30),
+                /** admin */
+                ADMIN(1100);
+
+                private final Integer code;
+
+                StatusWithEnumValue(Integer code) {
+                    this.code = code;
+                }
+
+                @EnumValue
+                private final Integer code;
+            }
+        """.trimIndent()
+
+        override fun createConfigReader() = TestConfigReader.fromConfigText(
+            project,
+            """
+            enum.use.custom=groovy:```
+                if (!it.isEnum()) return null
+                def f = it.fields().find { it.hasAnn("com.baomidou.mybatisplus.annotation.EnumValue") && !it.isStatic() && !it.isEnumField() }
+                return f?.name()
+            ```
+            """.trimIndent()
+        )
+
+        fun testEnumValueOnFieldUsesThatField() = runBlocking {
+            myFixture.addFileToProject("com/baomidou/mybatisplus/annotation/EnumValue.java", enumValueAnnotation)
+            myFixture.addFileToProject("constant/StatusWithEnumValue.java", enumWithEnumValue)
+            myFixture.addFileToProject(
+                "model/StatusDto3.java", """
+                package model;
+                import constant.StatusWithEnumValue;
+                public class StatusDto3 {
+                    public StatusWithEnumValue status;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.StatusDto3")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["status"]!!
+            assertEquals(JsonType.INT, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf(30, 1100),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 7 — Type reconciliation (Case 2)
+    // ================================================================
+
+    class Case2_TypeReconciliation : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        fun testIntFieldSeeEnumCodeReconcilesToInteger() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/TypeReconDto.java", """
+                package model;
+                import constant.UserType;
+                public class TypeReconDto {
+                    /**
+                     * @see UserType#code
+                     */
+                    public int type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.TypeReconDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            // int field + @see Enum#code (Integer) → INT (primitive↔boxed normalize)
+            assertEquals(JsonType.INT, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf(30, 1100, 1200),
+                field.options!!.map { it.value }
+            )
+        }
+
+        fun testStringFieldSeeEnumCodeReconcilesToInteger() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/TypeReconDto2.java", """
+                package model;
+                import constant.UserType;
+                public class TypeReconDto2 {
+                    /**
+                     * @see UserType#code
+                     */
+                    public String type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.TypeReconDto2")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            // String field + @see Enum#code (Integer) → INT (incompatible, values authoritative)
+            assertEquals(
+                "String field with @see Enum#code (Integer) should reconcile to INT",
+                JsonType.INT, (field.model as ObjectModel.Single).type
+            )
+            assertEquals(
+                listOf(30, 1100, 1200),
+                field.options!!.map { it.value }
+            )
+        }
+
+        fun testLongFieldSeeEnumCodeReconcilesToInteger() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/TypeReconDto3.java", """
+                package model;
+                import constant.UserType;
+                public class TypeReconDto3 {
+                    /**
+                     * @see UserType#code
+                     */
+                    public long type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.TypeReconDto3")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            // long field + @see Enum#code (Integer) → INT (numeric narrowing, value-field wins)
+            assertEquals(
+                "long field with @see Enum#code (Integer) should reconcile to INT",
+                JsonType.INT, (field.model as ObjectModel.Single).type
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 4.2 — @see name()/name parity (Case 2)
+    // ================================================================
+
+    class Case2_SeeNameParity : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        fun testSeeNameCallResolvesToPseudoField() = runBlocking {
+            myFixture.addFileToProject("constant/NameConflict.java", NAME_CONFLICT_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SeeNameCallDto.java", """
+                package model;
+                import constant.NameConflict;
+                public class SeeNameCallDto {
+                    /**
+                     * @see NameConflict#name()
+                     */
+                    public int value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SeeNameCallDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            // name() → pseudo-field → STRING, constant names
+            assertEquals(JsonType.STRING, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf("ONE", "TWO", "THREE"),
+                field.options!!.map { it.value }
+            )
+        }
+
+        fun testSeeNameBareResolvesToInstanceField() = runBlocking {
+            myFixture.addFileToProject("constant/NameConflict.java", NAME_CONFLICT_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/SeeNameBareDto.java", """
+                package model;
+                import constant.NameConflict;
+                public class SeeNameBareDto {
+                    /**
+                     * @see NameConflict#name
+                     */
+                    public int value;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.SeeNameBareDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["value"]!!
+            // bare name → instance field wins (issue #1383) → INT, field values
+            assertEquals(JsonType.INT, (field.model as ObjectModel.Single).type)
+            assertEquals(
+                listOf(1, 2, 3),
+                field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 6 — Case 1 / Case 2 consistency
+    // ================================================================
+
+    class Case1Case2Consistency : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.fromRules(
+            project, "enum.use.custom" to "code"
+        )
+
+        fun testSameEnumProducesIdenticalResultsCase1AndCase2() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            // Case 1: enum-typed field
+            myFixture.addFileToProject(
+                "model/Case1Dto.java", """
+                package model;
+                import constant.UserType;
+                public class Case1Dto {
+                    public UserType type;
+                }
+            """.trimIndent()
+            )
+            // Case 2: int field with @see UserType#code
+            myFixture.addFileToProject(
+                "model/Case2Dto.java", """
+                package model;
+                import constant.UserType;
+                public class Case2Dto {
+                    /**
+                     * @see UserType#code
+                     */
+                    public int type;
+                }
+            """.trimIndent()
+            )
+
+            val case1Result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(findClass("model.Case1Dto")!!, option = JsonOption.ALL)
+            val case2Result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(findClass("model.Case2Dto")!!, option = JsonOption.ALL)
+
+            val case1Field = (case1Result as ObjectModel.Object).fields["type"]!!
+            val case2Field = (case2Result as ObjectModel.Object).fields["type"]!!
+
+            // Same JSON type
+            assertEquals(
+                "Case 1 and Case 2 should produce the same JSON type",
+                (case1Field.model as ObjectModel.Single).type,
+                (case2Field.model as ObjectModel.Single).type
+            )
+            // Same option values
+            assertEquals(
+                "Case 1 and Case 2 should produce the same option values",
+                case1Field.options!!.map { it.value },
+                case2Field.options!!.map { it.value }
+            )
+        }
+    }
+
+    // ================================================================
+    //  Req 4.1 — @see with nonexistent member falls back to names
+    // ================================================================
+
+    class Case2_SeeNonexistentMember : EasyApiLightCodeInsightFixtureTestCase() {
+
+        override fun createConfigReader() = TestConfigReader.empty(project)
+
+        fun testSeeNonexistentMemberFallsBackToNames() = runBlocking {
+            myFixture.addFileToProject("constant/UserType.java", USER_TYPE_ENUM.trimIndent())
+            myFixture.addFileToProject(
+                "model/NonexistentDto.java", """
+                package model;
+                import constant.UserType;
+                public class NonexistentDto {
+                    /**
+                     * @see UserType#nonexistent
+                     */
+                    public int type;
+                }
+            """.trimIndent()
+            )
+            val psiClass = findClass("model.NonexistentDto")!!
+            val result = DefaultPsiClassHelper.getInstance(project)
+                .buildObjectModel(psiClass, option = JsonOption.ALL)
+
+            val field = (result as ObjectModel.Object).fields["type"]!!
+            // Nonexistent member → falls back to constant names
+            assertEquals(
+                listOf("GUEST", "ADMIN", "DEVELOPER"),
+                field.options!!.map { it.value }
+            )
         }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/SeeTagResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/SeeTagResolverTest.kt
@@ -50,10 +50,10 @@ class SeeTagResolverTest {
     //  Plain reference — class + getter method
     // ================================================================
 
-    @Test fun `Xxx#getField()`()        = assertParsed("Xxx#getField()", "Xxx", "getField")
-    @Test fun `fqcn#getField()`()       = assertParsed("xxx.xxx.Xxx#getField()", "xxx.xxx.Xxx", "getField")
+    @Test fun `Xxx#getField()`()        = assertParsed("Xxx#getField()", "Xxx", "getField()")
+    @Test fun `fqcn#getField()`()       = assertParsed("xxx.xxx.Xxx#getField()", "xxx.xxx.Xxx", "getField()")
     @Test fun `Xxx#getType`()           = assertParsed("Xxx#getType", "Xxx", "getType")
-    @Test fun `Xxx#isActive()`()        = assertParsed("Xxx#isActive()", "Xxx", "isActive")
+    @Test fun `Xxx#isActive()`()        = assertParsed("Xxx#isActive()", "Xxx", "isActive()")
 
     // ================================================================
     //  {@link ...} — class only
@@ -83,11 +83,11 @@ class SeeTagResolverTest {
     //  {@link ...} — class + getter method
     // ================================================================
 
-    @Test fun `link Xxx#getField()`()   = assertParsed("{@link Xxx#getField()}", "Xxx", "getField")
-    @Test fun `link fqcn#getField()`()  = assertParsed("{@link xxx.xxx.Xxx#getField()}", "xxx.xxx.Xxx", "getField")
-    @Test fun `link Xxx#getType()`()    = assertParsed("{@link UserType#getType()}", "UserType", "getType")
-    @Test fun `link fqcn#getType()`()   = assertParsed("{@link com.example.UserType#getType()}", "com.example.UserType", "getType")
-    @Test fun `link Xxx#isActive()`()   = assertParsed("{@link Xxx#isActive()}", "Xxx", "isActive")
+    @Test fun `link Xxx#getField()`()   = assertParsed("{@link Xxx#getField()}", "Xxx", "getField()")
+    @Test fun `link fqcn#getField()`()  = assertParsed("{@link xxx.xxx.Xxx#getField()}", "xxx.xxx.Xxx", "getField()")
+    @Test fun `link Xxx#getType()`()    = assertParsed("{@link UserType#getType()}", "UserType", "getType()")
+    @Test fun `link fqcn#getType()`()   = assertParsed("{@link com.example.UserType#getType()}", "com.example.UserType", "getType()")
+    @Test fun `link Xxx#isActive()`()   = assertParsed("{@link Xxx#isActive()}", "Xxx", "isActive()")
 
     // ================================================================
     //  [...] (Kotlin KDoc) — class only

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsDefaultsTest.kt
@@ -71,4 +71,33 @@ class SettingsDefaultsTest {
             appState.gutterIconEnabled
         )
     }
+
+    @Test
+    fun `test Settings default enumFieldAutoInferEnabled is false`() {
+        val settings = Settings()
+        assertFalse(
+            "Default enumFieldAutoInferEnabled should be false",
+            settings.enumFieldAutoInferEnabled
+        )
+    }
+
+    @Test
+    fun `test ApplicationSettingsState State default enumFieldAutoInferEnabled is false`() {
+        val state = ApplicationSettingsState.State()
+        assertFalse(
+            "ApplicationSettingsState default enumFieldAutoInferEnabled should be false",
+            state.enumFieldAutoInferEnabled
+        )
+    }
+
+    @Test
+    fun `test Settings and ApplicationSettingsState have matching enumFieldAutoInferEnabled defaults`() {
+        val settings = Settings()
+        val appState = ApplicationSettingsState.State()
+        assertEquals(
+            "enumFieldAutoInferEnabled defaults should match between Settings and ApplicationSettingsState",
+            settings.enumFieldAutoInferEnabled,
+            appState.enumFieldAutoInferEnabled
+        )
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -141,4 +141,20 @@ class ApplicationSettingsStateTest {
         val s = ApplicationSettingsState.State()
         assertNotEquals(s, "not a state")
     }
+
+    @Test
+    fun testState_inequality_enumFieldAutoInferEnabled() {
+        val s1 = ApplicationSettingsState.State(enumFieldAutoInferEnabled = false)
+        val s2 = ApplicationSettingsState.State(enumFieldAutoInferEnabled = true)
+        assertNotEquals(s1, s2)
+    }
+
+    @Test
+    fun testState_copyTo_enumFieldAutoInferEnabled() {
+        val source = ApplicationSettingsState.State(enumFieldAutoInferEnabled = true)
+        val target = ApplicationSettingsState.State()
+        assertEquals(false, target.enumFieldAutoInferEnabled)
+        source.copyTo(target)
+        assertEquals(true, target.enumFieldAutoInferEnabled)
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanelsParityTest.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.settings.ui
 
 import com.itangcent.easyapi.settings.Settings
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -40,5 +41,29 @@ class SettingsPanelsParityTest {
         builtIn.resetFrom(settings)
         assertFalse(builtIn.isModified(settings))
         builtIn.applyTo(settings)
+    }
+
+    @Test
+    fun testIntelligentPanelEnumFieldAutoInferEnabledRoundTrip() {
+        val settings = Settings().apply {
+            enumFieldAutoInferEnabled = true
+        }
+        val panel = IntelligentSettingsPanel()
+        panel.resetFrom(settings)
+        assertFalse(panel.isModified(settings))
+        panel.applyTo(settings)
+        assertEquals(true, settings.enumFieldAutoInferEnabled)
+    }
+
+    @Test
+    fun testIntelligentPanelEnumFieldAutoInferEnabledChangeDetected() {
+        val settings = Settings().apply {
+            enumFieldAutoInferEnabled = false
+        }
+        val panel = IntelligentSettingsPanel()
+        panel.resetFrom(settings)
+        assertFalse(panel.isModified(settings))
+        settings.enumFieldAutoInferEnabled = true
+        assertTrue(panel.isModified(settings))
     }
 }

--- a/src/test/resources/com/baomidou/mybatisplus/annotation/EnumValue.java
+++ b/src/test/resources/com/baomidou/mybatisplus/annotation/EnumValue.java
@@ -1,0 +1,8 @@
+package com.baomidou.mybatisplus.annotation;
+
+/**
+ * Stub of MyBatis-Plus's @EnumValue annotation for testing.
+ * Loaded into the test fixture's virtual file system.
+ */
+public @interface EnumValue {
+}

--- a/src/test/resources/com/fasterxml/jackson/annotation/JsonValue.java
+++ b/src/test/resources/com/fasterxml/jackson/annotation/JsonValue.java
@@ -1,0 +1,8 @@
+package com.fasterxml.jackson.annotation;
+
+/**
+ * Stub of Jackson's @JsonValue annotation for testing.
+ * Loaded into the test fixture's virtual file system.
+ */
+public @interface JsonValue {
+}

--- a/src/test/resources/enumcases/constant/JacksonStatus.java
+++ b/src/test/resources/enumcases/constant/JacksonStatus.java
@@ -1,0 +1,25 @@
+package enumcases.constant;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum with @JsonValue on getter.
+ * Used to test Case 1b: value field via framework annotation.
+ */
+public enum JacksonStatus {
+    /** guest */
+    GUEST(30),
+    /** admin */
+    ADMIN(1100),
+    /** developer */
+    DEVELOPER(1200);
+
+    private final Integer code;
+
+    JacksonStatus(Integer code) {
+        this.code = code;
+    }
+
+    @JsonValue
+    public Integer getCode() { return code; }
+}

--- a/src/test/resources/enumcases/constant/MyBatisStatus.java
+++ b/src/test/resources/enumcases/constant/MyBatisStatus.java
@@ -1,0 +1,25 @@
+package enumcases.constant;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+
+/**
+ * Enum with @EnumValue on field.
+ * Used to test Case 1b: value field via framework annotation.
+ */
+public enum MyBatisStatus {
+    /** guest */
+    GUEST(10),
+    /** admin */
+    ADMIN(20),
+    /** developer */
+    DEVELOPER(30);
+
+    @EnumValue
+    private final Integer code;
+
+    MyBatisStatus(Integer code) {
+        this.code = code;
+    }
+
+    public Integer getCode() { return code; }
+}

--- a/src/test/resources/enumcases/constant/NameConflictEnum.java
+++ b/src/test/resources/enumcases/constant/NameConflictEnum.java
@@ -1,0 +1,22 @@
+package enumcases.constant;
+
+/**
+ * Enum with an instance field literally named `name` (issue #1383).
+ * Used to test @see Enum#name() pseudo-field disambiguation.
+ */
+public enum NameConflictEnum {
+    /** first */
+    ONE(1),
+    /** second */
+    TWO(2),
+    /** third */
+    THREE(3);
+
+    private final Integer name;
+
+    NameConflictEnum(Integer name) {
+        this.name = name;
+    }
+
+    public Integer getName() { return name; }
+}

--- a/src/test/resources/enumcases/constant/SimpleStatus.java
+++ b/src/test/resources/enumcases/constant/SimpleStatus.java
@@ -1,0 +1,14 @@
+package enumcases.constant;
+
+/**
+ * Simple enum with no instance fields.
+ * Used to test Case 1a: default name serialization.
+ */
+public enum SimpleStatus {
+    /** Active */
+    ACTIVE,
+    /** Inactive */
+    INACTIVE,
+    /** Pending review */
+    PENDING
+}

--- a/src/test/resources/enumcases/constant/UserType.java
+++ b/src/test/resources/enumcases/constant/UserType.java
@@ -1,0 +1,25 @@
+package enumcases.constant;
+
+/**
+ * Enum with multiple instance fields (code, desc).
+ * Used to test Case 2 (@see) and auto-match by type.
+ */
+public enum UserType {
+    /** guest */
+    GUEST(30, "unspecified"),
+    /** admin */
+    ADMIN(1100, "administrator"),
+    /** developer */
+    DEVELOPER(1200, "developer");
+
+    private final Integer code;
+    private final String desc;
+
+    UserType(Integer code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+
+    public Integer getCode() { return code; }
+    public String getDesc() { return desc; }
+}

--- a/src/test/resources/enumcases/model/ComprehensiveEnumCasesDto.java
+++ b/src/test/resources/enumcases/model/ComprehensiveEnumCasesDto.java
@@ -1,0 +1,71 @@
+package enumcases.model;
+
+import enumcases.constant.SimpleStatus;
+import enumcases.constant.UserType;
+import enumcases.constant.JacksonStatus;
+import enumcases.constant.MyBatisStatus;
+import enumcases.constant.NameConflictEnum;
+
+/**
+ * Comprehensive DTO covering all enum resolution cases from the enum-resolution spec.
+ *
+ * Case 1 (field declared as enum type):
+ * - simpleStatus: Case 1a — default name serialization (no annotation, no rule)
+ * - jacksonStatus: Case 1b — @JsonValue on getter
+ * - myBatisStatus: Case 1b — @EnumValue on field
+ *
+ * Case 2 (normal-typed field with @see):
+ * - userCode: @see Enum#field (explicit field)
+ * - userDesc: @see Enum#getField() (getter)
+ * - constantName: @see Enum#name() (pseudo-field)
+ * - autoMatchedCode: @see Enum (class-only, auto-match by type)
+ */
+public class ComprehensiveEnumCasesDto {
+
+    // ================================================================
+    //  Case 1a: enum-typed field, default name serialization
+    // ================================================================
+    public SimpleStatus simpleStatus;
+
+    // ================================================================
+    //  Case 1b: @JsonValue on getter
+    // ================================================================
+    public JacksonStatus jacksonStatus;
+
+    // ================================================================
+    //  Case 1b: @EnumValue on field
+    // ================================================================
+    public MyBatisStatus myBatisStatus;
+
+    // ================================================================
+    //  Case 2: @see Enum#field (explicit field)
+    // ================================================================
+    /**
+     * @see UserType#code
+     */
+    public int userCode;
+
+    // ================================================================
+    //  Case 2: @see Enum#getField() (getter)
+    // ================================================================
+    /**
+     * @see UserType#getDesc()
+     */
+    public String userDesc;
+
+    // ================================================================
+    //  Case 2: @see Enum#name() (pseudo-field)
+    // ================================================================
+    /**
+     * @see NameConflictEnum#name()
+     */
+    public String constantName;
+
+    // ================================================================
+    //  Case 2: @see Enum (class-only, auto-match by type)
+    // ================================================================
+    /**
+     * @see UserType
+     */
+    public int autoMatchedCode;
+}

--- a/src/test/resources/enumcases/model/ComprehensiveEnumCasesDto.kt
+++ b/src/test/resources/enumcases/model/ComprehensiveEnumCasesDto.kt
@@ -1,0 +1,71 @@
+package enumcases.model
+
+import enumcases.constant.SimpleStatus
+import enumcases.constant.UserType
+import enumcases.constant.JacksonStatus
+import enumcases.constant.MyBatisStatus
+import enumcases.constant.NameConflictEnum
+
+/**
+ * Comprehensive DTO covering all enum resolution cases from the enum-resolution spec.
+ *
+ * Case 1 (field declared as enum type):
+ * - simpleStatus: Case 1a — default name serialization (no annotation, no rule)
+ * - jacksonStatus: Case 1b — @JsonValue on getter
+ * - myBatisStatus: Case 1b — @EnumValue on field
+ *
+ * Case 2 (normal-typed field with @see):
+ * - userCode: @see Enum#field (explicit field)
+ * - userDesc: @see Enum#getField() (getter)
+ * - constantName: @see Enum#name() (pseudo-field)
+ * - autoMatchedCode: @see Enum (class-only, auto-match by type)
+ */
+class ComprehensiveEnumCasesDto {
+
+    // ================================================================
+    //  Case 1a: enum-typed field, default name serialization
+    // ================================================================
+    var simpleStatus: SimpleStatus? = null
+
+    // ================================================================
+    //  Case 1b: @JsonValue on getter
+    // ================================================================
+    var jacksonStatus: JacksonStatus? = null
+
+    // ================================================================
+    //  Case 1b: @EnumValue on field
+    // ================================================================
+    var myBatisStatus: MyBatisStatus? = null
+
+    // ================================================================
+    //  Case 2: @see Enum#field (explicit field)
+    // ================================================================
+    /**
+     * @see UserType#code
+     */
+    var userCode: Int = 0
+
+    // ================================================================
+    //  Case 2: @see Enum#getField() (getter)
+    // ================================================================
+    /**
+     * @see UserType#getDesc()
+     */
+    var userDesc: String = ""
+
+    // ================================================================
+    //  Case 2: @see Enum#name() (pseudo-field)
+    // ================================================================
+    /**
+     * @see NameConflictEnum#name()
+     */
+    var constantName: String = ""
+
+    // ================================================================
+    //  Case 2: @see Enum (class-only, auto-match by type)
+    // ================================================================
+    /**
+     * @see UserType
+     */
+    var autoMatchedCode: Int = 0
+}


### PR DESCRIPTION
Add comprehensive enum value resolution for API documentation generation:

- New EnumValueResolver centralizes enum value-field detection supporting `@JsonValue` (getter/field), @EnumValue (field), and intelligent auto-match by type when enumFieldAutoInferEnabled is true
- SeeTagResolver now delegates to EnumValueResolver and returns the enum's value-field JSON type for Case 2 type reconciliation
- LinkResolver gains Kotlin file support: resolves package/imports from KtFile via KtLightElement.kotlinOrigin, fixing `@see` class resolution for Kotlin DTOs
- KotlinPsiAdapter.parseKDoc fixes `@see` tag value formatting to preserve reference syntax (UserType#code instead of UserType #code)
- DefaultPsiClassHelper integrates EnumValueResolver for both Case 1 (enum-typed fields) and Case 2 (@see-referenced fields) with type reconciliation
- Add mybatis-plus.config extension with `@EnumValue` recipe
- Add enumFieldAutoInferEnabled setting with UI toggle
- Add comprehensive Java/Kotlin DTO test fixtures covering all enum cases
- Add ComprehensiveEnumCasesTest verifying buildObjectModel produces expected options for every field in both Java and Kotlin DTOs

Reference: #1383