### PR TITLE
fix: preserve dashboard edits when switching between APIs

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanel.kt
@@ -24,7 +24,6 @@ import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.exporter.model.path
-import com.itangcent.easyapi.http.HttpClientProvider
 import com.itangcent.easyapi.ide.dialog.EndpointSelection
 import com.itangcent.easyapi.ide.dialog.ExportDialog
 import com.itangcent.easyapi.ide.support.NotificationUtils
@@ -103,8 +102,7 @@ class ApiDashboardPanel(private val project: Project) : JPanel(BorderLayout()), 
      * Initializes the panel with HTTP client, UI components, tree listeners, and API data.
      */
     init {
-        val httpClient = HttpClientProvider.getInstance(project).getClient()
-        endpointDetailsPanel = EndpointDetailsPanel(project, httpClient)
+        endpointDetailsPanel = EndpointDetailsPanel(project)
         
         inlineEnvPanel = InlineEnvironmentPanel(project).apply {
             onEnvironmentSaved = {

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
@@ -61,11 +61,9 @@ import javax.swing.table.DefaultTableModel
  * - Host history management
  * 
  * @param project The IntelliJ IDEA project context
- * @param httpClient The HTTP client for executing requests
  */
 class EndpointDetailsPanel(
-    private val project: Project,
-    private val httpClient: HttpClient
+    private val project: Project
 ) : JBPanel<EndpointDetailsPanel>(BorderLayout()) {
     companion object : IdeaLog
 
@@ -684,6 +682,7 @@ class EndpointDetailsPanel(
     }
 
     fun showEndpoint(endpoint: ApiEndpoint) {
+        saveCurrentEditBeforeSwitch()
         saveEndpointScripts()
         isLoading = true
         try {
@@ -866,44 +865,77 @@ class EndpointDetailsPanel(
         pathParamsTableModel.rowCount = 0
         pathParamsEnumValues.clear()
         val cachedPathParams = cache.pathParams.associateBy { it.name }
+        val originalPathParamNames = mutableSetOf<String>()
         pathParams.forEachIndexed { index, p ->
+            originalPathParamNames.add(p.name)
             val cachedValue = cachedPathParams[p.name]?.value ?: p.defaultValue ?: p.example ?: ""
             pathParamsTableModel.addRow(arrayOf(p.name, cachedValue, p.description ?: "", ""))
             updatePathParamComboBox(index, p.enumValues)
+        }
+        // Restore custom path params added by the user that are not part of the original endpoint
+        cache.pathParams.forEach { p ->
+            if (p.name !in originalPathParamNames) {
+                pathParamsTableModel.addRow(arrayOf(p.name, p.value ?: "", p.description ?: "", ""))
+            }
         }
         ensureEmptyRow(pathParamsTableModel)
 
         paramsTableModel.rowCount = 0
         val cachedQueryParams = cache.queryParams.associateBy { it.name }
+        val originalQueryParamNames = mutableSetOf<String>()
         parameters
             .filter { it.binding == ParameterBinding.Query || it.binding == ParameterBinding.Cookie }
             .forEach { p ->
+                originalQueryParamNames.add(p.name)
                 val cachedValue = cachedQueryParams[p.name]?.value ?: p.defaultValue ?: p.example ?: ""
                 paramsTableModel.addRow(arrayOf(p.name, cachedValue, p.description ?: "", ""))
             }
+        // Restore custom query params added by the user that are not part of the original endpoint
+        cache.queryParams.forEach { p ->
+            if (p.name !in originalQueryParamNames) {
+                paramsTableModel.addRow(arrayOf(p.name, p.value ?: "", p.description ?: "", ""))
+            }
+        }
         ensureEmptyRow(paramsTableModel)
 
         headersTableModel.rowCount = 0
         val cachedHeaders = cache.headers.associateBy { it.name }
+        val originalHeaderNames = mutableSetOf<String>()
         headers.forEach { h ->
+            originalHeaderNames.add(h.name)
             val cachedValue = cachedHeaders[h.name]?.value ?: h.value ?: ""
             headersTableModel.addRow(arrayOf(h.name, cachedValue, ""))
         }
         parameters.filter { it.binding == ParameterBinding.Header }
             .forEach { p ->
+                originalHeaderNames.add(p.name)
                 val cachedValue = cachedHeaders[p.name]?.value ?: p.defaultValue ?: p.example ?: ""
                 headersTableModel.addRow(arrayOf(p.name, cachedValue, ""))
             }
+        // Restore custom headers added by the user that are not part of the original endpoint
+        cache.headers.forEach { h ->
+            if (h.name !in originalHeaderNames) {
+                headersTableModel.addRow(arrayOf(h.name, h.value ?: "", ""))
+            }
+        }
         ensureEmptyRow(headersTableModel)
 
         val formParams = parameters.filter { it.binding == ParameterBinding.Form }
         formTableModel.rowCount = 0
         formFileRows.clear()
         val cachedFormParams = cache.formParams.associateBy { it.name }
+        val originalFormParamNames = mutableSetOf<String>()
         formParams.forEachIndexed { index, p ->
+            originalFormParamNames.add(p.name)
             val cachedValue = cachedFormParams[p.name]?.value ?: p.defaultValue ?: p.example ?: ""
             formTableModel.addRow(arrayOf(p.name, cachedValue, p.description ?: "", ""))
             if (p.type == ParameterType.FILE) formFileRows.add(index)
+        }
+        // Restore custom form params added by the user that are not part of the original endpoint
+        cache.formParams.forEach { p ->
+            if (p.name !in originalFormParamNames) {
+                formTableModel.addRow(arrayOf(p.name, p.value ?: "", p.description ?: "", ""))
+            }
         }
         ensureEmptyRow(formTableModel)
         setupFormTableFileEditors()
@@ -1033,6 +1065,7 @@ class EndpointDetailsPanel(
     }
 
     fun clear() {
+        saveCurrentEditBeforeSwitch()
         saveEndpointScripts()
         currentEndpoint = null
         currentEndpointKey = ""
@@ -1451,6 +1484,20 @@ class EndpointDetailsPanel(
         autoSaveTimer.restart()
     }
 
+    /**
+     * Flushes any pending auto-save for the current endpoint before switching away.
+     *
+     * Without this, the debounced auto-save timer would fire after `currentEndpointKey`
+     * has already been updated to the new endpoint, causing the previous endpoint's
+     * edits to be lost (or worse, overwritten with the new endpoint's data).
+     */
+    private fun saveCurrentEditBeforeSwitch() {
+        autoSaveTimer.stop()
+        if (!isLoading && currentEndpointKey.isNotEmpty()) {
+            doSaveCurrentEdit()
+        }
+    }
+
     private fun doSaveCurrentEdit() {
         val endpoint = currentEndpoint ?: return
 
@@ -1553,6 +1600,7 @@ class EndpointDetailsPanel(
     }
 
     fun dispose() {
+        saveCurrentEditBeforeSwitch()
         saveEndpointScripts()
         scope.cancel()
     }

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiDashboardPanelTest.kt
@@ -57,7 +57,7 @@ class ApiDashboardPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     fun testEndpointDetailsPanelShowsEndpoint() {
         val endpoint = ApiFixtures.createGetEndpoint()
-        val detailsPanel = EndpointDetailsPanel(project, com.itangcent.easyapi.http.UrlConnectionHttpClient)
+        val detailsPanel = EndpointDetailsPanel(project)
         
         detailsPanel.showEndpoint(endpoint)
         


### PR DESCRIPTION
## Description

Fixes a bug where edits to request headers, params, body, host, and path in the API Dashboard are lost when switching between endpoints and switching back.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1388

## Changes Made

- **Flush pending edits before switching endpoints.** Added `saveCurrentEditBeforeSwitch()` which stops the debounced auto-save timer and immediately persists the current endpoint's edits using the *current* key. This is now called at the start of `showEndpoint()`, `clear()`, and `dispose()` — mirroring the existing `saveEndpointScripts()` pattern that was already in place for scripts.
  - Root cause: `showEndpoint()` updated `currentEndpointKey` to the new endpoint before the 500ms auto-save timer fired, so the timer ended up saving the *new* endpoint's data to the *new* key, silently dropping the previous endpoint's edits.
- **Restore custom rows from cache.** `loadFromCache()` previously only iterated over headers/parameters defined in the original endpoint metadata, so any custom rows the user added (and which were saved to the cache) were dropped on reload. Now, after restoring original rows, any cached entries whose name doesn't match an original entry are also restored — for path params, query params, headers, and form params.

## Testing

- [x] Unit tests pass (`./gradlew test --tests "com.itangcent.easyapi.dashboard.*"`)
- [x] Compilation verified (`./gradlew compileKotlin`)
- [ ] Manual testing completed

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The same save-before-switch pattern was already used for pre/post request scripts (`saveEndpointScripts()`). This PR extends that pattern to the request edit cache (headers/params/body/host/path), which was the missing piece.
