### PR TITLE
amend: extract ObjectModelVisitTracker to centralize visit-count logic

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/PropertiesFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/PropertiesFormatter.kt
@@ -3,9 +3,9 @@ package com.itangcent.easyapi.exporter.formatter
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.FieldOption
 import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.util.text.append
-import java.util.IdentityHashMap
 
 /**
  * Formats an [ObjectModel] as a Java properties string.
@@ -27,7 +27,7 @@ import java.util.IdentityHashMap
  *
  * ## Recursive Reference Handling
  * To prevent infinite loops with self-referencing types, each object
- * is tracked and limited to [maxVisits] expansions (default: 2).
+ * is tracked and limited to [ObjectModel.DEFAULT_MAX_VISITS] expansions.
  *
  * ## Usage
  * ```kotlin
@@ -35,15 +35,14 @@ import java.util.IdentityHashMap
  * val properties = formatter.format(objectModel)
  * ```
  *
- * @param maxVisits Maximum number of times to expand the same object
  * @see ObjectModel for the input model
  */
-class PropertiesFormatter(private val maxVisits: Int = 2) {
+class PropertiesFormatter {
 
     fun format(model: ObjectModel, prefix: String = ""): String {
         val sb = StringBuilder()
-        val visitCounts = IdentityHashMap<ObjectModel.Object, Int>()
-        flatten(prefix, model, null, sb, visitCounts)
+        val tracker = ObjectModelVisitTracker()
+        flatten(prefix, model, null, sb, tracker)
         return sb.toString()
     }
 
@@ -52,12 +51,11 @@ class PropertiesFormatter(private val maxVisits: Int = 2) {
         model: ObjectModel,
         fieldModel: FieldModel?,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (model) {
             is ObjectModel.Object -> {
-                val count = visitCounts.getOrDefault(model, 0)
-                if (count >= maxVisits) {
+                if (!tracker.tryEnter(model)) {
                     // Recursive reference — emit as empty value to avoid infinite loop
                     sb.appendComment(fieldModel?.comment)
                     if (prefix.isNotEmpty()) {
@@ -65,13 +63,15 @@ class PropertiesFormatter(private val maxVisits: Int = 2) {
                     }
                     return
                 }
-                visitCounts[model] = count + 1
-                sb.appendComment(fieldModel?.comment)
-                for ((name, field) in model.fields) {
-                    val full = prefix.append(name, separator = ".")
-                    flatten(full, field.model, field, sb, visitCounts)
+                try {
+                    sb.appendComment(fieldModel?.comment)
+                    for ((name, field) in model.fields) {
+                        val full = prefix.append(name, separator = ".")
+                        flatten(full, field.model, field, sb, tracker)
+                    }
+                } finally {
+                    tracker.exit(model)
                 }
-                visitCounts[model] = count
             }
 
             is ObjectModel.Array -> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/formatter/YamlFormatter.kt
@@ -2,8 +2,8 @@ package com.itangcent.easyapi.exporter.formatter
 
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
 import com.itangcent.easyapi.psi.type.JsonType
-import java.util.IdentityHashMap
 
 /**
  * Renders an [ObjectModel] as YAML (block style, 2-space indent).
@@ -28,8 +28,8 @@ import java.util.IdentityHashMap
  *
  * ## Recursive Reference Handling
  * To prevent infinite loops with self-referencing types, each object
- * is tracked and limited to [MAX_VISITS] expansions — same pattern as
- * [PropertiesFormatter].
+ * is tracked and limited to [ObjectModel.DEFAULT_MAX_VISITS] expansions —
+ * same pattern as [PropertiesFormatter].
  *
  * ## Usage
  * ```kotlin
@@ -41,25 +41,24 @@ import java.util.IdentityHashMap
 object YamlFormatter {
 
     private const val INDENT = "  "
-    private const val MAX_VISITS = 2
 
     /** YAML rendering of an [ObjectModel]. */
     fun format(model: ObjectModel): String {
         val sb = StringBuilder()
-        val visitCounts = IdentityHashMap<ObjectModel.Object, Int>()
-        renderTop(model, sb, visitCounts)
+        val tracker = ObjectModelVisitTracker()
+        renderTop(model, sb, tracker)
         return sb.toString().trimEnd()
     }
 
     private fun renderTop(
         model: ObjectModel,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (model) {
-            is ObjectModel.Object -> renderObjectFields(model, 0, sb, visitCounts, firstLine = true)
-            is ObjectModel.Array -> renderArray(model, 0, sb, visitCounts)
-            is ObjectModel.MapModel -> renderMap(model, 0, sb, visitCounts)
+            is ObjectModel.Object -> renderObjectFields(model, 0, sb, tracker, firstLine = true)
+            is ObjectModel.Array -> renderArray(model, 0, sb, tracker)
+            is ObjectModel.MapModel -> renderMap(model, 0, sb, tracker)
             is ObjectModel.Single -> sb.append("value: ").append(formatSingleValue(model, null))
         }
     }
@@ -73,7 +72,7 @@ object YamlFormatter {
         model: ObjectModel.Object,
         indent: Int,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>,
+        tracker: ObjectModelVisitTracker,
         firstLine: Boolean
     ) {
         if (model.fields.isEmpty()) {
@@ -81,20 +80,20 @@ object YamlFormatter {
             return
         }
 
-        val count = visitCounts.getOrDefault(model, 0)
-        if (count >= MAX_VISITS) {
+        if (!tracker.tryEnter(model)) {
             sb.append("{}")
             return
         }
-        visitCounts[model] = count + 1
 
-        model.fields.entries.forEachIndexed { index, (name, field) ->
-            if (!firstLine || index > 0) sb.appendLine()
-            sb.append(INDENT.repeat(indent)).append(name).append(":")
-            renderFieldValue(field, indent, sb, visitCounts)
+        try {
+            model.fields.entries.forEachIndexed { index, (name, field) ->
+                if (!firstLine || index > 0) sb.appendLine()
+                sb.append(INDENT.repeat(indent)).append(name).append(":")
+                renderFieldValue(field, indent, sb, tracker)
+            }
+        } finally {
+            tracker.exit(model)
         }
-
-        visitCounts[model] = count
     }
 
     /**
@@ -105,31 +104,34 @@ object YamlFormatter {
         field: FieldModel,
         indent: Int,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (val model = field.model) {
             is ObjectModel.Object -> {
                 if (model.fields.isEmpty()) {
                     sb.append(" {}")
                 } else {
-                    val count = visitCounts.getOrDefault(model, 0)
-                    if (count >= MAX_VISITS) {
+                    if (!tracker.tryEnter(model)) {
                         sb.append(" {}")
                     } else {
-                        sb.appendLine()
-                        renderObjectFields(model, indent + 1, sb, visitCounts, firstLine = false)
+                        try {
+                            sb.appendLine()
+                            renderObjectFields(model, indent + 1, sb, tracker, firstLine = false)
+                        } finally {
+                            tracker.exit(model)
+                        }
                     }
                 }
             }
 
             is ObjectModel.Array -> {
                 sb.appendLine()
-                renderArray(model, indent + 1, sb, visitCounts)
+                renderArray(model, indent + 1, sb, tracker)
             }
 
             is ObjectModel.MapModel -> {
                 sb.appendLine()
-                renderMap(model, indent + 1, sb, visitCounts)
+                renderMap(model, indent + 1, sb, tracker)
             }
 
             is ObjectModel.Single -> {
@@ -145,7 +147,7 @@ object YamlFormatter {
         model: ObjectModel.Array,
         indent: Int,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         sb.append(INDENT.repeat(indent)).append("- ")
         when (val item = model.item) {
@@ -153,33 +155,34 @@ object YamlFormatter {
                 if (item.fields.isEmpty()) {
                     sb.append("{}")
                 } else {
-                    val count = visitCounts.getOrDefault(item, 0)
-                    if (count >= MAX_VISITS) {
+                    if (!tracker.tryEnter(item)) {
                         sb.append("{}")
                     } else {
-                        visitCounts[item] = count + 1
-                        // First field inline with `- `, rest on new lines
-                        val entries = item.fields.entries.toList()
-                        entries.forEachIndexed { index, (name, field) ->
-                            if (index > 0) {
-                                sb.appendLine()
-                                sb.append(INDENT.repeat(indent + 1))
+                        try {
+                            // First field inline with `- `, rest on new lines
+                            val entries = item.fields.entries.toList()
+                            entries.forEachIndexed { index, (name, field) ->
+                                if (index > 0) {
+                                    sb.appendLine()
+                                    sb.append(INDENT.repeat(indent + 1))
+                                }
+                                sb.append(name).append(":")
+                                renderFieldValue(field, indent + 1, sb, tracker)
                             }
-                            sb.append(name).append(":")
-                            renderFieldValue(field, indent + 1, sb, visitCounts)
+                        } finally {
+                            tracker.exit(item)
                         }
-                        visitCounts[item] = count
                     }
                 }
             }
 
             is ObjectModel.Array -> {
-                renderArray(item, indent + 1, sb, visitCounts)
+                renderArray(item, indent + 1, sb, tracker)
             }
 
             is ObjectModel.MapModel -> {
                 sb.appendLine()
-                renderMap(item, indent + 1, sb, visitCounts)
+                renderMap(item, indent + 1, sb, tracker)
             }
 
             is ObjectModel.Single -> {
@@ -195,20 +198,20 @@ object YamlFormatter {
         model: ObjectModel.MapModel,
         indent: Int,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         sb.append(INDENT.repeat(indent)).append("key:")
-        renderMapValue(model.keyType, indent, sb, visitCounts)
+        renderMapValue(model.keyType, indent, sb, tracker)
         sb.appendLine()
         sb.append(INDENT.repeat(indent)).append("value:")
-        renderMapValue(model.valueType, indent, sb, visitCounts)
+        renderMapValue(model.valueType, indent, sb, tracker)
     }
 
     private fun renderMapValue(
         model: ObjectModel,
         indent: Int,
         sb: StringBuilder,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (model) {
             is ObjectModel.Object -> {
@@ -216,18 +219,18 @@ object YamlFormatter {
                     sb.append(" {}")
                 } else {
                     sb.appendLine()
-                    renderObjectFields(model, indent + 1, sb, visitCounts, firstLine = false)
+                    renderObjectFields(model, indent + 1, sb, tracker, firstLine = false)
                 }
             }
 
             is ObjectModel.Array -> {
                 sb.appendLine()
-                renderArray(model, indent + 1, sb, visitCounts)
+                renderArray(model, indent + 1, sb, tracker)
             }
 
             is ObjectModel.MapModel -> {
                 sb.appendLine()
-                renderMap(model, indent + 1, sb, visitCounts)
+                renderMap(model, indent + 1, sb, tracker)
             }
 
             is ObjectModel.Single -> {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/markdown/DefaultMarkdownFormatter.kt
@@ -10,18 +10,8 @@ import com.itangcent.easyapi.exporter.model.ParameterBinding
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
 
-/**
- * Default implementation of MarkdownFormatter.
- * 
- * This formatter generates comprehensive Markdown documentation including:
- * - Endpoint grouping by folder
- * - Request parameters (path, query, headers, form)
- * - Request body with optional JSON demo
- * - Response body documentation
- * 
- * @param outputDemo Whether to include JSON demo snippets in the output
- */
 /**
  * Default implementation of Markdown formatter for API documentation.
  * 
@@ -36,10 +26,9 @@ import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
  * @param outputDemo Whether to include JSON demo examples in the output
  */
 class DefaultMarkdownFormatter(
-    private val outputDemo: Boolean = true,
-    private val maxVisits: Int = 2
+    private val outputDemo: Boolean = true
 ) : MarkdownFormatter {
-    
+
     /**
      * Formats a list of API endpoints as Markdown documentation.
      * Groups endpoints by folder and generates detailed documentation for each.
@@ -59,22 +48,22 @@ class DefaultMarkdownFormatter(
     override suspend fun format(endpoints: List<ApiEndpoint>, moduleName: String): String {
         val sb = StringBuilder()
         sb.append("# ").append(moduleName).append('\n')
-        
+
         val grouped = endpoints.groupBy { it.folder ?: "" }
-        
+
         for ((folder, list) in grouped) {
             if (folder.isNotBlank()) {
                 sb.append('\n').append("## ").append(folder).append('\n')
             }
-            
+
             for (ep in list) {
                 formatEndpoint(sb, ep)
             }
         }
-        
+
         return sb.toString()
     }
-    
+
     /**
      * Formats a single API endpoint as a Markdown section.
      * Dispatches to protocol-specific formatting based on metadata type.
@@ -99,18 +88,18 @@ class DefaultMarkdownFormatter(
     private fun formatHttpEndpoint(sb: StringBuilder, ep: ApiEndpoint, meta: HttpMetadata) {
         sb.append('\n').append("---\n")
         sb.append("### ").append(ep.name ?: "${meta.method.name} ${meta.path}").append('\n')
-        
+
         sb.append('\n').append("> BASIC").append('\n').append('\n')
         sb.append("**Path:** ").append(meta.path).append('\n').append('\n')
         sb.append("**Method:** ").append(meta.method.name).append('\n').append('\n')
-        
+
         ep.description?.takeIf { it.isNotBlank() }?.let {
             sb.append("**Desc:**").append('\n').append('\n')
             sb.append(it).append('\n').append('\n')
         }
-        
+
         formatRequest(sb, ep, meta)
-        
+
         formatResponse(sb, ep, meta)
     }
 
@@ -153,7 +142,7 @@ class DefaultMarkdownFormatter(
 
         formatResponse(sb, ep, meta)
     }
-    
+
     /**
      * Formats the request section of an endpoint.
      * Includes path params, query params, headers, form data, and body.
@@ -170,34 +159,34 @@ class DefaultMarkdownFormatter(
      */
     private fun formatRequest(sb: StringBuilder, ep: ApiEndpoint, meta: HttpMetadata) {
         sb.append('\n').append("> REQUEST").append('\n').append('\n')
-        
+
         val pathParams = meta.parameters.filter { it.binding == ParameterBinding.Path }
         if (pathParams.isNotEmpty()) {
             sb.append("**Path Params:**").append('\n').append('\n')
             formatParamsTable(sb, pathParams)
         }
-        
+
         val queryParams = meta.parameters.filter { it.binding == ParameterBinding.Query }
         if (queryParams.isNotEmpty()) {
             sb.append("**Query:**").append('\n').append('\n')
             formatQueryTable(sb, queryParams)
         }
-        
+
         if (meta.headers.isNotEmpty()) {
             sb.append("**Headers:**").append('\n').append('\n')
             formatHeadersTable(sb, meta.headers)
         }
-        
+
         val formParams = meta.parameters.filter { it.binding == ParameterBinding.Form }
         if (formParams.isNotEmpty()) {
             sb.append("**Form:**").append('\n').append('\n')
             formatFormTable(sb, formParams)
         }
-        
+
         if (meta.body != null) {
             sb.append("**Request Body:**").append('\n').append('\n')
             formatBodyTable(sb, meta.body)
-            
+
             if (outputDemo) {
                 sb.append('\n').append("**Request Demo:**").append('\n').append('\n')
                 sb.append("```json").append('\n')
@@ -205,12 +194,12 @@ class DefaultMarkdownFormatter(
                 sb.append('\n').append("```").append('\n')
             }
         }
-        
+
         if (pathParams.isEmpty() && queryParams.isEmpty() && meta.headers.isEmpty() && formParams.isEmpty() && meta.body == null) {
             sb.append('\n')
         }
     }
-    
+
     /**
      * Formats the response section of an endpoint.
      * 
@@ -229,14 +218,14 @@ class DefaultMarkdownFormatter(
             is GrpcMetadata -> meta.responseBody
             else -> null
         }
-        
+
         if (responseBody == null) return
-        
+
         sb.append('\n').append("> RESPONSE").append('\n').append('\n')
-        
+
         sb.append("**Body:**").append('\n').append('\n')
         formatBodyTable(sb, responseBody)
-        
+
         if (outputDemo) {
             sb.append('\n').append("**Response Demo:**").append('\n').append('\n')
             sb.append("```json").append('\n')
@@ -244,7 +233,7 @@ class DefaultMarkdownFormatter(
             sb.append('\n').append("```").append('\n')
         }
     }
-    
+
     /**
      * Formats a table for path parameters.
      * 
@@ -254,7 +243,7 @@ class DefaultMarkdownFormatter(
     private fun formatParamsTable(sb: StringBuilder, params: List<ApiParameter>) {
         sb.append("| name | value | required | desc |").append('\n')
         sb.append("| ------------ | ------------ | ------------ | ------------ |").append('\n')
-        
+
         for (p in params) {
             sb.append("| ")
                 .append(escape(p.name)).append(" | ")
@@ -265,7 +254,7 @@ class DefaultMarkdownFormatter(
         }
         sb.append('\n')
     }
-    
+
     /**
      * Formats a table for query parameters.
      * 
@@ -275,7 +264,7 @@ class DefaultMarkdownFormatter(
     private fun formatQueryTable(sb: StringBuilder, params: List<ApiParameter>) {
         sb.append("| name | value | required | desc |").append('\n')
         sb.append("| ------------ | ------------ | ------------ | ------------ |").append('\n')
-        
+
         for (p in params) {
             sb.append("| ")
                 .append(escape(p.name)).append(" | ")
@@ -286,7 +275,7 @@ class DefaultMarkdownFormatter(
         }
         sb.append('\n')
     }
-    
+
     /**
      * Formats a table for HTTP headers.
      * 
@@ -296,7 +285,7 @@ class DefaultMarkdownFormatter(
     private fun formatHeadersTable(sb: StringBuilder, headers: List<ApiHeader>) {
         sb.append("| name | value | required | desc |").append('\n')
         sb.append("| ------------ | ------------ | ------------ | ------------ |").append('\n')
-        
+
         for (h in headers) {
             sb.append("| ")
                 .append(escape(h.name)).append(" | ")
@@ -307,7 +296,7 @@ class DefaultMarkdownFormatter(
         }
         sb.append('\n')
     }
-    
+
     /**
      * Formats a table for form data parameters.
      * 
@@ -317,7 +306,7 @@ class DefaultMarkdownFormatter(
     private fun formatFormTable(sb: StringBuilder, params: List<ApiParameter>) {
         sb.append("| name | value | required | type | desc |").append('\n')
         sb.append("| ------------ | ------------ | ------------ | ------------ | ------------ |").append('\n')
-        
+
         for (p in params) {
             sb.append("| ")
                 .append(escape(p.name)).append(" | ")
@@ -329,7 +318,7 @@ class DefaultMarkdownFormatter(
         }
         sb.append('\n')
     }
-    
+
     /**
      * Formats a table describing the structure of a request/response body.
      * 
@@ -338,14 +327,14 @@ class DefaultMarkdownFormatter(
      */
     private fun formatBodyTable(sb: StringBuilder, model: ObjectModel?) {
         if (model == null) return
-        
+
         sb.append("| name | type | desc |").append('\n')
         sb.append("| ------------ | ------------ | ------------ |").append('\n')
-        
+
         formatObjectModelRecursive(sb, model, 0)
         sb.append('\n')
     }
-    
+
     /**
      * Recursively formats an object model into table rows.
      * Handles objects, arrays, single values, and maps.
@@ -355,39 +344,43 @@ class DefaultMarkdownFormatter(
      * @param depth The current nesting depth for indentation
      */
     private fun formatObjectModelRecursive(sb: StringBuilder, model: ObjectModel, depth: Int) {
-        val visitCounts = HashMap<Int, Int>()
-        formatObjectModelRecursive(sb, model, depth, visitCounts)
+        val tracker = ObjectModelVisitTracker()
+        formatObjectModelRecursive(sb, model, depth, tracker)
     }
 
     private fun formatObjectModelRecursive(
         sb: StringBuilder,
         model: ObjectModel,
         depth: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (model) {
             is ObjectModel.Object -> {
-                val count = visitCounts.getOrDefault(model.id, 0)
-                if (count >= maxVisits) return
-                visitCounts[model.id] = count + 1
-                for ((fieldName, fieldModel) in model.fields) {
-                    formatFieldRow(sb, fieldName, fieldModel, depth, visitCounts)
+                if (!tracker.tryEnter(model)) return
+                try {
+                    for ((fieldName, fieldModel) in model.fields) {
+                        formatFieldRow(sb, fieldName, fieldModel, depth, tracker)
+                    }
+                } finally {
+                    tracker.exit(model)
                 }
-                visitCounts[model.id] = count
             }
+
             is ObjectModel.Array -> {
-                formatArrayItemRecursive(sb, model.item, "[0]", depth, visitCounts)
+                formatArrayItemRecursive(sb, model.item, "[0]", depth, tracker)
             }
+
             is ObjectModel.Single -> {
                 sb.append("| | ").append(escape(model.type)).append(" | |").append('\n')
             }
+
             is ObjectModel.MapModel -> {
                 sb.append("| key | ").append(formatType(model.keyType)).append(" | |").append('\n')
                 sb.append("| value | ").append(formatType(model.valueType)).append(" | |").append('\n')
             }
         }
     }
-    
+
     /**
      * Recursively formats array items with a prefix.
      * 
@@ -401,26 +394,30 @@ class DefaultMarkdownFormatter(
         item: ObjectModel,
         prefix: String,
         depth: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (item) {
             is ObjectModel.Object -> {
-                val count = visitCounts.getOrDefault(item.id, 0)
-                if (count >= maxVisits) return
-                visitCounts[item.id] = count + 1
-                for ((fieldName, fieldModel) in item.fields) {
-                    formatFieldRow(sb, "$prefix.$fieldName", fieldModel, depth, visitCounts)
+                if (!tracker.tryEnter(item)) return
+                try {
+                    for ((fieldName, fieldModel) in item.fields) {
+                        formatFieldRow(sb, "$prefix.$fieldName", fieldModel, depth, tracker)
+                    }
+                } finally {
+                    tracker.exit(item)
                 }
-                visitCounts[item.id] = count
             }
+
             is ObjectModel.Array -> {
-                formatArrayItemRecursive(sb, item.item, "$prefix[0]", depth, visitCounts)
+                formatArrayItemRecursive(sb, item.item, "$prefix[0]", depth, tracker)
             }
+
             is ObjectModel.Single -> {
                 sb.append("| ").append(escape(prefix)).append(" | ")
                     .append(escape(item.type)).append("[] | |")
                     .append('\n')
             }
+
             is ObjectModel.MapModel -> {
                 sb.append("| ").append(escape(prefix)).append(".key | ")
                     .append(formatType(item.keyType)).append(" | |")
@@ -431,7 +428,7 @@ class DefaultMarkdownFormatter(
             }
         }
     }
-    
+
     /**
      * Formats a single field row in a body table.
      * Includes indentation for nested fields.
@@ -446,60 +443,67 @@ class DefaultMarkdownFormatter(
         fieldName: String,
         fieldModel: FieldModel,
         depth: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         val indent = if (depth > 0) {
             "&ensp;&ensp;".repeat(depth) + "&#124;─"
         } else {
             ""
         }
-        
+
         val type = formatType(fieldModel.model)
         val desc = buildFieldDescription(fieldModel)
-        
+
         sb.append("| ")
             .append(indent).append(escape(fieldName)).append(" | ")
             .append(escape(type)).append(" | ")
             .append(escape(desc)).append(" |")
             .append('\n')
-        
+
         when (val nestedModel = fieldModel.model) {
             is ObjectModel.Object -> {
-                val count = visitCounts.getOrDefault(nestedModel.id, 0)
-                if (count >= maxVisits) return
-                visitCounts[nestedModel.id] = count + 1
-                for ((nestedFieldName, nestedFieldModel) in nestedModel.fields) {
-                    formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, visitCounts)
+                if (tracker.tryEnter(nestedModel)) {
+                    try {
+                        for ((nestedFieldName, nestedFieldModel) in nestedModel.fields) {
+                            formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, tracker)
+                        }
+                    } finally {
+                        tracker.exit(nestedModel)
+                    }
                 }
-                visitCounts[nestedModel.id] = count
             }
+
             is ObjectModel.Array -> {
                 when (val item = nestedModel.item) {
                     is ObjectModel.Object -> {
-                        val count = visitCounts.getOrDefault(item.id, 0)
-                        if (count >= maxVisits) return
-                        visitCounts[item.id] = count + 1
-                        for ((nestedFieldName, nestedFieldModel) in item.fields) {
-                            formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, visitCounts)
+                        if (tracker.tryEnter(item)) {
+                            try {
+                                for ((nestedFieldName, nestedFieldModel) in item.fields) {
+                                    formatFieldRow(sb, nestedFieldName, nestedFieldModel, depth + 1, tracker)
+                                }
+                            } finally {
+                                tracker.exit(item)
+                            }
                         }
-                        visitCounts[item.id] = count
                     }
+
                     else -> {
                         // For simple array types, no nested rows needed
                     }
                 }
             }
+
             else -> {
                 // Simple types don't need nested rows
             }
         }
     }
-    
+
     private fun buildFieldDescription(fieldModel: FieldModel): String {
         val parts = mutableListOf<String>()
-        
+
         fieldModel.comment?.takeIf { it.isNotBlank() }?.let { parts.add(it) }
-        
+
         fieldModel.options?.takeIf { it.isNotEmpty() }?.let { options ->
             val optionDesc = options.joinToString("<br>") { opt ->
                 if (opt.desc.isNullOrBlank()) {
@@ -510,10 +514,10 @@ class DefaultMarkdownFormatter(
             }
             parts.add(optionDesc)
         }
-        
+
         return parts.joinToString("<br>")
     }
-    
+
     private fun formatType(model: ObjectModel): String {
         return when (model) {
             is ObjectModel.Single -> model.type
@@ -522,7 +526,7 @@ class DefaultMarkdownFormatter(
             is ObjectModel.MapModel -> "map"
         }
     }
-    
+
     private fun escape(text: String): String {
         return MarkdownEscapeUtils.escape(text)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/JsonSchemaBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/JsonSchemaBuilder.kt
@@ -3,9 +3,9 @@ package com.itangcent.easyapi.exporter.yapi
 import com.itangcent.easyapi.exporter.model.ApiParameter
 import com.itangcent.easyapi.psi.model.FieldModel
 import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelVisitTracker
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.util.json.GsonUtils
-import java.util.IdentityHashMap
 
 /**
  * Builder for creating JSON Schema from object models.
@@ -18,14 +18,11 @@ import java.util.IdentityHashMap
  * - Field descriptions, defaults, and mock data
  * - Enum values with descriptions
  * - Circular reference detection
- * 
- * @param maxVisits Maximum times to visit the same object (prevents infinite recursion)
  */
-class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
+class JsonSchemaBuilder {
 
     /** Configuration constants */
     companion object {
-        private const val MAX_VISITS = 2
         private const val SCHEMA_URL = "http://json-schema.org/draft-04/schema#"
     }
 
@@ -123,18 +120,18 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
      * Dispatches to the appropriate type-specific builder.
      * 
      * @param model The object model
-     * @param visitCounts Tracking map for circular reference detection
+     * @param tracker Tracking map for circular reference detection
      * @return A schema map
      */
     private fun buildSchema(
         model: ObjectModel,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int> = IdentityHashMap()
+        tracker: ObjectModelVisitTracker = ObjectModelVisitTracker()
     ): LinkedHashMap<String, Any?> {
         return when (model) {
             is ObjectModel.Single -> buildSingleSchema(model)
-            is ObjectModel.Object -> buildObjectSchema(model, visitCounts)
-            is ObjectModel.Array -> buildArraySchema(model, visitCounts)
-            is ObjectModel.MapModel -> buildMapSchema(model, visitCounts)
+            is ObjectModel.Object -> buildObjectSchema(model, tracker)
+            is ObjectModel.Array -> buildArraySchema(model, tracker)
+            is ObjectModel.MapModel -> buildMapSchema(model, tracker)
         }
     }
 
@@ -154,25 +151,23 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
      * Implements circular reference detection using visit counts.
      * 
      * @param model The object model
-     * @param visitCounts Tracking map for circular reference detection
+     * @param tracker Tracking map for circular reference detection
      * @return A schema map with type, properties, and required
      */
     private fun buildObjectSchema(
         model: ObjectModel.Object,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ): LinkedHashMap<String, Any?> {
-        val count = visitCounts.getOrDefault(model, 0)
-        if (count >= maxVisits) {
+        if (!tracker.tryEnter(model)) {
             return linkedMapOf("type" to "object")
         }
-        visitCounts[model] = count + 1
 
         try {
             val properties = linkedMapOf<String, Any?>()
             val requiredList = mutableListOf<String>()
 
             for ((name, field) in model.fields) {
-                val propSchema = buildSchema(field.model, visitCounts)
+                val propSchema = buildSchema(field.model, tracker)
 
                 // Add description from field comment
                 field.comment?.let { propSchema["description"] = it }
@@ -236,7 +231,7 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
 
             return result
         } finally {
-            visitCounts[model] = count
+            tracker.exit(model)
         }
     }
 
@@ -244,16 +239,16 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
      * Builds a schema for an array type.
      * 
      * @param model The array model
-     * @param visitCounts Tracking map for circular reference detection
+     * @param tracker Tracking map for circular reference detection
      * @return A schema map with type and items
      */
     private fun buildArraySchema(
         model: ObjectModel.Array,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ): LinkedHashMap<String, Any?> {
         return linkedMapOf(
             "type" to "array",
-            "items" to buildSchema(model.item, visitCounts)
+            "items" to buildSchema(model.item, tracker)
         )
     }
 
@@ -262,16 +257,16 @@ class JsonSchemaBuilder(private val maxVisits: Int = MAX_VISITS) {
      * Uses additionalProperties to define value types.
      * 
      * @param model The map model
-     * @param visitCounts Tracking map for circular reference detection
+     * @param tracker Tracking map for circular reference detection
      * @return A schema map with type and additionalProperties
      */
     private fun buildMapSchema(
         model: ObjectModel.MapModel,
-        visitCounts: IdentityHashMap<ObjectModel.Object, Int>
+        tracker: ObjectModelVisitTracker
     ): LinkedHashMap<String, Any?> {
         return linkedMapOf(
             "type" to "object",
-            "additionalProperties" to buildSchema(model.valueType, visitCounts)
+            "additionalProperties" to buildSchema(model.valueType, tracker)
         )
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModel.kt
@@ -203,6 +203,9 @@ sealed class ObjectModel {
     fun asMap(): MapModel? = this as? MapModel
 
     companion object {
+        /** Default maximum times to visit the same object during traversal (prevents infinite recursion). */
+        const val DEFAULT_MAX_VISITS = 2
+
         fun emptyObject(): Object = Object(emptyMap())
         fun nullValue(): Single = Single("null")
         fun single(type: String): Single = Single(type)

--- a/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelJsonBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelJsonBuilder.kt
@@ -10,20 +10,18 @@ package com.itangcent.easyapi.psi.model
  * Handles circular references by tracking visited objects via their unique id.
  *
  * @param handler The handler for JSON generation
- * @param maxVisits Maximum times an object can be visited (for circular reference handling)
  * @see ObjectModelJsonHandler for handler interface
  * @see ObjectModelJsonConverter for convenience methods
  */
 class ObjectModelJsonBuilder(
-    private val handler: ObjectModelJsonHandler,
-    private val maxVisits: Int = 2
+    private val handler: ObjectModelJsonHandler
 ) {
     
     fun build(model: ObjectModel?): String {
         if (model == null) return "{}"
         val builder = StringBuilder()
-        val visitCounts = HashMap<Int, Int>()
-        buildValue(model, builder, 0, visitCounts)
+        val tracker = ObjectModelVisitTracker()
+        buildValue(model, builder, 0, tracker)
         return builder.toString()
     }
     
@@ -31,13 +29,13 @@ class ObjectModelJsonBuilder(
         model: ObjectModel,
         builder: StringBuilder,
         indent: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         when (model) {
             is ObjectModel.Single -> handler.handleSingleValue(builder, model, indent)
-            is ObjectModel.Object -> buildObject(model, builder, indent, visitCounts)
-            is ObjectModel.Array -> buildArray(model, builder, indent, visitCounts)
-            is ObjectModel.MapModel -> buildMap(model, builder, indent, visitCounts)
+            is ObjectModel.Object -> buildObject(model, builder, indent, tracker)
+            is ObjectModel.Array -> buildArray(model, builder, indent, tracker)
+            is ObjectModel.MapModel -> buildMap(model, builder, indent, tracker)
         }
     }
     
@@ -45,38 +43,39 @@ class ObjectModelJsonBuilder(
         model: ObjectModel.Object,
         builder: StringBuilder,
         indent: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
-        val count = visitCounts.getOrDefault(model.id, 0)
-        if (count >= maxVisits) {
+        if (!tracker.tryEnter(model)) {
             handler.beforeObjectStart(builder, indent)
             handler.afterObjectEnd(builder, indent)
             return
         }
-        visitCounts[model.id] = count + 1
 
-        handler.beforeObjectStart(builder, indent)
-        
-        val fields = model.fields.entries.toList()
-        fields.forEachIndexed { index, (name, field) ->
-            handler.beforeObjectField(builder, name, field, index, fields.size, indent)
-            buildValue(field.model, builder, indent + 1, visitCounts)
-            handler.afterObjectField(builder, name, field, index, fields.size, indent)
+        try {
+            handler.beforeObjectStart(builder, indent)
+            
+            val fields = model.fields.entries.toList()
+            fields.forEachIndexed { index, (name, field) ->
+                handler.beforeObjectField(builder, name, field, index, fields.size, indent)
+                buildValue(field.model, builder, indent + 1, tracker)
+                handler.afterObjectField(builder, name, field, index, fields.size, indent)
+            }
+            
+            handler.afterObjectEnd(builder, indent)
+        } finally {
+            tracker.exit(model)
         }
-        
-        handler.afterObjectEnd(builder, indent)
-        visitCounts[model.id] = count
     }
     
     private fun buildArray(
         model: ObjectModel.Array,
         builder: StringBuilder,
         indent: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         handler.beforeArrayStart(builder, indent)
         handler.beforeArrayItem(builder, model.item, 0, 1, indent)
-        buildValue(model.item, builder, indent + 1, visitCounts)
+        buildValue(model.item, builder, indent + 1, tracker)
         handler.afterArrayItem(builder, model.item, 0, 1, indent)
         handler.afterArrayEnd(builder, indent)
     }
@@ -85,13 +84,13 @@ class ObjectModelJsonBuilder(
         model: ObjectModel.MapModel,
         builder: StringBuilder,
         indent: Int,
-        visitCounts: HashMap<Int, Int>
+        tracker: ObjectModelVisitTracker
     ) {
         handler.beforeMapStart(builder, indent)
         handler.beforeMapKey(builder, indent)
-        buildValue(model.keyType, builder, indent + 1, visitCounts)
+        buildValue(model.keyType, builder, indent + 1, tracker)
         handler.betweenMapKeyAndValue(builder, indent)
-        buildValue(model.valueType, builder, indent + 1, visitCounts)
+        buildValue(model.valueType, builder, indent + 1, tracker)
         handler.afterMapValue(builder, indent)
         handler.afterMapEnd(builder, indent)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTracker.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTracker.kt
@@ -1,0 +1,57 @@
+package com.itangcent.easyapi.psi.model
+
+import java.util.IdentityHashMap
+
+/**
+ * Tracks how many times each [ObjectModel.Object] has been visited during a
+ * single traversal, preventing infinite recursion on self-referencing or
+ * mutually-referencing types.
+ *
+ * An object is allowed to be expanded up to [ObjectModel.DEFAULT_MAX_VISITS]
+ * times across the whole traversal. On the next attempt [tryEnter] returns
+ * `false` and the caller should emit a placeholder (e.g. `{}`, `[]`).
+ *
+ * The count is restored on [exit] (via `try/finally` inside [withVisit]), so
+ * sibling fields that reference the same instance are each allowed their own
+ * expansions.
+ *
+ * ## Usage
+ * ```kotlin
+ * val tracker = ObjectModelVisitTracker()
+ * tracker.withVisit(model) {
+ *     // expand model.fields ...
+ * } ?: run { sb.append("{}") }   // fallback when limit hit
+ * ```
+ */
+class ObjectModelVisitTracker {
+
+    private val counts = IdentityHashMap<ObjectModel.Object, Int>()
+
+    /** Returns `false` if [model] has already been visited [ObjectModel.DEFAULT_MAX_VISITS] times. */
+    fun tryEnter(model: ObjectModel.Object): Boolean {
+        val count = counts.getOrDefault(model, 0)
+        if (count >= ObjectModel.DEFAULT_MAX_VISITS) return false
+        counts[model] = count + 1
+        return true
+    }
+
+    /** Must be called once for every successful [tryEnter]. */
+    fun exit(model: ObjectModel.Object) {
+        val count = counts.getOrDefault(model, 0)
+        if (count <= 1) counts.remove(model) else counts[model] = count - 1
+    }
+
+    /**
+     * Runs [block] only if [model] can be entered (i.e. the visit limit has not
+     * been reached). Returns the block's result, or `null` if the limit was hit.
+     * The visit count is always restored via `try/finally`.
+     */
+    inline fun <T> withVisit(model: ObjectModel.Object, block: () -> T): T? {
+        if (!tryEnter(model)) return null
+        return try {
+            block()
+        } finally {
+            exit(model)
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/formatter/PropertiesFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/formatter/PropertiesFormatterTest.kt
@@ -124,7 +124,7 @@ class PropertiesFormatterTest {
         val obj = ObjectModel.Object(fields = mutableMapOf())
         val selfField = FieldModel(model = obj)
         (obj.fields as MutableMap)["parent"] = selfField
-        val formatter = PropertiesFormatter(maxVisits = 2)
+        val formatter = PropertiesFormatter()
         
         val result = formatter.format(obj)
         assertTrue(result.contains("parent="))

--- a/src/test/kotlin/com/itangcent/easyapi/psi/model/ObjectModelJsonBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/model/ObjectModelJsonBuilderTest.kt
@@ -208,35 +208,4 @@ class ObjectModelJsonBuilderTest : TestCase() {
         assertTrue(json.contains("\"inner\""))
         assertTrue(json.contains("\"leaf\""))
     }
-
-    fun testCustomMaxVisitsOfOne() {
-        // With maxVisits=1, self-reference should be {} immediately
-        val fields = linkedMapOf<String, FieldModel>()
-        val nodeModel = ObjectModel.Object(fields)
-
-        fields["id"] = FieldModel(ObjectModel.single(JsonType.LONG))
-        fields["parent"] = FieldModel(nodeModel)
-
-        val builder = ObjectModelJsonBuilder(RawJsonHandler, maxVisits = 1)
-        val json = builder.build(nodeModel)
-
-        // id appears only once — parent is {} on first re-encounter
-        val idCount = Regex("\"id\"").findAll(json).count()
-        assertEquals("With maxVisits=1, id should appear once", 1, idCount)
-    }
-
-    fun testCustomMaxVisitsOfThree() {
-        // With maxVisits=3, self-reference expands 3 levels
-        val fields = linkedMapOf<String, FieldModel>()
-        val nodeModel = ObjectModel.Object(fields)
-
-        fields["id"] = FieldModel(ObjectModel.single(JsonType.LONG))
-        fields["parent"] = FieldModel(nodeModel)
-
-        val builder = ObjectModelJsonBuilder(RawJsonHandler, maxVisits = 3)
-        val json = builder.build(nodeModel)
-
-        val idCount = Regex("\"id\"").findAll(json).count()
-        assertEquals("With maxVisits=3, id should appear three times", 3, idCount)
-    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTrackerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/psi/model/ObjectModelVisitTrackerTest.kt
@@ -1,0 +1,162 @@
+package com.itangcent.easyapi.psi.model
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ObjectModelVisitTrackerTest {
+
+    @Test
+    fun testTryEnter_allowsEntryUnderLimit() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        assertTrue("First entry should be allowed", tracker.tryEnter(obj))
+        assertTrue("Second entry should be allowed (limit = 2)", tracker.tryEnter(obj))
+    }
+
+    @Test
+    fun testTryEnter_blocksEntryOverLimit() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        tracker.tryEnter(obj)
+        tracker.tryEnter(obj)
+        assertFalse("Third entry should be blocked (limit = 2)", tracker.tryEnter(obj))
+    }
+
+    @Test
+    fun testExit_restoresCountForSiblingVisits() {
+        val tracker = ObjectModelVisitTracker()
+        val shared = ObjectModel.Object(emptyMap())
+
+        // First visit: enter + exit
+        assertTrue(tracker.tryEnter(shared))
+        tracker.exit(shared)
+
+        // Count should be restored to 0, so sibling visit is allowed twice again
+        assertTrue("Sibling visit after exit should be allowed", tracker.tryEnter(shared))
+        assertTrue("Second sibling visit should be allowed", tracker.tryEnter(shared))
+        assertFalse("Third visit should be blocked", tracker.tryEnter(shared))
+    }
+
+    @Test
+    fun testExit_restoresCountAfterNestedReentry() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        // Root visit
+        assertTrue(tracker.tryEnter(obj))
+        // Nested re-encounter (e.g. self-reference): allowed once more
+        assertTrue(tracker.tryEnter(obj))
+        assertFalse("Third nested visit should be blocked", tracker.tryEnter(obj))
+        tracker.exit(obj) // exit the nested visit
+
+        // After exiting the nested visit, one more entry is allowed again
+        assertTrue("Entry after exiting nested visit should be allowed", tracker.tryEnter(obj))
+        tracker.exit(obj) // exit the new visit
+        tracker.exit(obj) // exit the root visit
+    }
+
+    @Test
+    fun testTryEnter_independentObjectsTrackedSeparately() {
+        val tracker = ObjectModelVisitTracker()
+        val a = ObjectModel.Object(emptyMap())
+        val b = ObjectModel.Object(emptyMap())
+
+        assertTrue(tracker.tryEnter(a))
+        assertTrue(tracker.tryEnter(b))
+        // Each object has its own count
+        assertTrue(tracker.tryEnter(a))
+        assertTrue(tracker.tryEnter(b))
+    }
+
+    @Test
+    fun testWithVisit_runsBlockOnFirstEntry() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        val result = tracker.withVisit(obj) { "expanded" }
+
+        assertEquals("expanded", result)
+    }
+
+    @Test
+    fun testWithVisit_returnsNullWhenLimitHit() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        tracker.tryEnter(obj)
+        tracker.tryEnter(obj)
+
+        val result = tracker.withVisit(obj) { "should not run" }
+
+        assertNull("withVisit should return null when limit is hit", result)
+    }
+
+    @Test
+    fun testWithVisit_restoresCountOnNormalExit() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        tracker.withVisit(obj) { /* first visit */ }
+        tracker.withVisit(obj) { /* second visit */ }
+
+        // After two withVisit calls, count should be back to 0
+        assertTrue("Count should be restored after withVisit exits", tracker.tryEnter(obj))
+        assertTrue(tracker.tryEnter(obj))
+        assertFalse(tracker.tryEnter(obj))
+    }
+
+    @Test
+    fun testWithVisit_restoresCountOnException() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        try {
+            tracker.withVisit(obj) { throw RuntimeException("boom") }
+        } catch (e: RuntimeException) {
+            // expected
+        }
+
+        // Count must be restored even though the block threw
+        assertTrue(
+            "Count should be restored after exception in withVisit",
+            tracker.tryEnter(obj)
+        )
+        assertTrue(tracker.tryEnter(obj))
+        assertFalse(tracker.tryEnter(obj))
+    }
+
+    @Test
+    fun testWithVisit_nestedCallsRespectLimit() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        // Simulate a self-referencing object: root visit + one nested visit
+        val outer = tracker.withVisit(obj) {
+            val inner = tracker.withVisit(obj) {
+                val blocked = tracker.withVisit(obj) { "third level" }
+                assertNull("Third level should be blocked", blocked)
+                "second level"
+            }
+            assertEquals("second level", inner)
+            "first level"
+        }
+
+        assertEquals("first level", outer)
+    }
+
+    @Test
+    fun testExit_withoutEntry_isNoOp() {
+        val tracker = ObjectModelVisitTracker()
+        val obj = ObjectModel.Object(emptyMap())
+
+        // Calling exit without a prior tryEnter should not throw
+        tracker.exit(obj)
+
+        // And the object should still be enterable up to the limit
+        assertTrue(tracker.tryEnter(obj))
+        assertTrue(tracker.tryEnter(obj))
+        assertFalse(tracker.tryEnter(obj))
+    }
+}


### PR DESCRIPTION
Consolidate the duplicated maxVisits/visitCounts pattern across 5 classes (JsonSchemaBuilder, YamlFormatter, PropertiesFormatter, ObjectModelJsonBuilder, DefaultMarkdownFormatter) into a single ObjectModelVisitTracker helper.

- Add DEFAULT_MAX_VISITS=2 constant to ObjectModel.Companion
- Remove per-class maxVisits constructor params and local MAX_VISITS constants
- Standardize on IdentityHashMap<ObjectModel.Object, Int> for type safety
- Wrap visit restoration in try/finally for proper cleanup on exceptions
- Add comprehensive tests for ObjectModelVisitTracker (11 cases)