### PR TITLE
feat(logging): enforce logging channel discipline with SILENT default console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,25 @@ EasyYapi is an IntelliJ IDEA plugin (v3.0 rewrite) for API development — expor
 - Add KDoc comments for public APIs
 - Prefer expression bodies for simple functions
 
+## Logging
+
+The plugin has three output channels:
+
+- **`LOG`** (`IdeaLog` → `idea.log`) — background recording. **Use this in the vast majority of cases.**
+- **`NotificationUtils`** (balloon toast, bottom-right) — progress updates and task-completion prompts.
+- **`IdeaConsole`** (EasyAPI tool window) — diagnostic overlay, **off by default** (`logLevel=SILENT`). Use for errors/exceptions, operation failures, and debug/trace diagnostics. `console.warn`/`console.error` always mirror to `LOG.warn` — failures are never lost.
+
+### Rules
+
+1. **Never call `LOG.error`.** IntelliJ's `Logger.error` triggers an intrusive error-report popup (and throws `TestLoggerAssertionError` in tests). If error-level severity is needed, use `LOG.warn` as the fallback.
+2. **Default to `LOG`.** Routine milestones, per-item decisions, debug detail, and recoverable failures all go to `LOG`.
+3. **Use `NotificationUtils` for progress and completion.** "Export started", "Upload complete", "Export failed".
+4. **Console is a diagnostic overlay, off by default.** Use `console.warn(msg, t)` for operation failures, `console.error(msg, t)` for errors/exceptions, `console.debug`/`console.trace` for diagnostics. At SILENT (default), only `console.warn`/`console.error` reach `idea.log` via mirror; the rest are no-ops. Users enable the console by lowering `logLevel`.
+5. **One call per event.** `IdeaConsole.warn/error` and `NotificationUtils.notifyWarning/notifyError` mirror to `idea.log` automatically — do not also write a `LOG.*` call.
+6. **Always pass the throwable** as the last arg to `LOG.warn` / `console.warn` / `console.error` / `notifyError`.
+
+See `.spec/logging-channel-discipline/` for the full spec.
+
 ## Project Structure
 
 ```

--- a/src/main/kotlin/com/itangcent/easyapi/cache/api/ApiFileChangeListener.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/cache/api/ApiFileChangeListener.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -51,7 +51,7 @@ class ApiFileChangeListener(private val project: Project) : BulkFileListener, Di
     }
 
     override fun after(events: MutableList<out VFileEvent>) {
-        if (!SettingBinder.getInstance(project).read().autoScanEnabled) {
+        if (!project.settings.autoScanEnabled) {
             return
         }
 

--- a/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
@@ -6,7 +6,7 @@ import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.config.resource.CachedResourceResolver
 import com.itangcent.easyapi.config.source.*
 import com.itangcent.easyapi.extension.ExtensionConfigRegistry
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.util.storage.LocalStorage
 
@@ -45,8 +45,7 @@ class DefaultConfigReader(
     private val settingBinder = SettingBinder.getInstance(project)
     private val localStorage = LocalStorage.getInstance(project)
 
-    private val console by lazy { IdeaConsoleProvider.getInstance(project).getConsole() }
-    private val cachedResourceResolver by lazy { CachedResourceResolver(localStorage, console) }
+    private val cachedResourceResolver by lazy { CachedResourceResolver(localStorage, project.console) }
 
     @Volatile
     private var delegate: LayeredConfigReader = buildDelegate()

--- a/src/main/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolver.kt
@@ -27,12 +27,12 @@ import kotlin.time.Duration.Companion.milliseconds
  * - Default TTL: 2 hours
  *
  * @param localStorage The local storage for persisting fetched content
- * @param console Optional console for logging warnings
+ * @param console Console for logging warnings
  * @param ttlMs Time-to-live in milliseconds (default: 2 hours)
  */
 class CachedResourceResolver(
     private val localStorage: LocalStorage,
-    private val console: IdeaConsole? = null,
+    private val console: IdeaConsole,
     private val ttlMs: Long = 2 * 60 * 60 * 1000L,
     private val fetchTimeoutMs: Long = 30_000L
 ) {
@@ -48,9 +48,9 @@ class CachedResourceResolver(
         val content = runCatching { fetch(url) }
             .onFailure { e ->
                 if (e is TimeoutCancellationException) {
-                    console?.warn("Remote config fetch timed out (${fetchTimeoutMs}ms): $url")
+                    console.warn("Remote config fetch timed out (${fetchTimeoutMs}ms): $url")
                 } else {
-                    console?.warn("Remote config unreachable: $url", e)
+                    console.warn("Remote config unreachable: $url", e)
                 }
             }
             .getOrNull()

--- a/src/main/kotlin/com/itangcent/easyapi/core/event/EventBus.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/event/EventBus.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.messages.Topic
-import com.itangcent.easyapi.logging.IdeaConsole
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
 @Service(Service.Level.PROJECT)
-class EventBus(private val project: Project) : Disposable {
+class EventBus(private val project: Project) : Disposable, IdeaLog {
 
     private val handlers = ConcurrentHashMap<String, CopyOnWriteArrayList<suspend () -> Unit>>()
     private val oneTimeHandlers = ConcurrentHashMap<String, CopyOnWriteArrayList<suspend () -> Unit>>()
@@ -26,9 +26,7 @@ class EventBus(private val project: Project) : Disposable {
     @Volatile
     private var messageBusConnection: MessageBusConnection? = null
 
-    private val console: IdeaConsole by lazy {
-        IdeaConsoleProvider.getInstance(project).getConsole()
-    }
+    private val console get() = project.console
 
     private fun ensureConnected() {
         if (messageBusConnection != null) return

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
@@ -17,9 +17,9 @@ import com.itangcent.easyapi.exporter.core.CompositeApiClassRecognizer
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.ide.support.runWithProgress
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.logging.console
+import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -76,6 +76,7 @@ class ApiScanner(private val project: Project) {
     }
 
     private val apiClassRecognizer = CompositeApiClassRecognizer.getInstance(project)
+    private val console get() = project.console
 
     /**
      * Scans the entire project for API endpoints.
@@ -151,28 +152,31 @@ class ApiScanner(private val project: Project) {
             read {
                 LOG.debug("Looking for annotation: $annotationFqn")
                 val annotationClass = javaFacade.findClass(annotationFqn, GlobalSearchScope.allScope(project))
-                if (annotationClass != null) {
-                    LOG.debug("Found annotation class: $annotationFqn")
-                    if (!annotationClass.isAnnotationType) {
-                        LOG.debug("Skipping $annotationFqn — not an annotation type (interface or class)")
-                    } else {
-                        try {
-                            val annotated = AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope)
-                            val found = annotated.findAll().filter { !it.isAnnotationType }
-                            LOG.debug("Found ${found.size} classes annotated with $annotationFqn")
-                            controllerClasses.addAll(found)
-
-                            val metaAnnotated = findMetaAnnotatedClasses(annotationClass, scope)
-                            if (metaAnnotated.isNotEmpty()) {
-                                LOG.debug("Found ${metaAnnotated.size} meta-annotated classes for $annotationFqn")
-                                controllerClasses.addAll(metaAnnotated)
-                            }
-                        } catch (e: Exception) {
-                            LOG.warn("Error searching for classes annotated with $annotationFqn: ${e.message}")
-                        }
-                    }
-                } else {
+                if (annotationClass == null) {
                     LOG.debug("Annotation class not found: $annotationFqn (project may not have this dependency)")
+                    return@read
+                }
+
+                // Verify the found class is actually an annotation type before proceeding
+                LOG.debug("Found annotation class: $annotationFqn")
+                if (!annotationClass.isAnnotationType) {
+                    LOG.debug("Skipping $annotationFqn — not an annotation type (interface or class)")
+                    return@read
+                }
+                
+                try {
+                    val annotated = AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope)
+                    val found = annotated.findAll().filter { !it.isAnnotationType }
+                    LOG.debug("Found ${found.size} classes annotated with $annotationFqn")
+                    controllerClasses.addAll(found)
+
+                    val metaAnnotated = findMetaAnnotatedClasses(annotationClass, scope)
+                    if (metaAnnotated.isNotEmpty()) {
+                        LOG.debug("Found ${metaAnnotated.size} meta-annotated classes for $annotationFqn")
+                        controllerClasses.addAll(metaAnnotated)
+                    }
+                } catch (e: Exception) {
+                    console.warn("Error searching for classes annotated with $annotationFqn: ${e.message}")
                 }
             }
         }
@@ -211,11 +215,11 @@ class ApiScanner(private val project: Project) {
                     val annotated = AnnotatedElementsSearch.searchPsiClasses(customAnn, scope).findAll()
                     result.addAll(annotated)
                 } catch (e: Exception) {
-                    LOG.warn("Error searching for classes annotated with custom annotation $customFqn: ${e.message}")
+                    console.warn("Error searching for classes annotated with custom annotation $customFqn: ${e.message}")
                 }
             }
         } catch (e: Exception) {
-            LOG.warn("Error searching for meta-annotations of $targetFqn: ${e.message}")
+            console.warn("Error searching for meta-annotations of $targetFqn: ${e.message}")
         }
 
         return result.toList()
@@ -241,10 +245,9 @@ class ApiScanner(private val project: Project) {
      * @return List of discovered endpoints
      */
     private suspend fun exportClasses(classes: List<PsiClass>, indicator: ProgressIndicator): List<ApiEndpoint> {
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
         val exporters = getEnabledExporters()
         if (exporters.isEmpty()) {
-            LOG.warn("No exporters enabled")
+            console.warn("No exporters enabled")
             return emptyList()
         }
         LOG.debug("Enabled exporters: ${exporters.map { it::class.simpleName }}")
@@ -252,7 +255,7 @@ class ApiScanner(private val project: Project) {
         indicator.isIndeterminate = false
         indicator.fraction = 0.0
 
-        val endpoints = scanClassesWithExporters(classes, exporters, console, indicator)
+        val endpoints = scanClassesWithExporters(classes, exporters, indicator)
 
         indicator.fraction = 1.0
         LOG.info("Total endpoints found: ${endpoints.size}")
@@ -263,10 +266,9 @@ class ApiScanner(private val project: Project) {
         classes: List<PsiClass>,
         indicator: ProgressIndicator
     ): List<ApiEndpoint> {
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
         val exporters = getEnabledExporters()
         if (exporters.isEmpty()) {
-            LOG.warn("No exporters enabled")
+            console.warn("No exporters enabled")
             return emptyList()
         }
         LOG.info("Enabled exporters: ${exporters.map { it::class.simpleName }}")
@@ -274,7 +276,7 @@ class ApiScanner(private val project: Project) {
         indicator.isIndeterminate = false
         indicator.fraction = 0.0
 
-        val endpoints = scanClassesWithExporters(classes, exporters, console, indicator)
+        val endpoints = scanClassesWithExporters(classes, exporters, indicator)
 
         indicator.fraction = 1.0
         return endpoints
@@ -288,22 +290,20 @@ class ApiScanner(private val project: Project) {
      *
      * @param psiClasses The classes to scan
      * @param exporters The enabled class exporters
-     * @param console The console for logging
      * @param indicator Progress indicator for cancellation and progress updates
      * @return List of all discovered endpoints
      */
     private suspend fun scanClassesWithExporters(
         psiClasses: List<PsiClass>,
         exporters: List<ClassExporter>,
-        console: com.itangcent.easyapi.logging.IdeaConsole,
         indicator: ProgressIndicator?
     ): List<ApiEndpoint> {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
 
         return if (settings.concurrentScanEnabled) {
-            scanClassesConcurrently(psiClasses, exporters, console, indicator)
+            scanClassesConcurrently(psiClasses, exporters, indicator)
         } else {
-            scanClassesSequentially(psiClasses, exporters, console, indicator)
+            scanClassesSequentially(psiClasses, exporters, indicator)
         }
     }
 
@@ -315,14 +315,12 @@ class ApiScanner(private val project: Project) {
      *
      * @param psiClasses The classes to scan
      * @param exporters The enabled class exporters
-     * @param console The console for logging
      * @param indicator Progress indicator for cancellation and progress updates
      * @return List of all discovered endpoints
      */
     private suspend fun scanClassesSequentially(
         psiClasses: List<PsiClass>,
         exporters: List<ClassExporter>,
-        console: com.itangcent.easyapi.logging.IdeaConsole,
         indicator: ProgressIndicator?
     ): List<ApiEndpoint> {
         val endpoints = mutableListOf<ApiEndpoint>()
@@ -378,14 +376,12 @@ class ApiScanner(private val project: Project) {
      *
      * @param psiClasses The classes to scan
      * @param exporters The enabled class exporters
-     * @param console The console for logging
      * @param indicator Progress indicator for cancellation and progress updates
      * @return List of all discovered endpoints
      */
     private suspend fun scanClassesConcurrently(
         psiClasses: List<PsiClass>,
         exporters: List<ClassExporter>,
-        console: com.itangcent.easyapi.logging.IdeaConsole,
         indicator: ProgressIndicator?
     ): List<ApiEndpoint> = coroutineScope {
         val semaphore = Semaphore(MAX_CONCURRENT_SCANS)

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
@@ -17,6 +17,7 @@ import com.itangcent.easyapi.script.ScriptCache
 import com.itangcent.easyapi.script.ScriptCacheService
 import com.itangcent.easyapi.script.ScriptScope
 import com.itangcent.easyapi.script.env.EnvironmentService
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.script.pm.*
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.GrpcMetadata
@@ -1114,7 +1115,7 @@ class EndpointDetailsPanel(
     }
 
     private fun checkGrpcCallReady(): Boolean {
-        val settings = com.itangcent.easyapi.settings.SettingBinder.getInstance(project).read()
+        val settings = project.settings
 
         if (!settings.grpcCallEnabled) {
             val result = Messages.showOkCancelDialog(

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/RequestExecutor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/RequestExecutor.kt
@@ -20,8 +20,8 @@ import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.model.isGrpc
 import com.itangcent.easyapi.grpc.DynamicJarClient
 import com.itangcent.easyapi.http.*
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.core.threading.readSync
 import kotlinx.coroutines.CancellationException
 import kotlin.system.measureTimeMillis
@@ -75,7 +75,7 @@ class RequestExecutor(private val project: Project) : IdeaLog {
     private val environmentService: EnvironmentService get() = EnvironmentService.getInstance(project)
     private val scriptCacheService: ScriptCacheService get() = ScriptCacheService.getInstance(project)
     private val pmScriptExecutor: PmScriptExecutor get() = PmScriptExecutor.getInstance(project)
-    private val console by lazy { IdeaConsoleProvider.getInstance(project).getConsole() }
+    private val console get() = project.console
 
     private val envVars: Map<String, String> get() = environmentService.resolveAllVariables()
 
@@ -219,7 +219,7 @@ class RequestExecutor(private val project: Project) : IdeaLog {
     ): RequestResult {
         val scopeDesc = input.scriptScopes.joinToString(" → ") { it.displayLabel() }
         LOG.info("Executing request with scripts for [${input.endpointName}], scopes: [$scopeDesc]")
-        console.info("[Script] Executing request for '${input.endpointName}' with scripts (scopes: $scopeDesc)")
+        LOG.info("[Script] Executing request for '${input.endpointName}' with scripts (scopes: $scopeDesc)")
 
         val envVars = LivePmVariableScope(environmentService)
         val globalVars = PmVariableScope()
@@ -243,13 +243,13 @@ class RequestExecutor(private val project: Project) : IdeaLog {
         if (!resolvedScripts.preRequestScript.isNullOrBlank()) {
             val preScriptLines = resolvedScripts.preRequestScript.lines().size
             LOG.info("Pre-request script: $preScriptLines lines, scopes: [$scopeDesc]")
-            console.info("[Script] Running pre-request script ($preScriptLines lines)...")
+            LOG.info("[Script] Running pre-request script ($preScriptLines lines)...")
             try {
                 val elapsed = measureTimeMillis {
                     pmScriptExecutor.executePreRequestScript(resolvedScripts.preRequestScript, pm)
                 }
                 LOG.info("Pre-request script completed in ${elapsed}ms")
-                console.info("[Script] Pre-request script completed (${elapsed}ms)")
+                LOG.info("[Script] Pre-request script completed (${elapsed}ms)")
             } catch (e: Exception) {
                 LOG.warn("Pre-request script error: ${e.message}", e)
                 console.error("[Script] Pre-request script failed: ${e.message}")
@@ -288,7 +288,7 @@ class RequestExecutor(private val project: Project) : IdeaLog {
         if (!resolvedScripts.postResponseScript.isNullOrBlank()) {
             val postScriptLines = resolvedScripts.postResponseScript.lines().size
             LOG.info("Post-response script: $postScriptLines lines, scopes: [$scopeDesc]")
-            console.info("[Script] Running post-response script ($postScriptLines lines)...")
+            LOG.info("[Script] Running post-response script ($postScriptLines lines)...")
             val postTestCollector = PmTestCollector()
             val postInfo = PmInfo(
                 eventName = "test",
@@ -311,10 +311,10 @@ class RequestExecutor(private val project: Project) : IdeaLog {
                     testResults = pmScriptExecutor.executePostResponseScript(resolvedScripts.postResponseScript, postPm)
                 }
                 LOG.info("Post-response script completed in ${elapsed}ms, tests: ${testResults?.size ?: 0}")
-                console.info("[Script] Post-response script completed (${elapsed}ms, ${testResults?.size ?: 0} tests)")
+                LOG.info("[Script] Post-response script completed (${elapsed}ms, ${testResults?.size ?: 0} tests)")
                 testResults?.forEach { tr ->
                     if (tr.passed) {
-                        console.info("[Script]   ✓ ${tr.name}")
+                        LOG.info("[Script]   ✓ ${tr.name}")
                     } else {
                         console.error("[Script]   ✗ ${tr.name}: ${tr.error ?: "failed"}")
                     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/EndpointBuilder.kt
@@ -15,7 +15,7 @@ import com.itangcent.easyapi.psi.model.ObjectModelUtils
 import com.itangcent.easyapi.psi.type.PrimitiveKind
 import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.TypeResolver
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.settings.Settings
 
 /**
@@ -40,7 +40,7 @@ import com.itangcent.easyapi.settings.Settings
  */
 class EndpointBuilder(private val project: Project) {
 
-    private val settings: Settings by lazy { SettingBinder.getInstance(project).read() }
+    private val settings: Settings get() = project.settings
     private val docHelper: DocHelper by lazy { UnifiedDocHelper.getInstance(project) }
     private val metadataResolver: DocMetadataResolver get() = DocMetadataResolver.getInstance(project)
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
@@ -13,13 +13,14 @@ import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.ide.support.NotificationUtils
 import com.itangcent.easyapi.ide.support.SelectionScope
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.withContext
 
 @Service(Service.Level.PROJECT)
-class ExportOrchestrator(private val project: Project) {
+class ExportOrchestrator(private val project: Project) : IdeaLog {
 
     private val apiScanner: ApiScanner = ApiScanner.getInstance(project)
     private val apiIndex: ApiIndex = ApiIndex.getInstance(project)
@@ -31,15 +32,13 @@ class ExportOrchestrator(private val project: Project) {
         }
     }
 
-    private val console = IdeaConsoleProvider.getInstance(project).getConsole()
-
     suspend fun orchestrateExport(
         selection: SelectionScope?,
         channelId: String,
         channelConfig: ChannelConfig = ChannelConfig.Empty,
         indicator: ProgressIndicator? = null
     ): ExportResult {
-        console.debug("ExportOrchestrator.orchestrateExport: channelId=$channelId, selection=$selection")
+        LOG.debug("ExportOrchestrator.orchestrateExport: channelId=$channelId, selection=$selection")
         val channel = channelRegistry.getChannel(channelId)
             ?: return ExportResult.Error("No channel registered for id: $channelId")
 
@@ -48,16 +47,16 @@ class ExportOrchestrator(private val project: Project) {
         val endpoints = scanEndpoints(selection, indicator)
 
         if (endpoints.isEmpty()) {
-            console.info("ExportOrchestrator.orchestrateExport: no endpoints found")
+            NotificationUtils.notifyWarning(project, "Export", "No API endpoints found in selection")
             return ExportResult.Error("No API endpoints found")
         }
 
-        console.info("ExportOrchestrator.orchestrateExport: exporting ${endpoints.size} endpoints via ${channel.displayName}")
+        NotificationUtils.notifyInfo(project, "Export", "Exporting ${endpoints.size} endpoints via ${channel.displayName}")
         indicator?.text = "Exporting ${endpoints.size} endpoints via ${channel.displayName}..."
         indicator?.isIndeterminate = false
         indicator?.fraction = 0.0
 
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val context = ExportContext(
             project = project,
             endpoints = endpoints,
@@ -80,7 +79,7 @@ class ExportOrchestrator(private val project: Project) {
                 }
             }
         } else if (result is ExportResult.Error) {
-            console.warn("ExportOrchestrator.orchestrateExport: channel=$channelId failed: ${result.message}")
+            NotificationUtils.notifyError(project, "Export", "Channel $channelId failed: ${result.message}")
         }
         return result
     }
@@ -91,7 +90,7 @@ class ExportOrchestrator(private val project: Project) {
         channelConfig: ChannelConfig = ChannelConfig.Empty,
         indicator: ProgressIndicator? = null
     ): ExportResult {
-        console.debug("ExportOrchestrator.exportViaChannel: channelId=$channelId, endpoints=${endpoints.size}")
+        LOG.debug("ExportOrchestrator.exportViaChannel: channelId=$channelId, endpoints=${endpoints.size}")
         val channel = channelRegistry.getChannel(channelId)
             ?: return ExportResult.Error("No channel registered for id: $channelId")
 
@@ -99,7 +98,7 @@ class ExportOrchestrator(private val project: Project) {
         indicator?.isIndeterminate = false
         indicator?.fraction = 0.0
 
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val context = ExportContext(
             project = project,
             endpoints = endpoints,
@@ -122,7 +121,7 @@ class ExportOrchestrator(private val project: Project) {
                 }
             }
         } else if (result is ExportResult.Error) {
-            console.warn("ExportOrchestrator.exportViaChannel: channel=$channelId failed: ${result.message}")
+            LOG.warn("ExportOrchestrator.exportViaChannel: channel=$channelId failed: ${result.message}")
         }
         return result
     }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanChannel.kt
@@ -23,7 +23,7 @@ import com.itangcent.easyapi.exporter.postman.model.postmanGson
 import com.itangcent.easyapi.http.HttpClientProvider
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.settings.PostmanExportMode
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.ide.ModuleHelper
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
@@ -57,7 +57,7 @@ class PostmanChannel : ApiChannel, IdeaLog {
     override suspend fun export(context: ExportContext): ExportResult {
         LOG.debug("PostmanChannel.export: endpoints=${context.endpointsToExport.size}")
         val project = context.project
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val token = settings.postmanToken
         val postmanConfig = context.channelConfig as? ChannelConfig.PostmanConfig
 
@@ -492,7 +492,7 @@ class PostmanOptionsPanel(private val project: Project) : ChannelOptionsPanel, I
     }
 
     private fun loadPostmanDataFromApi() {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val token = settings.postmanToken
 
         if (token.isNullOrBlank()) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/yapi/YapiOptionsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/yapi/YapiOptionsPanel.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.ide.dialog.ExportDialogPreferences
 import com.itangcent.easyapi.ide.dialog.ExportDialogPreferencesPersistence
 import java.awt.BorderLayout
@@ -76,7 +76,7 @@ class YapiOptionsPanel(private val project: Project) : ChannelOptionsPanel {
     }
 
     private fun loadYapiProjects() {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val yapiTokens = settings.yapiTokens
         if (!yapiTokens.isNullOrBlank()) {
             yapiTokens.lines()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/core/CompositeApiClassRecognizer.kt
@@ -9,8 +9,9 @@ import com.itangcent.easyapi.exporter.grpc.GrpcServiceRecognizer
 import com.itangcent.easyapi.exporter.jaxrs.JaxRsResourceRecognizer
 import com.itangcent.easyapi.exporter.springmvc.ActuatorEndpointRecognizer
 import com.itangcent.easyapi.exporter.springmvc.SpringControllerRecognizer
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.settings.SettingsChangeListener
+import com.itangcent.easyapi.settings.onSettingsChanged
 
 /**
  * Composite recognizer that combines all framework-specific [ApiClassRecognizer]s.
@@ -26,15 +27,13 @@ class CompositeApiClassRecognizer(private val project: Project) {
     private var cachedRecognizers: List<ApiClassRecognizer> = buildRecognizers()
 
     init {
-        project.messageBus.connect().subscribe(SettingsChangeListener.TOPIC, object : SettingsChangeListener {
-            override fun settingsChanged() {
-                cachedRecognizers = buildRecognizers()
-            }
-        })
+        project.onSettingsChanged {
+            cachedRecognizers = buildRecognizers()
+        }
     }
 
     private fun buildRecognizers(): List<ApiClassRecognizer> {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         return buildList {
             add(SpringControllerRecognizer())
             if (settings.jaxrsEnable) {

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/feign/FeignClassExporter.kt
@@ -20,7 +20,7 @@ import com.itangcent.easyapi.psi.type.ResolvedType
 import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.text.PathVariablePattern
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 import kotlinx.coroutines.withContext
@@ -57,7 +57,7 @@ class FeignClassExporter(
     override val frameworkName: String = "Feign"
 
     override suspend fun isEnabled(): Boolean {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val availabilityService = ProjectClassAvailabilityService.getInstance(project)
         return settings.feignEnable &&
                 availabilityService.hasAnyClassInProject(FeignClientRecognizer.FEIGN_ANNOTATIONS)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/grpc/GrpcClassExporter.kt
@@ -14,7 +14,7 @@ import com.itangcent.easyapi.psi.model.ObjectModel
 import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 
 /**
@@ -41,7 +41,7 @@ class GrpcClassExporter(
     override val frameworkName: String = "gRPC"
 
     override suspend fun isEnabled(): Boolean {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val availabilityService = ProjectClassAvailabilityService.getInstance(project)
         return settings.grpcEnable &&
                 (availabilityService.hasAnyClassInProject(GrpcServiceRecognizer.GRPC_SERVICE_ANNOTATIONS) ||

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/jaxrs/JaxRsClassExporter.kt
@@ -17,7 +17,7 @@ import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.psi.type.searchAnnotation
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 import kotlinx.coroutines.withContext
 
@@ -53,7 +53,7 @@ class JaxRsClassExporter(
     override val frameworkName: String = "JAX-RS"
 
     override suspend fun isEnabled(): Boolean {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val availabilityService = ProjectClassAvailabilityService.getInstance(project)
         return settings.jaxrsEnable &&
                 availabilityService.hasAnyClassInProject(JaxRsResourceRecognizer.PATH_ANNOTATIONS)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/ActuatorEndpointExporter.kt
@@ -9,7 +9,7 @@ import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 
 /**
@@ -30,7 +30,7 @@ class ActuatorEndpointExporter(
     override val frameworkName: String = "SpringActuator"
 
     override suspend fun isEnabled(): Boolean {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val availabilityService = ProjectClassAvailabilityService.getInstance(project)
         return settings.actuatorEnable &&
                 availabilityService.hasAnyClassInProject(SpringActuatorConstants.ENDPOINT_ANNOTATIONS)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/springmvc/SpringMvcClassExporter.kt
@@ -25,7 +25,7 @@ import com.itangcent.easyapi.psi.type.SpecialTypeHandler
 import com.itangcent.easyapi.psi.type.TypeResolver
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.text.PathVariablePattern
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 import kotlinx.coroutines.withContext
@@ -59,7 +59,7 @@ class SpringMvcClassExporter(
     override val frameworkName: String = "SpringMVC"
 
     override suspend fun isEnabled(): Boolean {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val availabilityService = ProjectClassAvailabilityService.getInstance(project)
         return availabilityService.hasAnyClassInProject(SpringControllerRecognizer.CONTROLLER_ANNOTATIONS)
     }
@@ -360,7 +360,7 @@ class SpringMvcClassExporter(
     private suspend fun expandFormParameter(
         resolvedParamType: ResolvedType
     ): List<ApiParameter> {
-        val formExpanded = SettingBinder.getInstance(project).read().formExpanded
+        val formExpanded = project.settings.formExpanded
         if (!formExpanded) {
             return emptyList()
         }
@@ -370,7 +370,7 @@ class SpringMvcClassExporter(
     private suspend fun expandQueryParameter(
         resolvedParamType: ResolvedType
     ): List<ApiParameter> {
-        val queryExpanded = SettingBinder.getInstance(project).read().queryExpanded
+        val queryExpanded = project.settings.queryExpanded
         if (!queryExpanded) {
             return emptyList()
         }

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/DefaultYapiApiClient.kt
@@ -9,9 +9,8 @@ import com.itangcent.easyapi.http.HttpClient
 import com.itangcent.easyapi.http.HttpRequest
 import com.itangcent.easyapi.http.HttpResponse
 import com.itangcent.easyapi.http.KeyValue
-import com.itangcent.easyapi.logging.IdeaConsole
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.util.json.GsonUtils
 import com.itangcent.easyapi.util.markdown.BundledMarkdownRender
 import kotlinx.coroutines.Dispatchers
@@ -34,8 +33,8 @@ import java.net.URLEncoder
  * @param serverUrl Base URL of the YAPI server (trailing slash is trimmed automatically)
  * @param token Project private token used for authentication
  * @param httpClient HTTP client used for all network calls
- * @param project IntelliJ [Project] used to obtain the [IdeaConsole] for user-facing logging.
- *        When null (e.g. tests), logging falls back to [IdeaLog] only.
+ * @param project IntelliJ [Project] used for context. Per-item failures are logged via [IdeaLog];
+ *        the caller (e.g. [YapiExporter]) is responsible for user-facing progress/completion notifications.
  */
 class DefaultYapiApiClient(
     private val serverUrl: String,
@@ -45,13 +44,9 @@ class DefaultYapiApiClient(
     private val project: com.intellij.openapi.project.Project
 ) : YapiApiClient, IdeaLog {
 
-    /** Console for user-facing messages; falls back to a no-op sink when no Project is available (tests). */
-    private val console: IdeaConsole by lazy {
-        IdeaConsoleProvider.getInstance(project).getConsole()
-    }
-
     /** Cached project ID for this client instance. Populated on first [getProjectId] call. */
     private var cachedProjectId: String? = null
+    private val console get() = project.console
 
     // region Project
 

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/yapi/YapiExporter.kt
@@ -7,9 +7,8 @@ import com.itangcent.easyapi.exporter.model.ExportContext
 import com.itangcent.easyapi.exporter.model.ExportMetadata
 import com.itangcent.easyapi.exporter.model.ExportResult
 import com.itangcent.easyapi.exporter.model.path
-import com.itangcent.easyapi.logging.IdeaConsole
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.psi.helper.DocMetadataResolver
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
@@ -22,7 +21,7 @@ import com.itangcent.easyapi.util.markdown.MarkdownRender
 class YapiExporter(private val project: Project) : IdeaLog {
 
     private val settingBinder by lazy { SettingBinder.getInstance(project) }
-    private val console: IdeaConsole by lazy { IdeaConsoleProvider.getInstance(project).getConsole() }
+    private val console get() = project.console
 
     companion object {
         fun getInstance(project: Project): YapiExporter {

--- a/src/main/kotlin/com/itangcent/easyapi/http/HttpClientProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/http/HttpClientProvider.kt
@@ -9,7 +9,7 @@ import com.itangcent.easyapi.http.HttpClientProvider.Companion.getInstance
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.rule.engine.RuleEngine
 import com.itangcent.easyapi.settings.HttpClientType
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 
 /**
  * Creates [HttpClient] instances based on the user's configured HTTP client type.
@@ -37,7 +37,7 @@ class HttpClientProvider(private val project: Project) {
         httpTimeOut: Int? = null,
         unsafeSsl: Boolean? = null
     ): HttpClient {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val resolvedHttpClient = httpClient ?: settings.httpClient ?: HttpClientType.APACHE.value
         val resolvedHttpTimeOutSec = httpTimeOut ?: settings.httpTimeOut ?: 30
         val resolvedHttpTimeOutMs = resolvedHttpTimeOutSec * 1000

--- a/src/main/kotlin/com/itangcent/easyapi/ide/ApiIndexStartupActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/ApiIndexStartupActivity.kt
@@ -7,7 +7,7 @@ import com.itangcent.easyapi.cache.api.ApiIndexManager
 import com.itangcent.easyapi.cache.VcsBranchChangeListener
 import com.itangcent.easyapi.config.ConfigSyncService
 import com.itangcent.easyapi.core.threading.backgroundAsync
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
@@ -36,7 +36,7 @@ class ApiIndexStartupActivity : ProjectActivity {
 
             delay(10.seconds)
 
-            val settings = SettingBinder.getInstance(project).read()
+            val settings = project.settings
             val autoScan = settings.autoScanEnabled
 
             ApiIndexManager.getInstance(project).start(triggerInitialScan = autoScan)

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ApiCallAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ApiCallAction.kt
@@ -7,7 +7,8 @@ import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiDashboardService
 import com.itangcent.easyapi.ide.support.SelectionScope
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -19,12 +20,12 @@ import kotlinx.coroutines.runBlocking
  *
  * @see ApiDashboardService for the dashboard functionality
  */
-class ApiCallAction : EasyApiAction() {
+class ApiCallAction : EasyApiAction(), IdeaLog {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val selection = resolveScope(e) ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("ApiCallAction.actionPerformed: project=${project.name}")
 
         backgroundAsync {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
@@ -11,12 +11,13 @@ import com.itangcent.easyapi.exporter.ExportOrchestrator
 import com.itangcent.easyapi.ide.DumbModeHelper
 import com.itangcent.easyapi.ide.support.SelectedHelper
 import com.itangcent.easyapi.ide.support.runWithProgress
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 
 class ChannelExportAction(
     private val channelId: String,
     channelDisplayName: String
-) : AnAction(channelDisplayName) {
+) : AnAction(channelDisplayName), IdeaLog {
 
     private val channelDisplayName = channelDisplayName
 
@@ -28,7 +29,7 @@ class ChannelExportAction(
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("ChannelExportAction.actionPerformed: channel=$channelId, project=${project.name}")
         val selection = SelectedHelper.resolveSelection(e)
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
@@ -18,14 +18,14 @@ import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
 import com.itangcent.easyapi.ide.dialog.ExportDialogPreferences
 import com.itangcent.easyapi.ide.dialog.ExportDialogPreferencesPersistence
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 
 class ExportApiAction : AnAction(), IdeaLog {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("ExportApiAction.actionPerformed: project=${project.name}")
         val selection = SelectedHelper.resolveSelection(e)
 

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/OpenApiDashboardAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/OpenApiDashboardAction.kt
@@ -3,7 +3,8 @@ package com.itangcent.easyapi.ide.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.wm.ToolWindowManager
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 
 /**
  * Action to open the API Dashboard tool window.
@@ -11,10 +12,10 @@ import com.itangcent.easyapi.logging.IdeaConsoleProvider
  * Activates the "API Dashboard" tool window, which provides a centralized
  * view for browsing and testing API endpoints.
  */
-class OpenApiDashboardAction : AnAction() {
+class OpenApiDashboardAction : AnAction(), IdeaLog {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("OpenApiDashboardAction.actionPerformed: project=${project.name}")
         ToolWindowManager.getInstance(project).getToolWindow("API Dashboard")?.activate(null)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/OpenScriptExecutorAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/OpenScriptExecutorAction.kt
@@ -3,17 +3,18 @@ package com.itangcent.easyapi.ide.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.itangcent.easyapi.ide.script.ScriptExecutorDialog
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 
 /**
  * Action to open the script executor dialog.
  *
  * @see ScriptExecutorDialog for the dialog
  */
-class OpenScriptExecutorAction : AnAction() {
+class OpenScriptExecutorAction : AnAction(), IdeaLog {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("OpenScriptExecutorAction.actionPerformed: project=${project.name}")
         ScriptExecutorDialog(project).show()
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ScriptExecutorAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ScriptExecutorAction.kt
@@ -3,7 +3,8 @@ package com.itangcent.easyapi.ide.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.itangcent.easyapi.ide.script.ScriptExecutorDialog
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 
 /**
  * Action to execute scripts against the selected PSI element.
@@ -13,10 +14,10 @@ import com.itangcent.easyapi.logging.IdeaConsoleProvider
  *
  * @see ScriptExecutorDialog for the dialog implementation
  */
-class ScriptExecutorAction : AnAction() {
+class ScriptExecutorAction : AnAction(), IdeaLog {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("ScriptExecutorAction.actionPerformed: project=${project.name}")
         ScriptExecutorDialog(project).show()
     }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/fieldformat/FieldFormatAction.kt
@@ -10,7 +10,8 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.itangcent.easyapi.core.event.ActionCompletedTopic
 import com.itangcent.easyapi.core.event.ActionCompletedTopic.Companion.syncPublish
 import com.itangcent.easyapi.ide.support.NotificationUtils
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import java.awt.datatransfer.StringSelection
 
 /**
@@ -30,12 +31,12 @@ import java.awt.datatransfer.StringSelection
  */
 class FieldFormatAction(
     private val channel: FieldFormatChannel
-) : AnAction(channel.actionText) {
+) : AnAction(channel.actionText), IdeaLog {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val psiClass = findPsiClass(e) ?: return
-        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val console = project.console
         console.debug("FieldFormatAction.actionPerformed: channel=${channel.id}, class=${psiClass.qualifiedName}")
         try {
             val text = kotlinx.coroutines.runBlocking { channel.format(project, psiClass) }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/linemarker/ApiMethodLineMarkerProvider.kt
@@ -20,7 +20,7 @@ import com.itangcent.easyapi.exporter.grpc.GrpcMethodResolver
 import com.itangcent.easyapi.exporter.grpc.GrpcServiceRecognizer
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.psi.helper.UnifiedAnnotationHelper
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.ide.ProjectClassAvailabilityService
 import kotlinx.coroutines.runBlocking
 import java.awt.event.MouseEvent
@@ -70,7 +70,7 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
     }
 
     private fun isGutterIconEnabled(project: Project): Boolean {
-        return SettingBinder.getInstance(project).read().gutterIconEnabled
+        return project.settings.gutterIconEnabled
     }
 
     private fun isApiMethod(method: PsiMethod): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/support/NotificationUtils.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/support/NotificationUtils.kt
@@ -79,12 +79,12 @@ object NotificationUtils : IdeaLog {
     }
 
     fun notifyError(project: Project?, title: String, content: String, t: Throwable? = null) {
-        // Mirror to idea.log (FR-02). Use info level to avoid TestLoggerAssertionError in tests
-        // (IntelliJ treats Logger.error as test failure).
+        // Mirror to idea.log (FR-02). Use warn level: LOG.error is prohibited (triggers intrusive popup);
+        // warn preserves severity without popup (R-CH-03).
         if (t != null) {
-            LOG.info("$title: $content", t)
+            LOG.warn("$title: $content", t)
         } else {
-            LOG.info("$title: $content")
+            LOG.warn("$title: $content")
         }
         notify(Notification(GROUP_ID, title, content, NotificationType.ERROR), project)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/logging/ConfigurableIdeaConsole.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/ConfigurableIdeaConsole.kt
@@ -18,7 +18,7 @@ import com.itangcent.easyapi.settings.Settings
  * - ERROR (40): Errors only
  * - 100+: Disabled (no output)
  *
- * ## Mirror to idea.log (FR-01)
+ * ## Mirror to idea.log
  *
  * `warn` and `error` are mirrored to `idea.log` via [IdeaLog.LOG] **above** the level
  * filter gate, so a warn/error always reaches the durable log even when the user has turned
@@ -49,14 +49,22 @@ class ConfigurableIdeaConsole(
 
     override fun warn(msg: String, t: Throwable?) {
         // Mirror BEFORE the filter gate so warn always reaches idea.log (FR-01, review M1).
-        LOG.warn(msg, t ?: EmptyThrowable)
+        if (t == null) {
+            LOG.warn(msg)
+        } else {
+            LOG.warn(msg, t)
+        }
         if (enabled(LogLevel.WARN)) delegate.warn(msg, t)
     }
 
     override fun error(msg: String, t: Throwable?) {
         // Mirror BEFORE the filter gate so error always reaches idea.log (FR-01, review M1).
-        // Use info level to avoid TestLoggerAssertionError in tests (IntelliJ treats Logger.error as test failure).
-        LOG.info(msg, t ?: EmptyThrowable)
+        // Use warn level: LOG.error is prohibited (triggers intrusive popup); warn preserves severity without popup (R-CH-03).
+        if (t == null) {
+            LOG.warn(msg)
+        } else {
+            LOG.warn(msg, t)
+        }
         if (enabled(LogLevel.ERROR)) delegate.error(msg, t)
     }
 
@@ -64,9 +72,5 @@ class ConfigurableIdeaConsole(
         val configured = settings.logLevel.coerceIn(0, 100)
         if (configured >= 100) return false
         return level.threshold >= configured
-    }
-
-    private object EmptyThrowable : Throwable() {
-        override fun fillInStackTrace(): Throwable = this
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowFactory.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowFactory.kt
@@ -6,8 +6,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 
 class EasyApiConsoleToolWindowFactory : ToolWindowFactory {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val consoleProvider = IdeaConsoleProvider.getInstance(project)
-        val console = consoleProvider.getConsole()
+        val console = project.console
         if (console is DefaultIdeaConsole) {
             console.bindToolWindow(toolWindow)
         }

--- a/src/main/kotlin/com/itangcent/easyapi/logging/IdeaConsoleProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/IdeaConsoleProvider.kt
@@ -4,30 +4,42 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.onSettingsChanged
+import com.itangcent.easyapi.settings.settings
 
 /**
  * Provides a project-level [IdeaConsole] instance for logging within the IDE.
  *
- * This is an IntelliJ project-level service that creates and manages a [ConfigurableIdeaConsole]
- * which wraps a [DefaultIdeaConsole] with settings from [DefaultSettingBinder].
+ * This is an IntelliJ project-level service that resolves the appropriate [IdeaConsole]
+ * implementation based on the current [Settings.logLevel]:
  *
- * The console instance is lazily initialized on first access and cached for subsequent calls.
+ * - **`logLevel > ERROR` (e.g. SILENT=100, the default):** returns [IdeaLogConsole] —
+ *   the tool window is bypassed and console output is redirected to `idea.log`.
+ *   `trace`/`debug` are routed to `LOG.trace`/`LOG.debug` (filtered by IntelliJ unless
+ *   debug logging is enabled); `warn`/`error` are routed to `LOG.warn` (always captured).
+ * - **`logLevel <= ERROR`:** returns a [ConfigurableIdeaConsole] wrapping a
+ *   [DefaultIdeaConsole] — output appears in the EasyAPI tool window, filtered by the
+ *   configured log level, with `warn`/`error` mirrored to `idea.log`.
  *
  * ## Usage
+ *
+ * Prefer the `Project.console` extension property over calling this service directly:
  * ```kotlin
- * val console = IdeaConsoleProvider.getInstance(project).getConsole()
- * console.info("Message")
+ * project.console.warn("Message", throwable)
  * ```
  *
  * @see IdeaConsole for the console interface
  * @see ConfigurableIdeaConsole for settings-aware console wrapper
- * @see DefaultIdeaConsole for the default implementation
+ * @see IdeaLogConsole for the idea.log-only fallback
+ * @see DefaultIdeaConsole for the default tool-window implementation
  */
 @Service(Service.Level.PROJECT)
 class IdeaConsoleProvider(private val project: Project) {
 
-    private val console by lazy {
-        val settings = SettingBinder.getInstance(project).read()
+    private val settingBinder: SettingBinder by lazy { SettingBinder.getInstance(project) }
+
+    private val ideaConsole: IdeaConsole by lazy {
+        val settings = project.settings
         val delegate = DefaultIdeaConsole(project)
         ConfigurableIdeaConsole(delegate, settings)
     }
@@ -35,11 +47,19 @@ class IdeaConsoleProvider(private val project: Project) {
     /**
      * Returns the project's console instance for logging.
      *
-     * The console is lazily initialized on first call and reused for subsequent calls.
+     * The implementation is chosen dynamically based on [Settings.logLevel]:
+     * - `logLevel > ERROR.threshold` → [IdeaLogConsole] (idea.log only, no tool window)
+     * - otherwise → [ConfigurableIdeaConsole] (tool window + mirror)
      *
      * @return The [IdeaConsole] instance for this project
      */
-    fun getConsole(): IdeaConsole = console
+    fun getConsole(): IdeaConsole {
+        return if (settingBinder.read().logLevel > LogLevel.ERROR.threshold) {
+            IdeaLogConsole
+        } else {
+            ideaConsole
+        }
+    }
 
     companion object {
         /**
@@ -51,3 +71,16 @@ class IdeaConsoleProvider(private val project: Project) {
         fun getInstance(project: Project): IdeaConsoleProvider = project.service()
     }
 }
+
+/**
+ * Returns the project's [IdeaConsole] for logging.
+ *
+ * Resolves the console implementation based on the current `logLevel` setting.
+ * Use this instead of `IdeaConsoleProvider.getInstance(project).getConsole()`.
+ *
+ * ```kotlin
+ * project.console.warn("Export failed", e)
+ * ```
+ */
+val Project.console
+    get() = IdeaConsoleProvider.getInstance(this).getConsole()

--- a/src/main/kotlin/com/itangcent/easyapi/logging/IdeaLog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/IdeaLog.kt
@@ -9,6 +9,13 @@ import com.intellij.openapi.diagnostic.Logger
  * via the [LOG] property. The logger is automatically initialized with
  * the implementing class's name.
  *
+ * ## `LOG.error` is prohibited
+ *
+ * `Logger.error` triggers an intrusive error-report popup in the IDE and throws
+ * `TestLoggerAssertionError` in tests. Production code MUST NOT call `LOG.error`.
+ * Use `LOG.warn` as the error-level fallback (R-CH-03). A CI gate test
+ * (`AntiPatternGateTest.noLogErrorInProductionCode`) enforces this prohibition.
+ *
  * ## Usage
  * ```kotlin
  * class MyService : IdeaLog {

--- a/src/main/kotlin/com/itangcent/easyapi/logging/IdeaLogConsole.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/IdeaLogConsole.kt
@@ -19,7 +19,7 @@ object IdeaLogConsole : IdeaConsole, IdeaLog {
     }
 
     override fun error(msg: String, t: Throwable?) {
-        // Use info level to avoid TestLoggerAssertionError in tests (IntelliJ treats Logger.error as test failure).
-        LOG.info(msg, t)
+        // Use warn level: LOG.error is prohibited (triggers intrusive popup); warn preserves severity without popup (R-CH-03).
+        LOG.warn(msg, t)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/EnumValueResolver.kt
@@ -5,14 +5,14 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.itangcent.easyapi.core.threading.readSync
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.model.FieldOption
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 
 /**
  * Shared value-field resolver for enum usages, used by both Case 1
@@ -54,7 +54,7 @@ import com.itangcent.easyapi.settings.SettingBinder
 @Service(Service.Level.PROJECT)
 class EnumValueResolver(private val project: Project) : IdeaLog {
 
-    private val console = IdeaConsoleProvider.getInstance(project).getConsole()
+    private val console get() = project.console
 
     /**
      * The resolved value field of an enum.
@@ -120,7 +120,7 @@ class EnumValueResolver(private val project: Project) : IdeaLog {
      */
     private fun readAutoInferEnabled(): Boolean =
         runCatching {
-            SettingBinder.getInstance(project).read().enumFieldAutoInferEnabled
+            project.settings.enumFieldAutoInferEnabled
         }.getOrNull() ?: false
 
     /**
@@ -165,7 +165,7 @@ class EnumValueResolver(private val project: Project) : IdeaLog {
                 val instanceFields = instanceFields(enumClass)
                 if (instanceFields.size == 1) {
                     val field = instanceFields.first()
-                    console.info(
+                    console.debug(
                         "EnumValueResolver: auto-inferred value field for " +
                             "${enumClass.qualifiedName ?: enumClass.name} → instance field '${field.name}' " +
                             "(INTELLIGENT_SINGLE: sole instance field)"
@@ -176,7 +176,7 @@ class EnumValueResolver(private val project: Project) : IdeaLog {
                 // Case 2: context != null → type-match heuristic.
                 val matched = findEnumFieldByType(enumClass, context)
                 if (matched != null) {
-                    console.info(
+                    console.debug(
                         "EnumValueResolver: auto-inferred value field for " +
                             "${enumClass.qualifiedName ?: enumClass.name} → instance field '${matched.name}' " +
                             "(INTELLIGENT_TYPE_MATCH: type-compatible with referencing element)"

--- a/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/psi/helper/DocMetadataResolver.kt
@@ -16,7 +16,7 @@ import com.itangcent.easyapi.exporter.model.PathSelector
 import com.itangcent.easyapi.psi.type.JsonType
 import com.itangcent.easyapi.rule.RuleKeys
 import com.itangcent.easyapi.rule.engine.RuleEngine
-import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.json.GsonUtils
 import com.itangcent.easyapi.util.text.appendWithDedup
 
@@ -97,7 +97,7 @@ class DocMetadataResolver internal constructor(
 ) : com.itangcent.easyapi.logging.IdeaLog {
     private val engine: RuleEngine get() = RuleEngine.getInstance(project)
     private val docHelper: DocHelper get() = UnifiedDocHelper.getInstance(project)
-    private val settings get() = SettingBinder.getInstance(project).read()
+    private val settings get() = project.settings
 
     companion object {
         fun getInstance(project: Project): DocMetadataResolver = project.service()

--- a/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/context/RuleContext.kt
@@ -7,7 +7,7 @@ import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.logging.IdeaConsole
 import com.itangcent.easyapi.logging.IdeaLog
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.psi.helper.AnnotationHelper
 import com.itangcent.easyapi.psi.helper.DocHelper
 import com.itangcent.easyapi.psi.helper.UnifiedDocHelper
@@ -144,7 +144,7 @@ class RuleContext private constructor(
     val session: SessionStorage get() = sessionStorageInstance
     val config: ConfigReader get() = ConfigReader.getInstance(project)
     val localStorage: LocalStorage by lazy { LocalStorage.getInstance(project) }
-    val console: IdeaConsole by lazy { IdeaConsoleProvider.getInstance(project).getConsole() }
+    val console: IdeaConsole get() = project.console
 
     fun getExt(name: String): Any? = extensions[name]
     fun setExt(name: String, value: Any?) { extensions[name] = value }

--- a/src/main/kotlin/com/itangcent/easyapi/script/env/EnvironmentService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/script/env/EnvironmentService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.util.json.GsonUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -170,7 +171,7 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
      * Global environments are listed first, followed by project environments.
      */
     private fun loadEnvironmentData(): EnvironmentData {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val projectEnvJson = settings.projectEnvironments
         val projectData = if (projectEnvJson.isNotBlank()) {
             runCatching { GsonUtils.fromJson<EnvironmentData>(projectEnvJson) }
@@ -205,7 +206,7 @@ class EnvironmentService(private val project: Project) : com.itangcent.easyapi.l
      * Project-scoped environments go to project settings; global-scoped go to application settings.
      */
     private fun persistEnvironmentData(data: EnvironmentData) {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         val projectEnvs = data.environments.filter { it.scope == EnvironmentScope.PROJECT }
         val globalEnvs = data.environments.filter { it.scope == EnvironmentScope.GLOBAL }
 

--- a/src/main/kotlin/com/itangcent/easyapi/script/pm/PmScriptExecutor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/script/pm/PmScriptExecutor.kt
@@ -3,8 +3,8 @@ package com.itangcent.easyapi.script.pm
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.logging.IdeaConsole
-import com.itangcent.easyapi.logging.IdeaConsoleProvider
 import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.rule.parser.EnginePool
 import javax.script.Bindings
 
@@ -33,7 +33,7 @@ import javax.script.Bindings
 class PmScriptExecutor(private val project: Project) : IdeaLog {
 
     private val enginePool = EnginePool("groovy")
-    private val console: IdeaConsole by lazy { IdeaConsoleProvider.getInstance(project).getConsole() }
+    private val console get() = project.console
 
     /**
      * Executes a pre-request script.

--- a/src/main/kotlin/com/itangcent/easyapi/settings/SettingBinder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/SettingBinder.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.settings
 
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.idea.facet.getInstance
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -64,15 +65,8 @@ fun SettingBinder.update(updater: Settings.() -> Unit) {
     this.read().also(updater).let { this.save(it) }
 }
 
-/**
- * Wraps this SettingBinder with a caching layer.
- *
- * @param cacheTimeoutMillis Cache timeout in milliseconds, defaults to 30000 (30 seconds)
- * @return A cached SettingBinder
- */
-fun SettingBinder.lazy(cacheTimeoutMillis: Duration): SettingBinder {
-    return CachedSettingBinder(this, cacheTimeoutMillis)
-}
+
+val Project.settings get() = SettingBinder.getInstance(this).read()
 
 /**
  * A cached wrapper for SettingBinder.
@@ -147,4 +141,14 @@ class CachedSettingBinder(
             }
         }
     }
+}
+
+/**
+ * Wraps this SettingBinder with a caching layer.
+ *
+ * @param cacheTimeoutMillis Cache timeout in milliseconds, defaults to 30000 (30 seconds)
+ * @return A cached SettingBinder
+ */
+fun SettingBinder.lazy(cacheTimeoutMillis: Duration): SettingBinder {
+    return CachedSettingBinder(this, cacheTimeoutMillis)
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -49,7 +49,7 @@ data class Settings(
     override var httpTimeOut: Int = 30,
     override var unsafeSsl: Boolean = false,
     override var httpClient: String = HttpClientType.APACHE.value,
-    override var logLevel: Int = 0,
+    override var logLevel: Int = 100, // SILENT — console off by default
     override var outputDemo: Boolean = true,
     override var outputCharset: String = "UTF-8",
     override var markdownFormatType: String = MarkdownFormatType.SIMPLE.name,

--- a/src/main/kotlin/com/itangcent/easyapi/settings/SettingsChangeListener.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/SettingsChangeListener.kt
@@ -1,5 +1,7 @@
 package com.itangcent.easyapi.settings
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
 import com.intellij.util.messages.Topic
 
 interface SettingsChangeListener {
@@ -12,4 +14,20 @@ interface SettingsChangeListener {
             SettingsChangeListener::class.java
         )
     }
+}
+
+fun Project.onSettingsChanged(disposable: Disposable, handler: () -> Unit) {
+    messageBus.connect(disposable).subscribe(SettingsChangeListener.TOPIC, object : SettingsChangeListener {
+        override fun settingsChanged() {
+            handler()
+        }
+    })
+}
+
+fun Project.onSettingsChanged(handler: () -> Unit) {
+    messageBus.connect().subscribe(SettingsChangeListener.TOPIC, object : SettingsChangeListener {
+        override fun settingsChanged() {
+            handler()
+        }
+    })
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -51,7 +51,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var unsafeSsl: Boolean = false,
         override var httpClient: String = HttpClientType.APACHE.value,
         override var extensionConfigs: String = Settings().extensionConfigs,
-        override var logLevel: Int = 0,
+        override var logLevel: Int = 100, // SILENT — console off by default (FR-CH-13)
         override var outputDemo: Boolean = true,
         override var outputCharset: String = "UTF-8",
         override var markdownFormatType: String = MarkdownFormatType.SIMPLE.name,

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/GrpcSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/GrpcSettingsPanel.kt
@@ -11,6 +11,7 @@ import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.ListTableModel
 import com.itangcent.easyapi.grpc.*
 import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.settings
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GridLayout
@@ -420,7 +421,7 @@ class GrpcSettingsPanel(private val project: com.intellij.openapi.project.Projec
 
     companion object {
         fun selectUnavailableArtifact(project: com.intellij.openapi.project.Project, artifact: Artifact) {
-            val settings = com.itangcent.easyapi.settings.SettingBinder.getInstance(project).read()
+            val settings = project.settings
             val configs = settings.grpcArtifactConfigs.mapNotNull { GrpcArtifactConfig.parse(it) }
             val index = configs.indexOfFirst { it.artifact == artifact }
             if (index >= 0) {

--- a/src/test/kotlin/com/itangcent/easyapi/cache/api/ApiFileChangeListenerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/cache/api/ApiFileChangeListenerTest.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.cache.api
 
 import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -39,7 +40,7 @@ class ApiFileChangeListenerTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     fun testAutoScanDisabled() {
-        val settings = SettingBinder.getInstance(project).read()
+        val settings = project.settings
         settings.autoScanEnabled = false
         SettingBinder.getInstance(project).save(settings)
 

--- a/src/test/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolverTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 
 class CachedResourceResolverTest {
@@ -99,17 +100,37 @@ class CachedResourceResolverTest {
     }
 
     @Test
-    fun testWithNullConsole() {
+    fun testFetchFailureLogsWarningToConsole() {
         val url = "https://fake-local-test.example/config.txt"
 
         `when`(localStorage.get("remote-cache", url)).thenReturn(null)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(null)
 
-        resolver = CachedResourceResolver(localStorage, null, 60000L)
+        resolver = CachedResourceResolver(localStorage, console, 60000L)
 
         runBlocking {
             val result = resolver.get(url)
-            assertNull(result)
+            assertNull("Should return null when fetch fails and no cache", result)
+            // The fetch failure (non-timeout) should be logged via console.warn
+            verify(console).warn(anyString(), any())
+        }
+    }
+
+    @Test
+    fun testFetchFailureWithExpiredCacheReturnsStaleContent() {
+        val url = "https://fake-local-test.example/config.txt"
+        val staleContent = "stale content"
+        val oldTimestamp = (System.currentTimeMillis() - 100000).toString()
+
+        `when`(localStorage.get("remote-cache", url)).thenReturn(staleContent)
+        `when`(localStorage.get("remote-cache-ts", url)).thenReturn(oldTimestamp)
+
+        resolver = CachedResourceResolver(localStorage, console, 1000L)
+
+        runBlocking {
+            val result = resolver.get(url)
+            assertEquals("Should fall back to stale cache on fetch failure", staleContent, result)
+            verify(console).warn(anyString(), any())
         }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
@@ -5,9 +5,9 @@ import com.intellij.openapi.ui.TestDialogManager
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ExportResult
-import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 
@@ -117,6 +117,43 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
     fun testOrchestratorHandlesMarkdownChannel() = runTest {
         val result = orchestrator.orchestrateExport(null, "markdown", testFileConfig)
         assertNotNull("Should handle markdown channel", result)
+    }
+
+    fun testOrchestrateExportWithEmptyCacheReturnsError() = runTest {
+        // When no endpoints are cached and no selection is provided,
+        // orchestrateExport should return an Error result.
+        // Note: If a background scan has populated the cache, this may return Success instead.
+        val result = orchestrator.orchestrateExport(null, "markdown", testFileConfig)
+        assertNotNull(result)
+        assertTrue(
+            "Should be Error (no endpoints) or Success (background scan populated cache)",
+            result is ExportResult.Error || result is ExportResult.Success
+        )
+    }
+
+    fun testOrchestrateExportWithSelectionExportsEndpoints() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val selection = SelectionScope(listOf(psiClass!!))
+
+        val result = orchestrator.orchestrateExport(selection, "markdown", testFileConfig)
+        assertNotNull(result)
+        // With real endpoints found, the export should succeed or fail gracefully
+        // but either way the notifyInfo path is exercised
+    }
+
+    fun testOrchestrateExportWithUnknownChannelReturnsError() = runTest {
+        val result = orchestrator.orchestrateExport(null, "nonexistent-channel", testFileConfig)
+        assertNotNull(result)
+        assertTrue("Should be Error for unknown channel", result is ExportResult.Error)
+        assertEquals("No channel registered for id: nonexistent-channel", (result as ExportResult.Error).message)
+    }
+
+    fun testExportViaChannelWithUnknownChannelReturnsError() = runTest {
+        val endpoints = listOf(createTestEndpoint())
+        val result = orchestrator.exportViaChannel("nonexistent-channel", endpoints, testFileConfig)
+        assertNotNull(result)
+        assertTrue("Should be Error for unknown channel", result is ExportResult.Error)
     }
 
     private fun createTestEndpoint(

--- a/src/test/kotlin/com/itangcent/easyapi/ide/support/NotificationUtilsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/support/NotificationUtilsTest.kt
@@ -16,6 +16,15 @@ class NotificationUtilsTest : EasyApiLightCodeInsightFixtureTestCase() {
         NotificationUtils.notifyError(project, "Test Error", "Error Content")
     }
 
+    fun testNotifyErrorWithThrowableDoesNotThrow() {
+        val error = RuntimeException("boom")
+        NotificationUtils.notifyError(project, "Test Error", "Error Content", error)
+    }
+
+    fun testNotifyErrorWithNullThrowableDoesNotThrow() {
+        NotificationUtils.notifyError(project, "Test Error", "Error Content", null)
+    }
+
     fun testNotifyInfoWithLinksDoesNotThrow() {
         NotificationUtils.notifyInfoWithLinks(
             project,

--- a/src/test/kotlin/com/itangcent/easyapi/logging/AntiPatternGateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/logging/AntiPatternGateTest.kt
@@ -5,9 +5,10 @@ import org.junit.Test
 import java.io.File
 
 /**
- * Anti-pattern gate test (FR-12, R-PLACE-07).
+ * Anti-pattern gate test (FR-12, R-PLACE-07, FR-CH-04, FR-CH-11).
  *
  * Fails if `src/main` contains:
+ * - `LOG.error(` or `Logger.*.error(` (prohibited — triggers intrusive popup; use LOG.warn)
  * - `println(` outside `logging/IdeaConsole*` (the legit API)
  * - `.printStackTrace()`
  * - `Notifications.Bus.notify` / `NotificationGroupManager` outside `NotificationUtils.kt`
@@ -19,6 +20,25 @@ import java.io.File
 class AntiPatternGateTest {
 
     private val mainSrcRoot = File("src/main/kotlin")
+
+    @Test
+    fun noLogErrorInProductionCode() {
+        val offenders = scanFiles { content, file ->
+            val stripped = stripComments(content)
+            val patterns = listOf(
+                Regex("""\bLOG\.error\s*\("""),
+                Regex("""Logger\.getInstance\(.*\)\.error\s*\(""")
+            )
+            patterns.flatMap { regex ->
+                regex.findAll(stripped).map { it.value }.toList()
+            }
+        }
+        assertTrue(
+            "LOG.error is prohibited in production code (use LOG.warn as the error-level fallback per R-CH-03). " +
+                "Violations:\n${offenders.joinToString("\n")}",
+            offenders.isEmpty()
+        )
+    }
 
     @Test
     fun noPrintlnInProductionCode() {

--- a/src/test/kotlin/com/itangcent/easyapi/logging/IdeaConsoleProviderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/logging/IdeaConsoleProviderTest.kt
@@ -1,20 +1,34 @@
 package com.itangcent.easyapi.logging
 
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class IdeaConsoleProviderTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private val testSettingBinder by lazy { SettingBinder.getInstance(project) }
+
+    /**
+     * Restores `logLevel` after each test that mutates it so tests stay isolated.
+     */
+    private fun withLogLevel(level: Int, block: () -> Unit) {
+        val original = testSettingBinder.read().logLevel
+        try {
+            val settings = testSettingBinder.read()
+            settings.logLevel = level
+            testSettingBinder.save(settings)
+            block()
+        } finally {
+            val settings = testSettingBinder.read()
+            settings.logLevel = original
+            testSettingBinder.save(settings)
+        }
+    }
 
     fun testGetConsoleReturnsNonNull() {
         val provider = IdeaConsoleProvider.getInstance(project)
         val console = provider.getConsole()
         assertNotNull("getConsole should return non-null", console)
-    }
-
-    fun testGetConsoleReturnsSameInstance() {
-        val provider = IdeaConsoleProvider.getInstance(project)
-        val console1 = provider.getConsole()
-        val console2 = provider.getConsole()
-        assertSame("getConsole should return same instance", console1, console2)
     }
 
     fun testGetConsoleReturnsIdeaConsole() {
@@ -27,5 +41,119 @@ class IdeaConsoleProviderTest : EasyApiLightCodeInsightFixtureTestCase() {
         val provider1 = IdeaConsoleProvider.getInstance(project)
         val provider2 = IdeaConsoleProvider.getInstance(project)
         assertSame("getInstance should return same provider", provider1, provider2)
+    }
+
+    // ------------------------------------------------------------------
+    // SILENT (default) → IdeaLogConsole
+    // ------------------------------------------------------------------
+
+    fun testSilentLevelReturnsIdeaLogConsole() {
+        withLogLevel(100) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+            val console = provider.getConsole()
+            assertTrue(
+                "At SILENT level (100) getConsole should return IdeaLogConsole",
+                console is IdeaLogConsole
+            )
+        }
+    }
+
+    fun testSilentLevelReturnsSameSingleton() {
+        withLogLevel(100) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+            val console1 = provider.getConsole()
+            val console2 = provider.getConsole()
+            assertSame(
+                "At SILENT level getConsole should return the IdeaLogConsole singleton",
+                console1, console2
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Non-SILENT → ConfigurableIdeaConsole
+    // ------------------------------------------------------------------
+
+    fun testWarnLevelReturnsConfigurableIdeaConsole() {
+        withLogLevel(LogLevel.WARN.threshold) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+            val console = provider.getConsole()
+            assertTrue(
+                "At WARN level getConsole should return ConfigurableIdeaConsole",
+                console is ConfigurableIdeaConsole
+            )
+        }
+    }
+
+    fun testErrorLevelReturnsConfigurableIdeaConsole() {
+        withLogLevel(LogLevel.ERROR.threshold) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+            val console = provider.getConsole()
+            assertTrue(
+                "At ERROR level getConsole should return ConfigurableIdeaConsole",
+                console is ConfigurableIdeaConsole
+            )
+        }
+    }
+
+    fun testNonSilentLevelReturnsSameInstance() {
+        withLogLevel(LogLevel.WARN.threshold) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+            val console1 = provider.getConsole()
+            val console2 = provider.getConsole()
+            assertSame(
+                "At non-SILENT level getConsole should return the same ConfigurableIdeaConsole instance",
+                console1, console2
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Level switching
+    // ------------------------------------------------------------------
+
+    fun testConsoleSwitchesWhenLevelChanges() {
+        withLogLevel(100) {
+            val provider = IdeaConsoleProvider.getInstance(project)
+
+            val silentConsole = provider.getConsole()
+            assertTrue("Should start as IdeaLogConsole", silentConsole is IdeaLogConsole)
+
+            // Switch to WARN
+            val settings = testSettingBinder.read()
+            settings.logLevel = LogLevel.WARN.threshold
+            testSettingBinder.save(settings)
+
+            val warnConsole = provider.getConsole()
+            assertTrue("Should switch to ConfigurableIdeaConsole", warnConsole is ConfigurableIdeaConsole)
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Project.console extension
+    // ------------------------------------------------------------------
+
+    fun testProjectConsoleExtensionReturnsSameAsGetConsole() {
+        val provider = IdeaConsoleProvider.getInstance(project)
+        val directConsole = provider.getConsole()
+        val extensionConsole = project.console
+        assertSame(
+            "Project.console extension should return the same instance as getConsole()",
+            directConsole, extensionConsole
+        )
+    }
+
+    fun testProjectConsoleExtensionReturnsIdeaConsole() {
+        val console = project.console
+        assertTrue("Project.console should return an IdeaConsole", console is IdeaConsole)
+    }
+
+    fun testProjectSettingsExtensionReturnsSettings() {
+        val settings = project.settings
+        assertNotNull("Project.settings should return non-null Settings", settings)
+        assertTrue(
+            "Default logLevel should be SILENT (100)",
+            settings.logLevel >= 100
+        )
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsChangeListenerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsChangeListenerTest.kt
@@ -1,0 +1,41 @@
+package com.itangcent.easyapi.settings
+
+import com.intellij.openapi.util.Disposer
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import org.junit.Assert.*
+
+class SettingsChangeListenerTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    fun testOnSettingsChangedWithDisposableIsCalled() {
+        var callCount = 0
+        project.onSettingsChanged(Disposer.newDisposable()) {
+            callCount++
+        }
+
+        project.messageBus.syncPublisher(SettingsChangeListener.TOPIC).settingsChanged()
+        assertEquals("Handler should be invoked when settings change", 1, callCount)
+
+        project.messageBus.syncPublisher(SettingsChangeListener.TOPIC).settingsChanged()
+        assertEquals("Handler should be invoked on each settings change", 2, callCount)
+    }
+
+    fun testOnSettingsChangedWithoutDisposableIsCalled() {
+        var callCount = 0
+        project.onSettingsChanged {
+            callCount++
+        }
+
+        project.messageBus.syncPublisher(SettingsChangeListener.TOPIC).settingsChanged()
+        assertEquals("Handler should be invoked when settings change", 1, callCount)
+    }
+
+    fun testOnSettingsChangedFiresOnSettingBinderSave() {
+        var callCount = 0
+        project.onSettingsChanged(Disposer.newDisposable()) {
+            callCount++
+        }
+
+        settingBinder.save(Settings())
+        assertEquals("Saving settings should fire settingsChanged", 1, callCount)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/SettingsTest.kt
@@ -30,7 +30,7 @@ class SettingsTest {
         assertEquals(30, settings.httpTimeOut)
         assertFalse(settings.unsafeSsl)
         assertEquals(HttpClientType.APACHE.value, settings.httpClient)
-        assertEquals(0, settings.logLevel)
+        assertEquals(100, settings.logLevel) // SILENT — console off by default (FR-CH-13)
         assertTrue(settings.outputDemo)
         assertEquals("UTF-8", settings.outputCharset)
         assertEquals(MarkdownFormatType.SIMPLE.name, settings.markdownFormatType)
@@ -56,13 +56,13 @@ class SettingsTest {
             jaxrsEnable = false,
             postmanToken = "my-token",
             httpTimeOut = 30,
-            logLevel = 100
+            logLevel = 40
         )
         assertTrue(settings.feignEnable)
         assertFalse(settings.jaxrsEnable)
         assertEquals("my-token", settings.postmanToken)
         assertEquals(30, settings.httpTimeOut)
-        assertEquals(100, settings.logLevel)
+        assertEquals(40, settings.logLevel)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -30,7 +30,7 @@ class ApplicationSettingsStateTest {
         assertEquals(30, s.httpTimeOut)
         assertFalse(s.unsafeSsl)
         assertEquals(HttpClientType.APACHE.value, s.httpClient)
-        assertEquals(0, s.logLevel)
+        assertEquals(100, s.logLevel) // SILENT — console off by default (FR-CH-13)
         assertTrue(s.outputDemo)
         assertEquals("UTF-8", s.outputCharset)
         assertEquals(MarkdownFormatType.SIMPLE.name, s.markdownFormatType)
@@ -47,14 +47,14 @@ class ApplicationSettingsStateTest {
             feignEnable = true,
             jaxrsEnable = false,
             httpTimeOut = 30,
-            logLevel = 100
+            logLevel = 40
         )
         state.loadState(newState)
         val loaded = state.state
         assertTrue(loaded.feignEnable)
         assertFalse(loaded.jaxrsEnable)
         assertEquals(30, loaded.httpTimeOut)
-        assertEquals(100, loaded.logLevel)
+        assertEquals(40, loaded.logLevel)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/GeneralSettingsPanelLogicTest.kt
@@ -95,7 +95,7 @@ class GeneralSettingsPanelLogicTest {
         assertFalse(settings.concurrentScanEnabled)
         assertTrue(settings.gutterIconEnabled)
         assertTrue(settings.switchNotice)
-        assertEquals(0, settings.logLevel)
+        assertEquals(100, settings.logLevel)
         assertEquals("UTF-8", settings.outputCharset)
         assertTrue(settings.outputDemo)
         assertEquals(MarkdownFormatType.SIMPLE.name, settings.markdownFormatType)


### PR DESCRIPTION
## Summary

establishes clear discipline for the plugin's three logging channels (`LOG`, `NotificationUtils`, `IdeaConsole`) so failures are never lost while keeping the tool window quiet by default.

## Changes

- **Severity fixes (Phase 0):** Mirror `console.error` / `notifyError` to `LOG.warn` (never `LOG.error`, which triggers intrusive IDE error popups). Update KDoc on `IdeaLog` to state the prohibition.
- **Prohibition gate (Phase 0):** Add a CI gate test that scans `src/main/kotlin/` for `LOG.error(` / `Logger.*.error(` and fails on any match (excludes KDoc/comments).
- **Console call-site migration (Phase 1):** Reclassify all 44 `console.*` call-sites:
  - 9 → `LOG` (routine milestones, per-item script progress)
  - 3 → `NotificationUtils` (user-facing export progress/completion/failure)
  - 31 stay on Console (operation failures `console.warn`, error surfacing `console.error`, debug/trace diagnostics)
- **SILENT default (Phase 1.5):** Change default `logLevel` from `0` (TRACE) to `100` (SILENT) in `Settings.kt` and `ApplicationSettingsState.kt`. The tool window is now empty by default; `console.warn`/`console.error` still mirror to `LOG.warn`, while `console.debug`/`console.trace` are zero-cost no-ops until the user lowers `logLevel`.
- **AGENTS.md (Phase 2):** Document the logging channel discipline rules for future contributors.

## Test plan

- [x] `./gradlew test` — all tests green (updated assertions for new `warn` mirror severity and `SILENT` default)
- [x] `./gradlew runIde` — verify tool window is empty by default; export triggers balloon notifications (not console); errors still mirror to `idea.log` at `warn`; lowering `logLevel` to Trace lights up the tool window
- [x] `grep` for `LOG.error(` in `src/main/kotlin/` — zero hits (CI gate enforces)