### PR TITLE
feat(logging): hide EasyAPI console tool window when log level is SILENT

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/logging/EasyApiConsoleToolWindowActivity.kt
@@ -1,0 +1,44 @@
+package com.itangcent.easyapi.logging
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.wm.ToolWindowManager
+import com.itangcent.easyapi.core.threading.swingAsync
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.onSettingsChanged
+import com.itangcent.easyapi.settings.settings
+
+/**
+ * Dynamically shows/hides the "EasyAPI" console tool window based on the configured
+ * log level.
+ *
+ * - When `logLevel > [LogLevel.ERROR.threshold]` (i.e. SILENT), the tool window button
+ *   is hidden via [com.intellij.openapi.wm.ToolWindow.setAvailable] — the console is
+ *   never used in this mode ([IdeaConsoleProvider] routes output to [IdeaLogConsole]).
+ * - When `logLevel <= ERROR.threshold`, the tool window button is shown.
+ *
+ * Listens to settings changes so the visibility updates immediately when the user
+ * adjusts the log level, without requiring a project reload.
+ */
+class EasyApiConsoleToolWindowActivity : ProjectActivity {
+
+    override suspend fun execute(project: Project) {
+        updateAvailability(project)
+
+        project.onSettingsChanged {
+            updateAvailability(project)
+        }
+    }
+
+    private fun updateAvailability(project: Project) {
+        val logLevel = project.settings.logLevel
+        val available = logLevel <= LogLevel.ERROR.threshold
+
+        // ToolWindow.setAvailable must be called on EDT.
+        swingAsync {
+            val toolWindow = ToolWindowManager.getInstance(project)
+                .getToolWindow(DefaultIdeaConsole.WINDOW_ID) ?: return@swingAsync
+            toolWindow.setAvailable(available, null)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,7 @@
 
         <postStartupActivity implementation="com.itangcent.easyapi.ide.ApiIndexStartupActivity"/>
         <postStartupActivity implementation="com.itangcent.easyapi.ide.action.ChannelActionInitActivity"/>
+        <postStartupActivity implementation="com.itangcent.easyapi.logging.EasyApiConsoleToolWindowActivity"/>
 
         <projectConfigurable groupId="null"
                              displayName="EasyApi"


### PR DESCRIPTION
## Description

The EasyAPI console tool window button was always visible in the IDE stripe regardless of the configured log level. When the level is `SILENT` (the default), `IdeaConsoleProvider` routes output to `IdeaLogConsole` (idea.log only) and the console view is never used, so showing the button was noise.

This adds `EasyApiConsoleToolWindowActivity` (a `ProjectActivity`) that calls `ToolWindow.setAvailable()` based on the configured log level, and subscribes to settings changes so visibility updates immediately when the user switches between `SILENT` and verbose levels — no project reload required.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #N/A

## Changes Made

- Added `EasyApiConsoleToolWindowActivity` implementing `StartupActivity`/`ProjectActivity`.
- Activity calls `ToolWindow.setAvailable(...)` based on the current log level.
- Subscribes to settings changes so visibility flips live when the user toggles `SILENT` ↔ verbose.
- Registered the activity in `plugin.xml`.

## Testing

- [x] Manual testing completed
- [ ] Unit tests pass

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Default behavior is unchanged for users who already raised the log level above `SILENT` — they continue to see the console. Only the default-SILENT case is cleaned up.
