### PR TITLE
fix(dashboard): prevent header duplication when switching APIs in ApiDashboard

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/EndpointDetailsPanel.kt
@@ -689,6 +689,10 @@ class EndpointDetailsPanel(
             currentEndpoint = endpoint
             currentEndpointKey = computeCacheKey(endpoint)
 
+            // Always clear all request tables before rendering the new endpoint,
+            // so no stale entries from the previous API leak into the new view.
+            clearRequestTables()
+
             when (val meta = endpoint.metadata) {
                 is GrpcMetadata -> showGrpcEndpoint(endpoint, meta)
                 is HttpMetadata -> {
@@ -715,6 +719,23 @@ class EndpointDetailsPanel(
         } finally {
             isLoading = false
         }
+    }
+
+    /**
+     * Clears every multi-entry request table and its auxiliary state.
+     * Called at the start of [showEndpoint] so switching APIs never leaves
+     * stale rows from the previous endpoint. Single-value fields (host, path,
+     * body, labels) are overwritten in place by the specific loaders.
+     */
+    private fun clearRequestTables() {
+        pathParamsTableModel.rowCount = 0
+        pathParamsEnumValues.clear()
+        paramsTableModel.rowCount = 0
+        headersTableModel.rowCount = 0
+        formTableModel.rowCount = 0
+        formFileRows.clear()
+        hasFormData = false
+        endpointContentType = null
     }
 
     private fun loadEndpointScripts() {
@@ -908,6 +929,8 @@ class EndpointDetailsPanel(
         }
         parameters.filter { it.binding == ParameterBinding.Header }
             .forEach { p ->
+                // Skip headers already present in meta.headers to avoid duplicates
+                if (p.name in originalHeaderNames) return@forEach
                 originalHeaderNames.add(p.name)
                 val cachedValue = cachedHeaders[p.name]?.value ?: p.defaultValue ?: p.example ?: ""
                 headersTableModel.addRow(arrayOf(p.name, cachedValue, ""))
@@ -978,11 +1001,16 @@ class EndpointDetailsPanel(
         ensureEmptyRow(paramsTableModel)
 
         headersTableModel.rowCount = 0
+        val seenHeaderNames = mutableSetOf<String>()
         headers.forEach { h ->
+            seenHeaderNames.add(h.name)
             headersTableModel.addRow(arrayOf(h.name, h.value ?: "", ""))
         }
         parameters.filter { it.binding == ParameterBinding.Header }
             .forEach { p ->
+                // Skip headers already present in meta.headers to avoid duplicates
+                if (p.name in seenHeaderNames) return@forEach
+                seenHeaderNames.add(p.name)
                 headersTableModel.addRow(arrayOf(p.name, p.defaultValue ?: p.example ?: "", ""))
             }
         ensureEmptyRow(headersTableModel)

--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/RequestEditCacheService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/RequestEditCacheService.kt
@@ -90,6 +90,7 @@ class RequestEditCacheService(private val project: Project) {
         val meta = endpoint.httpMetadata
         val parameters = meta?.parameters ?: emptyList()
         val headers = meta?.headers ?: emptyList()
+        val headerNames = headers.map { it.name }.toSet()
         return HttpRequestEditCache(
             key = key,
             name = endpoint.name,
@@ -98,7 +99,7 @@ class RequestEditCacheService(private val project: Project) {
             host = host,
             headers = headers.map { EditableKeyValue(it.name, it.value ?: it.example ?: "", it.description) } +
                 parameters
-                    .filter { it.binding == ParameterBinding.Header }
+                    .filter { it.binding == ParameterBinding.Header && it.name !in headerNames }
                     .map { EditableKeyValue(it.name, it.defaultValue ?: it.example ?: "", it.description) },
             pathParams = parameters
                 .filter { it.binding == ParameterBinding.Path }


### PR DESCRIPTION
## Description

Headers from `@RequestHeader` parameters were being added twice in the API Dashboard — once via `meta.headers` and again via `meta.parameters` (`ParameterBinding.Header`) — causing headers to pile up and mix across APIs on every switch.

This change also ensures all request tables (path params, query params, headers, form params) are cleared at the start of `showEndpoint`, so no stale rows from the previous endpoint leak into the new view. This includes HTTP → gRPC switches, which previously left HTTP data hidden in the models.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #N/A

## Changes Made

- `EndpointDetailsPanel.loadFromCache` / `loadFromEndpoint` now track header names already added from `meta.headers` and skip duplicates coming from `meta.parameters` with `ParameterBinding.Header`.
- All request tables are reset at the start of `showEndpoint` so stale rows from the previously-selected endpoint cannot leak into the new view (covers HTTP ↔ gRPC switches too).
- `RequestEditCacheService.createDefaultHttpCache` filters out headers already present in `meta.headers` before seeding the editable cache.

## Testing

- [x] Manual testing completed
- [ ] Unit tests pass

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Repro before fix: open two HTTP APIs in the dashboard that each declare `@RequestHeader` params, switch between them a few times — header rows accumulate and may show headers from the other API. After fix, each switch shows exactly the headers of the selected API.
