### PR TITLE
docs: point plugin description Guide links to easyyapi.github.io

### DIFF
--- a/src/main/resources/pluginDescription.html
+++ b/src/main/resources/pluginDescription.html
@@ -2,7 +2,7 @@
 <br/>
 <a href="https://github.com/tangcent/easy-yapi">GitHub</a> |
 <a href="https://github.com/tangcent/easy-yapi/issues">Issues</a> |
-<a href="https://easyyapi.com">Guide</a>
+<a href="https://easyyapi.github.io/guide/">Guide</a>
 <br/>
 <br/>
 <b>Export API to Yapi / Postman / Markdown / Curl / HttpClient</b>
@@ -22,4 +22,4 @@
     <li>The APIs will be exported automatically</li>
 </ol>
 <br/>
-<b>For more details, refer to the <a href="https://easyyapi.com">Guide</a></b>
+<b>For more details, refer to the <a href="https://easyyapi.github.io/guide/">Guide</a></b>


### PR DESCRIPTION
## Description

The plugin description bundled in the IDE / JetBrains Marketplace listing (`src/main/resources/pluginDescription.html`) still linked its two "Guide" links to the retired `easyyapi.com` domain, which now returns 404 (the subject of #1367). This repoints both links to `https://easyyapi.github.io/guide/`, the canonical Guide URL already used in the project READMEs.

## Type of Change

- [x] Documentation update

## Related Issues

Refs #1367

## Changes Made

- Repoint the header "Guide" link in `pluginDescription.html` from `https://easyyapi.com` to `https://easyyapi.github.io/guide/`.
- Repoint the "For more details, refer to the Guide" link from `https://easyyapi.com` to `https://easyyapi.github.io/guide/`.

## Testing

- [x] Manual testing completed

Verified `https://easyyapi.github.io/guide/` returns HTTP 200, and confirmed no `easyyapi.com` references remain anywhere in the repo.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

This is a docs-only change scoped to the in-repo stale links. The deeper `easyyapi.com/setting/rules/*.html` pages mentioned in the issue thread live in the separate `easyyapi.github.io` docs-site repo, not this plugin repo.
