### PR TITLE
amend: improve SettingsPanel layout and extract shared size utilities

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ai/AiSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/AiSettings.kt
@@ -51,8 +51,9 @@ data class AiSettings(
             if (provider.requiresApiKey && apiKey.isBlank()) return null
             val model = s.aiModel.takeIf { it.isNotBlank() }
                 ?: provider.defaultModel ?: return null
-            // 0 (or any non-positive value) means "auto": use the provider's
-            // per-model default. A user-set value overrides it.
+            // A legacy persisted `0` (the old "Auto" sentinel, before the
+            // default became DEFAULT_CONTEXT_WINDOW) is treated as the
+            // provider's per-model default so old installs migrate cleanly.
             val contextWindow = s.aiContextWindow.takeIf { it > 0 }
                 ?: provider.contextWindow
             return AiSettings(

--- a/src/main/kotlin/com/itangcent/easyapi/ai/TokenSizeUtils.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/TokenSizeUtils.kt
@@ -1,0 +1,70 @@
+package com.itangcent.easyapi.ai
+
+/**
+ * AI assistant context-window presets and token-string parsing.
+ *
+ * The presets back the "Context Window" combo in the settings UI
+ * (see `AiAssistantSection`). Labels use plain `"8k"` shorthand so that
+ * a stored value round-trips through [parse] without any preset-label
+ * special-casing.
+ *
+ * Parsing uses **decimal** multipliers (`k` → 1_000, `m` → 1_000_000),
+ * which is the convention for token counts (not byte sizes).
+ *
+ * UI-agnostic and Swing-free, so it can be unit-tested without the
+ * IntelliJ fixture.
+ */
+object TokenSizeUtils {
+
+    /**
+     * Common context-window presets offered in the settings dropdown,
+     * as plain shorthand strings (`"8k"`, `"1m"`, …).
+     */
+    val presets: List<String> = listOf(
+        "8k",
+        "16k",
+        "32k",
+        "64k",
+        "128k",
+        "200k",
+        "500k",
+        "1m",
+        "2m"
+    )
+
+    /**
+     * Parses a free-form context-window string into a token count using
+     * **decimal** multipliers (`k` → 1_000, `m` → 1_000_000).
+     *
+     * Accepts (case-insensitive, surrounding whitespace ignored):
+     * - `"8000"`, `"8,000"` → `8000`
+     * - `"8k"`, `"8K"` → `8000`
+     * - `"1m"`, `"1M"` → `1_000_000`
+     * - `"8k (8,000)"` (a label) → `8000` — anything after the first
+     *   whitespace is ignored
+     *
+     * Returns `0` for any unparseable input rather than throwing, so the
+     * caller can fall back to a safe default.
+     */
+    fun parse(text: String): Int {
+        var trimmed = text.trim().replace(",", "")
+        if (trimmed.isEmpty()) return 0
+
+        // A label like "8k (8,000)" — take the first whitespace-delimited token only.
+        val firstSpace = trimmed.indexOfFirst { it.isWhitespace() }
+        if (firstSpace > 0) {
+            trimmed = trimmed.substring(0, firstSpace)
+        }
+        if (trimmed.isEmpty()) return 0
+
+        val lower = trimmed.lowercase()
+        val multiplier = when {
+            lower.endsWith("k") -> 1_000
+            lower.endsWith("m") -> 1_000_000
+            else -> 1
+        }
+        val numStr = if (multiplier != 1) lower.dropLast(1) else lower
+        val n = numStr.toIntOrNull() ?: return 0
+        return n * multiplier
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/Settings.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.settings
 
+import com.itangcent.easyapi.ai.AiProvider
 import com.itangcent.easyapi.extension.ExtensionConfigRegistry
 import com.itangcent.easyapi.settings.state.ApplicationSettingsSupport
 import com.itangcent.easyapi.settings.state.ProjectSettingsSupport
@@ -71,7 +72,7 @@ data class Settings(
     override var aiModel: String = "",
     override var aiRequestTimeoutSec: Int = 60,
     override var aiMaxRequests: Int = 100,
-    override var aiContextWindow: Int = 0,
+    override var aiContextWindow: Int = AiProvider.DEFAULT_CONTEXT_WINDOW,
     override var disabledAutoRuleFiles: Array<String> = emptyArray()
 ) : ProjectSettingsSupport, ApplicationSettingsSupport {
 

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsState.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.settings.state
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.itangcent.easyapi.ai.AiProvider
 import com.itangcent.easyapi.settings.HttpClientType
 import com.itangcent.easyapi.settings.MarkdownFormatType
 import com.itangcent.easyapi.settings.PostmanJson5FormatType
@@ -72,7 +73,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         override var aiModel: String = "",
         override var aiRequestTimeoutSec: Int = 60,
         override var aiMaxRequests: Int = 100,
-        override var aiContextWindow: Int = 0
+        override var aiContextWindow: Int = AiProvider.DEFAULT_CONTEXT_WINDOW
     ) : ApplicationSettingsSupport {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/state/SettingsSupport.kt
@@ -102,9 +102,10 @@ interface ApplicationSettingsSupport {
     /** Max requests per agent turn; asks to confirm when the limit is reached. */
     var aiMaxRequests: Int
     /**
-     * AI assistant model context window (in tokens), or `0` to auto-track the
-     * selected provider's default (see `AiProvider.contextWindow`). Used to
-     * derive the agent's token budget.
+     * AI assistant model context window (in tokens), used to derive the
+     * agent's token budget. Defaults to [com.itangcent.easyapi.ai.AiProvider.DEFAULT_CONTEXT_WINDOW];
+     * a value of `0` from legacy persisted state is treated as the provider's
+     * default at load time (see `com.itangcent.easyapi.ai.AiSettings.from`).
      */
     var aiContextWindow: Int
 

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/RulesTabPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/RulesTabPanel.kt
@@ -12,6 +12,7 @@ import com.itangcent.easyapi.ide.support.NotificationUtils
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.util.file.UniqueFileNameUtils
+import com.itangcent.easyapi.util.text.ByteSizeUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -49,13 +50,6 @@ object RuleFileSupport {
     fun fileSize(path: String): Long = runCatching {
         Files.size(Paths.get(path))
     }.getOrDefault(0L)
-
-    fun formatSize(bytes: Long): String = when {
-        bytes < 1024 -> "$bytes B"
-        bytes < 1024 * 1024 -> String.format("%.1f KB", bytes / 1024.0)
-        bytes < 1024 * 1024 * 1024 -> String.format("%.1f MB", bytes / (1024.0 * 1024.0))
-        else -> String.format("%.1f GB", bytes / (1024.0 * 1024.0 * 1024.0))
-    }
 
     /**
      * Returns the file name (last path segment).
@@ -183,7 +177,7 @@ class GlobalRulesSubTab(
             },
             object : ColumnInfo<RuleFileRow, String>("Size") {
                 override fun valueOf(item: RuleFileRow?): String? =
-                    item?.let { RuleFileSupport.formatSize(it.size) }
+                    item?.let { ByteSizeUtil.format(it.size) }
             },
             object : ColumnInfo<RuleFileRow, Boolean>("Enabled") {
                 override fun valueOf(item: RuleFileRow?): Boolean = item?.enabled ?: false
@@ -483,7 +477,7 @@ class ProjectRulesSubTab(
             },
             object : ColumnInfo<RuleFileRow, String>("Size") {
                 override fun valueOf(item: RuleFileRow?): String? =
-                    item?.let { RuleFileSupport.formatSize(it.size) }
+                    item?.let { ByteSizeUtil.format(it.size) }
             },
             object : ColumnInfo<RuleFileRow, Boolean>("Enabled") {
                 override fun valueOf(item: RuleFileRow?): Boolean = item?.enabled ?: true

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.settings.ui
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
+import com.intellij.icons.AllIcons
 import com.intellij.ui.CheckBoxList
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.*
@@ -31,6 +32,7 @@ import com.itangcent.easyapi.http.ApacheHttpClient
 import com.itangcent.easyapi.extension.ExtensionConfigRegistry
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.util.json.GsonUtils
+import com.itangcent.easyapi.util.text.ByteSizeUtil
 import com.itangcent.easyapi.settings.HttpClientType
 import com.itangcent.easyapi.settings.MarkdownFormatType
 import com.itangcent.easyapi.settings.PostmanExportMode
@@ -103,7 +105,8 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         toolTipText = "Use multiple threads for API scanning (may improve performance but is experimental)"
     }
     private val gutterIconEnabled = JBCheckBox("Show gutter icon on API methods", true).apply {
-        toolTipText = "Show a gutter icon on API methods for quick navigation to the API Dashboard. Disable if it conflicts with other plugins."
+        toolTipText =
+            "Show a gutter icon on API methods for quick navigation to the API Dashboard. Disable if it conflicts with other plugins."
     }
     private val switchNotice = JBCheckBox("Show notification on settings switch", true).apply {
         toolTipText = "Show a notification when switching between different setting profiles"
@@ -205,23 +208,11 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
             SwingUtilities.invokeLater {
                 projectCacheSizeLabel.text = when {
                     projectSize < 0 -> "N/A"
-                    else -> formatFileSize(projectSize)
+                    else -> ByteSizeUtil.format(projectSize)
                 }
                 projectCacheSizeLabel.toolTipText = null
-                globalCacheSizeLabel.text = if (globalSize < 0) "N/A" else formatFileSize(globalSize)
+                globalCacheSizeLabel.text = if (globalSize < 0) "N/A" else ByteSizeUtil.format(globalSize)
             }
-        }
-    }
-
-    /**
-     * Formats a file size in bytes to human-readable format.
-     */
-    private fun formatFileSize(size: Long): String {
-        return when {
-            size < 1024 -> "$size B"
-            size < 1024 * 1024 -> String.format("%.1f KB", size / 1024.0)
-            size < 1024 * 1024 * 1024 -> String.format("%.1f MB", size / (1024.0 * 1024.0))
-            else -> String.format("%.1f GB", size / (1024.0 * 1024.0 * 1024.0))
         }
     }
 
@@ -234,23 +225,23 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
                 TitledBorder.TOP
             )
             val toolbarDecorator = ToolbarDecorator.createDecorator(repositoryTable)
-.setAddAction {
+                .setAddAction {
                     showAddRepositoryDialog()
                 }
-.setRemoveAction {
+                .setRemoveAction {
                     val selected = repositoryTable.selectedRow
                     if (selected >= 0) {
                         repositoryTableModel.removeRow(selected)
                     }
                 }
-.setEditAction {
+                .setEditAction {
                     val selected = repositoryTable.selectedRow
                     if (selected >= 0) {
                         val config = repositoryTableModel.getItem(selected)
                         showEditRepositoryDialog(config)
                     }
                 }
-.disableUpDownActions()
+                .disableUpDownActions()
             add(toolbarDecorator.createPanel(), BorderLayout.CENTER)
         }
     }
@@ -384,25 +375,25 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
     }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addComponent(
+        .addComponent(
             createTitledPanel(
                 "Framework Support", listOf(
                     feignEnable, jaxrsEnable, actuatorEnable
                 )
             )
         )
-.addComponent(autoScanEnabled)
-.addComponent(concurrentScanEnabled)
-.addComponent(gutterIconEnabled)
-.addComponent(switchNotice)
-.addLabeledComponent("Log Level:", logLevelCombo)
-.addLabeledComponent("Output Charset:", outputCharsetCombo)
-.addComponent(outputDemoCheckBox)
-.addLabeledComponent("Markdown Format:", markdownFormatTypeCombo)
-.addComponent(createTitledPanel("Cache Management", listOf(cachePanel)))
-.addComponent(createRepositoryPanel())
-.addComponentFillVertically(JPanel(), 0)
-.panel
+        .addComponent(autoScanEnabled)
+        .addComponent(concurrentScanEnabled)
+        .addComponent(gutterIconEnabled)
+        .addComponent(switchNotice)
+        .addLabeledComponent("Log Level:", logLevelCombo)
+        .addLabeledComponent("Output Charset:", outputCharsetCombo)
+        .addComponent(outputDemoCheckBox)
+        .addLabeledComponent("Markdown Format:", markdownFormatTypeCombo)
+        .addComponent(createTitledPanel("Cache Management", listOf(cachePanel)))
+        .addComponent(createRepositoryPanel())
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
 
     override fun resetFrom(settings: Settings?) {
         feignEnable.isSelected = settings?.feignEnable ?: false
@@ -510,16 +501,16 @@ class PostmanSettingsPanel : SettingsPanel {
     }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addLabeledComponent("Postman Token:", createTokenPanel())
-.addLabeledComponent("Workspace:", createWorkspacePanel())
-.addLabeledComponent("Export Mode:", postmanExportModeCombo)
-.addComponent(postmanBuildExample)
-.addComponent(wrapCollection)
-.addComponent(autoMergeScript)
-.addLabeledComponent("JSON5 Format Type:", postmanJson5FormatTypeCombo)
-.addLabeledComponent("Collections (module:collectionId per line):", JScrollPane(postmanCollectionsField))
-.addComponentFillVertically(JPanel(), 0)
-.panel
+        .addLabeledComponent("Postman Token:", createTokenPanel())
+        .addLabeledComponent("Workspace:", createWorkspacePanel())
+        .addLabeledComponent("Export Mode:", postmanExportModeCombo)
+        .addComponent(postmanBuildExample)
+        .addComponent(wrapCollection)
+        .addComponent(autoMergeScript)
+        .addLabeledComponent("JSON5 Format Type:", postmanJson5FormatTypeCombo)
+        .addLabeledComponent("Collections (module:collectionId per line):", JScrollPane(postmanCollectionsField))
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
 
     private fun createTokenPanel(): JPanel {
         return JPanel(BorderLayout(4, 0)).apply {
@@ -694,15 +685,15 @@ class YapiSettingsPanel : SettingsPanel {
     private val yapiResBodyJson5 = JBCheckBox("Response body JSON5")
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addLabeledComponent("Yapi Server:", yapiServer)
-.addLabeledComponent("Tokens (module=token per line):", JScrollPane(yapiTokens))
-.addComponent(enableUrlTemplating)
-.addComponent(switchNotice)
-.addLabeledComponent("Export Mode:", yapiExportModeCombo)
-.addComponent(yapiReqBodyJson5)
-.addComponent(yapiResBodyJson5)
-.addComponentFillVertically(JPanel(), 0)
-.panel
+        .addLabeledComponent("Yapi Server:", yapiServer)
+        .addLabeledComponent("Tokens (module=token per line):", JScrollPane(yapiTokens))
+        .addComponent(enableUrlTemplating)
+        .addComponent(switchNotice)
+        .addLabeledComponent("Export Mode:", yapiExportModeCombo)
+        .addComponent(yapiReqBodyJson5)
+        .addComponent(yapiResBodyJson5)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
 
     override fun resetFrom(settings: Settings?) {
         yapiServer.text = settings?.yapiServer ?: ""
@@ -747,11 +738,11 @@ class HttpSettingsPanel : SettingsPanel {
     }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addLabeledComponent("HTTP Client:", httpClientCombo)
-.addLabeledComponent("Timeout (seconds):", httpTimeout)
-.addComponent(unsafeSsl)
-.addComponentFillVertically(JPanel(), 0)
-.panel
+        .addLabeledComponent("HTTP Client:", httpClientCombo)
+        .addLabeledComponent("Timeout (seconds):", httpTimeout)
+        .addComponent(unsafeSsl)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
 
     override fun resetFrom(settings: Settings?) {
         httpClientCombo.selectedItem = settings?.httpClient ?: HttpClientType.APACHE.value
@@ -787,23 +778,24 @@ class IntelligentSettingsPanel : SettingsPanel {
         toolTipText = "Use RFC 6570 URI template syntax for path variables in exported URLs (e.g., /users/{id})"
     }
     private val pathMultiCombo = ComboBox(PathSelector.values().map { it.name }.toTypedArray())
-    private val enumFieldAutoInferEnabled = JBCheckBox("Auto-infer enum value field for ambiguous references", false).apply {
-        toolTipText = buildString {
-            append("When enabled, auto-infer the enum value field for ambiguous references: ")
-            append("enum-typed fields with a single instance field, or @see references without a specific field. ")
-            append("Explicit references (@see Enum#field, @JsonValue, enum.use.custom) always work regardless of this setting.")
+    private val enumFieldAutoInferEnabled =
+        JBCheckBox("Auto-infer enum value field for ambiguous references", false).apply {
+            toolTipText = buildString {
+                append("When enabled, auto-infer the enum value field for ambiguous references: ")
+                append("enum-typed fields with a single instance field, or @see references without a specific field. ")
+                append("Explicit references (@see Enum#field, @JsonValue, enum.use.custom) always work regardless of this setting.")
+            }
         }
-    }
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addComponent(queryExpanded)
-.addComponent(formExpanded)
-.addComponent(inferReturnMain)
-.addComponent(enableUrlTemplating)
-.addLabeledComponent("Path multi-select strategy:", pathMultiCombo)
-.addComponent(enumFieldAutoInferEnabled)
-.addComponentFillVertically(JPanel(), 0)
-.panel
+        .addComponent(queryExpanded)
+        .addComponent(formExpanded)
+        .addComponent(inferReturnMain)
+        .addComponent(enableUrlTemplating)
+        .addLabeledComponent("Path multi-select strategy:", pathMultiCombo)
+        .addComponent(enumFieldAutoInferEnabled)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
 
     override fun resetFrom(settings: Settings?) {
         queryExpanded.isSelected = settings?.queryExpanded ?: true
@@ -875,9 +867,9 @@ class ExtensionConfigPanel : SettingsPanel {
         val currentSelected = selectedCodes().toSet()
         val savedSelected = ExtensionConfigRegistry.stringToCodes(s.extensionConfigs ?: "").toSet()
         val defaultEnabled = ExtensionConfigRegistry.allExtensions()
-.filter { it.defaultEnabled }
-.map { it.code }
-.toSet()
+            .filter { it.defaultEnabled }
+            .map { it.code }
+            .toSet()
         val effectiveSaved = savedSelected + defaultEnabled
         return currentSelected != effectiveSaved
     }
@@ -999,7 +991,8 @@ class RemoteConfigPanel : SettingsPanel {
         preview.putClientProperty("url", target)
         preview.text = "Loading..."
         thread {
-            val content = runCatching { java.net.URI(target).toURL().readText() }.getOrElse { "Load failed: ${it.message}" }
+            val content =
+                runCatching { java.net.URI(target).toURL().readText() }.getOrElse { "Load failed: ${it.message}" }
             SwingUtilities.invokeLater {
                 if (list.selectedIndex == index) {
                     preview.text = content
@@ -1027,7 +1020,8 @@ class RemoteConfigPanel : SettingsPanel {
 class AiAssistantSection : SettingsPanel {
 
     private val providerCombo = ComboBox(AiProvider.values().map { it.displayName }.toTypedArray()).apply {
-        toolTipText = "Pick your LLM provider. Use 'Custom (OpenAI-compatible)' for a LiteLLM proxy, LM Studio, or vLLM."
+        toolTipText =
+            "Pick your LLM provider. Use 'Custom (OpenAI-compatible)' for a LiteLLM proxy, LM Studio, or vLLM."
     }
     private val baseUrlField = JBTextField().apply {
         columns = 28
@@ -1035,7 +1029,39 @@ class AiAssistantSection : SettingsPanel {
     }
     private val apiKeyField = JBPasswordField().apply {
         columns = 28
-        toolTipText = "Stored securely in PasswordSafe; never written to settings XML. Optional for providers that don't require a key."
+        toolTipText =
+            "Stored securely in PasswordSafe; never written to settings XML. Optional for providers that don't require a key."
+    }
+
+    /**
+     * Default masking character for [apiKeyField], captured once so the eye
+     * toggle can restore it after revealing (the LaF's echo char, not a
+     * hard-coded bullet).
+     */
+    private val apiKeyEchoChar: Char = apiKeyField.echoChar
+
+    /**
+     * Toggle that reveals [apiKeyField]'s value by clearing its echo char, and
+     * re-masks by restoring it. Holding the key visible is a deliberate user
+     * action; the default is masked.
+     */
+    private val revealApiKeyButton: JButton = JButton().apply {
+        icon = AllIcons.Actions.Preview
+        toolTipText = "Show API key"
+        isFocusable = false
+        margin = Insets(0, 2, 0, 2)
+        addActionListener {
+            val revealed = apiKeyField.echoChar == 0.toChar()
+            if (revealed) {
+                apiKeyField.echoChar = apiKeyEchoChar
+                icon = AllIcons.Actions.Preview
+                toolTipText = "Show API key"
+            } else {
+                apiKeyField.echoChar = 0.toChar()
+                icon = AllIcons.Actions.PreviewDetails
+                toolTipText = "Hide API key"
+            }
+        }
     }
     private val modelField = JBTextField().apply {
         columns = 22
@@ -1045,10 +1071,28 @@ class AiAssistantSection : SettingsPanel {
         toolTipText = "LLM request timeout in seconds (default 60)."
     }
     private val maxAgentStepsSpinner = JBIntSpinner(100, 1, 1000).apply {
-        toolTipText = "The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue."
+        toolTipText =
+            "The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue."
     }
-    private val contextWindowSpinner = JBIntSpinner(0, 0, 1_000_000).apply {
-        toolTipText = "Model context window in tokens. 0 = auto (use the provider's default). Used to derive how much conversation history the agent keeps."
+
+    /**
+     * Dropdown option for the Context Window combo. [tokens] is the stored
+     * value; [label] is shown in the UI. The presets themselves live in
+     * [com.itangcent.easyapi.ai.TokenSizeUtils].
+     */
+    data class ContextWindowOption(val tokens: Int, val label: String) {
+        override fun toString(): String = label
+    }
+
+    private val contextWindowOptions: Array<ContextWindowOption> =
+        com.itangcent.easyapi.ai.TokenSizeUtils.presets
+            .map { label -> ContextWindowOption(com.itangcent.easyapi.ai.TokenSizeUtils.parse(label), label) }
+            .toTypedArray()
+
+    private val contextWindowCombo = ComboBox(contextWindowOptions).apply {
+        isEditable = true
+        toolTipText =
+            "Model context window in tokens. Used to derive how much conversation history the agent keeps."
     }
     private val testConnectionButton = JButton("Test Connection").apply {
         toolTipText = "Send a tiny request to verify the provider, key, and model."
@@ -1069,12 +1113,14 @@ class AiAssistantSection : SettingsPanel {
     private var userEditedBaseUrl = false
     private var userEditedModel = false
     private var userEditedApiKey = false
+
     /**
      * When true, the user manually changed the Context Window spinner, so
      * provider-switch auto-fill no longer touches it. Reset to false in
      * `resetFrom` after the spinner is programmatically set.
      */
     private var userEditedContextWindow = false
+
     /**
      * When true, document listeners on baseUrl/model/apiKey fields are
      * suppressed so programmatic updates (e.g. `preFillFromHit`,
@@ -1083,66 +1129,141 @@ class AiAssistantSection : SettingsPanel {
     private var suppressUserEditedListeners = false
 
     override val component: JComponent = FormBuilder.createFormBuilder()
-.addComponent(createTitledPanel("AI Assistant", listOf(
+        .addComponent(
+            createTitledPanel(
+                "AI Assistant", listOf(
             compactRow("Provider:", providerCombo),
             compactRow("Base URL:", baseUrlField),
-            compactRow("API Key:", apiKeyField),
+            compactRow("API Key:", apiKeyField, revealApiKeyButton),
             compactRow("Model:", modelField),
             compactRow("Request Timeout (sec):", timeoutSpinner),
             compactRow("Max Requests:", maxAgentStepsSpinner),
-            compactRow("Context Window:", contextWindowSpinner),
+            compactRow("Context Window:", contextWindowCombo),
             JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)).apply {
                 add(testConnectionButton)
                 add(autoDetectButton)
             },
             JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)).apply { add(statusLabel) }
         )))
-.panel
+        .panel
 
     init {
         testConnectionButton.addActionListener { onTestConnectionClicked() }
 
         providerCombo.addActionListener {
             val provider = currentProvider()
+            preFillProviderDefaults(provider)
+            updateContextWindowTooltip(provider)
+        }
+
+        baseUrlField.document.addDocumentListener(simpleDocListener {
+            if (!suppressUserEditedListeners) userEditedBaseUrl = true
+        })
+        modelField.document.addDocumentListener(simpleDocListener {
+            if (!suppressUserEditedListeners) userEditedModel = true
+        })
+        apiKeyField.document.addDocumentListener(simpleDocListener {
+            if (!suppressUserEditedListeners) userEditedApiKey = true
+        })
+        contextWindowCombo.addActionListener {
+            if (!suppressUserEditedListeners) {
+                userEditedContextWindow = true
+            }
+        }
+        // Also mark as edited when the user types a custom value in the editor.
+        (contextWindowCombo.editor.editorComponent as? JTextField)?.document?.addDocumentListener(
+            simpleDocListener { if (!suppressUserEditedListeners) userEditedContextWindow = true }
+        )
+
+        autoDetectButton.addActionListener { onAutoDetectClicked() }
+    }
+
+    /**
+     * Reflects the provider's default context window in the combo tooltip so a
+     * user who hasn't touched the field can see the provider's typical value.
+     */
+    private fun updateContextWindowTooltip(provider: AiProvider) {
+        val eff = provider.contextWindow
+        contextWindowCombo.toolTipText =
+            "Model context window in tokens. ${provider.displayName} default is $eff. " +
+                    "Used to derive how much conversation history the agent keeps."
+    }
+
+    /**
+     * Pre-fills base URL, model, and context window from the [provider]'s
+     * defaults — but only for fields the user hasn't manually edited. A real
+     * custom edit is sticky and survives provider switches; programmatic fills
+     * (here, or from `reset`/auto-detect) don't count as edits.
+     *
+     * Edit-tracking is suppressed around the writes so the fields' own document
+     * listeners don't latch `userEdited*` to `true` on a provider switch — that
+     * would otherwise make the pre-fill stick only on the *first* switch.
+     *
+     * The API key is always cleared on switch: a key is specific to a provider,
+     * so reusing it against a different one would just produce a 401. The user
+     * can re-enter it (or use Auto-detect). Recovery: cancelling the dialog
+     * abandons the clear, since PasswordSafe is only written on Apply.
+     */
+    private fun preFillProviderDefaults(provider: AiProvider) {
+        val previous = suppressUserEditedListeners
+        suppressUserEditedListeners = true
+        try {
             if (!userEditedBaseUrl) {
                 baseUrlField.text = provider.defaultBaseUrl ?: ""
             }
             if (!userEditedModel) {
                 modelField.text = provider.defaultModel ?: ""
             }
-            // Context Window: when left on "auto", keep tracking the provider's
-            // default — just update the tooltip so the user sees the effective
-            // value. The stored value stays 0 (auto) until the user edits it.
+            // Auto-set the context window to the provider's default when the
+            // user hasn't manually edited it. This makes the effective token
+            // budget visible in the UI.
             if (!userEditedContextWindow) {
-                updateContextWindowTooltip(provider)
+                setContextWindowValue(provider.contextWindow)
             }
+            // Always clear: a key is provider-specific. Latching userEditedApiKey
+            // would freeze it empty, so we DON'T set that flag here — the field's
+            // own listener does, but only on a real keystroke (the empty string
+            // write is suppressed above).
+            apiKeyField.text = ""
+        } finally {
+            suppressUserEditedListeners = previous
         }
-
-        baseUrlField.document.addDocumentListener(simpleDocListener { if (!suppressUserEditedListeners) userEditedBaseUrl = true })
-        modelField.document.addDocumentListener(simpleDocListener { if (!suppressUserEditedListeners) userEditedModel = true })
-        apiKeyField.document.addDocumentListener(simpleDocListener { if (!suppressUserEditedListeners) userEditedApiKey = true })
-        contextWindowSpinner.addChangeListener {
-            // The spinner fires change events during programmatic set in
-            // resetFrom; gate the flag on a real user value difference.
-            if (!suppressUserEditedListeners && contextWindowSpinner.value != null) {
-                userEditedContextWindow = true
-            }
-        }
-
-        autoDetectButton.addActionListener { onAutoDetectClicked() }
     }
 
     /**
-     * Reflects the provider's default context window in the spinner tooltip.
-     * The spinner value stays 0 (auto); only the tooltip shows the effective
-     * token count, so a user who hasn't touched the field can see what "auto"
-     * resolves to for the current provider.
+     * Sets the context window combo to [tokens]. If [tokens] matches a preset,
+     * the preset is selected; otherwise the raw number is placed in the
+     * editable editor. Listeners are suppressed so programmatic sets don't
+     * mark the field as user-edited.
      */
-    private fun updateContextWindowTooltip(provider: AiProvider) {
-        val eff = provider.contextWindow
-        contextWindowSpinner.toolTipText =
-            "Model context window in tokens. 0 = auto (currently $eff for ${provider.displayName}). " +
-                "Used to derive how much conversation history the agent keeps."
+    private fun setContextWindowValue(tokens: Int) {
+        val previous = suppressUserEditedListeners
+        suppressUserEditedListeners = true
+        try {
+            val match = contextWindowOptions.firstOrNull { it.tokens == tokens }
+            if (match != null) {
+                contextWindowCombo.selectedItem = match
+            } else {
+                contextWindowCombo.selectedItem = tokens.toString()
+            }
+        } finally {
+            suppressUserEditedListeners = previous
+        }
+    }
+
+    /**
+     * Reads the current context window value from the combo. Handles preset
+     * selections, raw integer strings, and "8k"/"1m" style shorthand via
+     * [com.itangcent.easyapi.ai.TokenSizeUtils.parse].
+     */
+    private fun contextWindowValue(): Int {
+        val item = contextWindowCombo.selectedItem ?: return 0
+        return when (item) {
+            is ContextWindowOption -> item.tokens
+            is Number -> item.toInt()
+            is String -> com.itangcent.easyapi.ai.TokenSizeUtils.parse(item)
+            else -> 0
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -1181,7 +1302,7 @@ class AiAssistantSection : SettingsPanel {
 
         com.itangcent.easyapi.core.threading.backgroundAsync {
             val result = runCatching { aiServiceFactory(settings).testConnection() }
-.getOrElse { Result.failure(it) }
+                .getOrElse { Result.failure(it) }
             com.itangcent.easyapi.core.threading.swingAsync {
                 testConnectionButton.isEnabled = true
                 testConnectionButton.text = previousLabel
@@ -1232,7 +1353,7 @@ class AiAssistantSection : SettingsPanel {
 
         com.itangcent.easyapi.core.threading.backgroundAsync {
             val result = runCatching { credentialScanner.scan() }
-.getOrElse {
+                .getOrElse {
                     com.itangcent.easyapi.core.threading.swingAsync {
                         setStatus("Auto-detect failed: ${it.message}", ok = false)
                     }
@@ -1263,6 +1384,7 @@ class AiAssistantSection : SettingsPanel {
                     ok = true
                 )
             }
+
             is DetectionResult.Hit -> {
                 preFillFromHit(result)
                 setStatus(
@@ -1270,12 +1392,13 @@ class AiAssistantSection : SettingsPanel {
                     ok = true
                 )
             }
+
             is DetectionResult.MultipleFound -> {
                 preFillFromHit(result.primary)
                 val others = result.others.joinToString(", ") { "${it.provider.displayName} (${it.sourceLabel})" }
                 setStatus(
                     "Detected ${result.primary.provider.displayName} from ${result.primary.sourceLabel}. " +
-                        "Also found: $others. Apply to save, or switch provider manually.",
+                            "Also found: $others. Apply to save, or switch provider manually.",
                     ok = true
                 )
             }
@@ -1316,21 +1439,17 @@ class AiAssistantSection : SettingsPanel {
         modelField.text = s.aiModel
         timeoutSpinner.value = s.aiRequestTimeoutSec.coerceIn(5, 300)
         maxAgentStepsSpinner.value = s.aiMaxRequests.coerceIn(1, 1000)
-        suppressUserEditedListeners = true
-        try {
-            contextWindowSpinner.value = s.aiContextWindow.coerceIn(0, 1_000_000)
-        } finally {
-            suppressUserEditedListeners = false
-        }
+        setContextWindowValue(s.aiContextWindow)
         updateContextWindowTooltip(provider)
         // API key from PasswordSafe
         apiKeyField.text = passwordSafe()
-.getPassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key")
+            .getPassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key")
             ?.toString() ?: ""
         // Reset edit flags AFTER writing fields — the document listeners above would
         // have set them to true.
         userEditedBaseUrl = false
         userEditedModel = false
+        userEditedApiKey = false
         userEditedContextWindow = false
     }
 
@@ -1341,11 +1460,11 @@ class AiAssistantSection : SettingsPanel {
         settings.aiModel = modelField.text.trim()
         settings.aiRequestTimeoutSec = (timeoutSpinner.value as Number).toInt()
         settings.aiMaxRequests = (maxAgentStepsSpinner.value as Number).toInt()
-        settings.aiContextWindow = (contextWindowSpinner.value as Number).toInt()
+        settings.aiContextWindow = contextWindowValue()
         // API key to PasswordSafe
         val key = String(apiKeyField.password)
         passwordSafe()
-.storePassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key", key)
+            .storePassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key", key)
     }
 
     override fun isModified(settings: Settings?): Boolean {
@@ -1356,16 +1475,16 @@ class AiAssistantSection : SettingsPanel {
         if (modelField.text.trim() != s.aiModel) return true
         if ((timeoutSpinner.value as Number).toInt() != s.aiRequestTimeoutSec) return true
         if ((maxAgentStepsSpinner.value as Number).toInt() != s.aiMaxRequests) return true
-        if ((contextWindowSpinner.value as Number).toInt() != s.aiContextWindow) return true
+        if (contextWindowValue() != s.aiContextWindow) return true
         // Password field — compare against PasswordSafe
         val storedKey = passwordSafe()
-.getPassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key")
+            .getPassword(null, com.itangcent.easyapi.ai.AiSettings::class.java, "ai-api-key")
             ?.toString() ?: ""
         if (String(apiKeyField.password) != storedKey) return true
         return false
     }
 
-    private fun compactRow(label: String, field: JComponent): JComponent {
+    private fun compactRow(label: String, field: JComponent, vararg extras: JComponent): JComponent {
         val panel = JPanel(FlowLayout(FlowLayout.LEFT, 6, 2))
         if (label.isNotEmpty()) {
             val l = JLabel(label)
@@ -1373,6 +1492,7 @@ class AiAssistantSection : SettingsPanel {
             panel.add(l)
         }
         panel.add(field)
+        extras.forEach { panel.add(it) }
         return panel
     }
 
@@ -1403,16 +1523,17 @@ class AiAssistantSection : SettingsPanel {
         providerCombo.selectedIndex = provider.ordinal
         // In headless test environments, JComboBox may not fire ActionEvent.
         // Perform the same pre-fill the action listener does.
-        if (!userEditedBaseUrl) {
-            baseUrlField.text = provider.defaultBaseUrl ?: ""
-        }
-        if (!userEditedModel) {
-            modelField.text = provider.defaultModel ?: ""
-        }
+        preFillProviderDefaults(provider)
+        updateContextWindowTooltip(provider)
     }
 
     internal fun setBaseUrl(url: String) {
         baseUrlField.text = url
+    }
+
+    /** Simulates a user typing the API key (marks the field as edited). */
+    internal fun setApiKey(key: String) {
+        apiKeyField.text = key
     }
 
     internal fun setModel(model: String) {
@@ -1428,7 +1549,9 @@ class AiAssistantSection : SettingsPanel {
     }
 
     internal fun setContextWindow(tokens: Int) {
-        contextWindowSpinner.value = tokens
+        // Simulates a user edit: mark as edited, then set the combo value.
+        userEditedContextWindow = true
+        setContextWindowValue(tokens)
     }
 
     // --- Auto-detect test helpers (used by AiAssistantSectionAutoDetectTest) ---
@@ -1438,6 +1561,14 @@ class AiAssistantSection : SettingsPanel {
 
     /** Returns the current API key field text (test-only). */
     internal fun apiKeyText(): String = String(apiKeyField.password)
+
+    /** Whether the API key is currently shown in clear text (test-only). */
+    internal fun isApiKeyRevealedForTest(): Boolean = apiKeyField.echoChar == 0.toChar()
+
+    /** Simulates clicking the reveal toggle (test-only). */
+    internal fun toggleRevealApiKeyForTest() {
+        revealApiKeyButton.doClick()
+    }
 
     /** Returns the current base URL text (test-only). */
     internal fun baseUrlText(): String = baseUrlField.text

--- a/src/main/kotlin/com/itangcent/easyapi/util/text/ByteSizeUtil.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/text/ByteSizeUtil.kt
@@ -1,0 +1,75 @@
+package com.itangcent.easyapi.util.text
+
+/**
+ * Pure parser/formatter for human-friendly **byte** size strings using
+ * **binary** multipliers (`KB` → 1024, `MB` → 1024², `GB` → 1024³).
+ *
+ * Accepts (case-insensitive, surrounding whitespace ignored):
+ * - `"1024"`, `"1,024"` → `1024`
+ * - `"1k"`, `"1K"`, `"1kb"`, `"1KB"` → `1024`
+ * - `"1m"`, `"1MB"` → `1_048_576`
+ * - `"1g"`, `"1GB"` → `1_073_741_824`
+ * - `"1 KB"` (with space) → `1024`
+ *
+ * Returns `0` for any unparseable input rather than throwing, so the
+ * caller can fall back to a safe default.
+ *
+ * Multipliers are binary (1024) — this is the convention for file/cache
+ * sizes. For token counts (decimal, 1000) use
+ * [com.itangcent.easyapi.ai.TokenSizeUtils].
+ */
+object ByteSizeUtil {
+
+    private const val KB: Long = 1024L
+    private const val MB: Long = KB * 1024
+    private const val GB: Long = MB * 1024
+
+    /**
+     * Parses a free-form byte-size string into a [Long].
+     *
+     * Accepts plain integers (`"1024"`), comma-grouped integers
+     * (`"1,024"`), shorthand with binary suffixes (`"1k"`, `"1KB"`,
+     * `"1MB"`, `"1GB"`), and space-separated forms (`"1 KB"`,
+     * `"1.5 KB"`). Decimal numbers are rounded to the nearest byte.
+     *
+     * Returns `0` for blank or unparseable input. Negative numbers are
+     * passed through unclamped — callers own clamping.
+     */
+    fun parse(text: String): Long {
+        // Strip commas and all whitespace so "1,024", "1 KB", and "1.0 KB" all work.
+        val cleaned = text.trim().replace(",", "").replace(Regex("\\s+"), "")
+        if (cleaned.isEmpty()) return 0L
+
+        val lower = cleaned.lowercase()
+        // Order matters: check two-char suffixes (kb/mb/gb) before single-char (k/m/g/b).
+        val (multiplier, suffixLen) = when {
+            lower.endsWith("gb") -> GB to 2
+            lower.endsWith("mb") -> MB to 2
+            lower.endsWith("kb") -> KB to 2
+            lower.endsWith("g") -> GB to 1
+            lower.endsWith("m") -> MB to 1
+            lower.endsWith("k") -> KB to 1
+            lower.endsWith("b") -> 1L to 1 // bytes — strip the unit
+            else -> 1L to 0
+        }
+        val numStr = if (suffixLen > 0) lower.dropLast(suffixLen) else lower
+        // Use double to handle formatted output like "1.5" from format().
+        val n = numStr.toDoubleOrNull() ?: return 0L
+        return (n * multiplier).toLong()
+    }
+
+    /**
+     * Formats a byte count into a human-readable string using binary
+     * multipliers (B, KB, MB, GB), keeping one decimal place for the
+     * scaled units.
+     *
+     * Examples: `0` → `"0 B"`, `1023` → `"1023 B"`, `1024` → `"1.0 KB"`,
+     * `1536` → `"1.5 KB"`, `2_097_152` → `"2.0 MB"`.
+     */
+    fun format(bytes: Long): String = when {
+        bytes < KB -> "$bytes B"
+        bytes < MB -> String.format("%.1f KB", bytes / KB.toDouble())
+        bytes < GB -> String.format("%.1f MB", bytes / MB.toDouble())
+        else -> String.format("%.1f GB", bytes / GB.toDouble())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/TokenSizeUtilsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/TokenSizeUtilsTest.kt
@@ -1,0 +1,149 @@
+package com.itangcent.easyapi.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [TokenSizeUtils]. Covers the AI-specific preset
+ * list and the decimal (x1000) parser.
+ */
+class TokenSizeUtilsTest {
+
+    // --- presets list ---
+
+    @Test
+    fun testPresetsAreSimpleShorthandStrings() {
+        assertEquals(
+            listOf("8k", "16k", "32k", "64k", "128k", "200k", "500k", "1m", "2m"),
+            TokenSizeUtils.presets
+        )
+    }
+
+    @Test
+    fun testPresetsHaveUniqueLabels() {
+        assertEquals(
+            "preset labels must be unique",
+            TokenSizeUtils.presets.toSet().size,
+            TokenSizeUtils.presets.size
+        )
+    }
+
+    @Test
+    fun testPresetsHaveNonBlankLabels() {
+        TokenSizeUtils.presets.forEach { label ->
+            assertTrue("label must be non-blank: '$label'", label.isNotBlank())
+        }
+    }
+
+    // --- parse(): bare numbers ---
+
+    @Test
+    fun testParseEmptyStringReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse(""))
+    }
+
+    @Test
+    fun testParseBlankStringReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse("   "))
+    }
+
+    @Test
+    fun testParsePlainNumber() {
+        assertEquals(8000, TokenSizeUtils.parse("8000"))
+    }
+
+    @Test
+    fun testParsePlainNumberWithSurroundingWhitespace() {
+        assertEquals(128_000, TokenSizeUtils.parse("  128000  "))
+    }
+
+    @Test
+    fun testParseCommaGroupedNumber() {
+        assertEquals(8_000, TokenSizeUtils.parse("8,000"))
+        assertEquals(1_000_000, TokenSizeUtils.parse("1,000,000"))
+    }
+
+    // --- parse(): k/m shorthand (decimal multipliers, x1000) ---
+
+    @Test
+    fun testParseLowercaseKShorthand() {
+        assertEquals(8_000, TokenSizeUtils.parse("8k"))
+        assertEquals(128_000, TokenSizeUtils.parse("128k"))
+    }
+
+    @Test
+    fun testParseUppercaseKShorthand() {
+        assertEquals(8_000, TokenSizeUtils.parse("8K"))
+        assertEquals(128_000, TokenSizeUtils.parse("128K"))
+    }
+
+    @Test
+    fun testParseLowercaseMShorthand() {
+        assertEquals(1_000_000, TokenSizeUtils.parse("1m"))
+        assertEquals(2_000_000, TokenSizeUtils.parse("2m"))
+    }
+
+    @Test
+    fun testParseUppercaseMShorthand() {
+        assertEquals(1_000_000, TokenSizeUtils.parse("1M"))
+    }
+
+    @Test
+    fun testParseShorthandWithWhitespace() {
+        assertEquals(8_000, TokenSizeUtils.parse("  8k  "))
+    }
+
+    // --- parse(): labels (e.g. "8k (8,000)") — first token only ---
+
+    @Test
+    fun testParseLabelK() {
+        assertEquals(8_000, TokenSizeUtils.parse("8k (8,000)"))
+        assertEquals(200_000, TokenSizeUtils.parse("200k (200,000)"))
+    }
+
+    @Test
+    fun testParseLabelM() {
+        assertEquals(1_000_000, TokenSizeUtils.parse("1M (1,000,000)"))
+    }
+
+    // --- parse(): invalid input ---
+
+    @Test
+    fun testParseNonNumericReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse("abc"))
+    }
+
+    @Test
+    fun testParseKShorthandWithoutNumberReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse("k"))
+    }
+
+    @Test
+    fun testParseMShorthandWithoutNumberReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse("m"))
+    }
+
+    @Test
+    fun testParseNegativeNumberIsPassedThrough() {
+        // Negative context windows are nonsensical, but the parser does not
+        // clamp — callers own clamping.
+        assertEquals(-1, TokenSizeUtils.parse("-1"))
+    }
+
+    @Test
+    fun testParseMixedAlphaSuffixReturnsZero() {
+        assertEquals(0, TokenSizeUtils.parse("8kk"))
+        assertEquals(0, TokenSizeUtils.parse("8km"))
+    }
+
+    // --- round-trip: parse(preset) is positive for every preset ---
+
+    @Test
+    fun testParseEveryPresetResolvesToPositiveTokens() {
+        TokenSizeUtils.presets.forEach { label ->
+            val tokens = TokenSizeUtils.parse(label)
+            assertTrue("parse('$label') should be positive, got $tokens", tokens > 0)
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/state/ApplicationSettingsStateTest.kt
@@ -167,7 +167,7 @@ class ApplicationSettingsStateTest {
         assertEquals("", s.aiModel)
         assertEquals(60, s.aiRequestTimeoutSec)
         assertEquals(100, s.aiMaxRequests)
-        assertEquals(0, s.aiContextWindow)
+        assertEquals(128_000, s.aiContextWindow)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/AiAssistantSectionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/AiAssistantSectionTest.kt
@@ -21,8 +21,8 @@ class AiAssistantSectionTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals(AiProvider.OPENAI.name, settings.aiProvider)
         assertEquals(60, settings.aiRequestTimeoutSec)
         assertEquals(100, settings.aiMaxRequests)
-        // Default context window is 0 (auto = track provider default).
-        assertEquals(0, settings.aiContextWindow)
+        // Default context window is the provider default (128_000).
+        assertEquals(128_000, settings.aiContextWindow)
     }
 
     fun testProviderSwitchPreFillsDefaults() {
@@ -38,6 +38,48 @@ class AiAssistantSectionTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertEquals(AiProvider.OLLAMA.name, settings.aiProvider)
         assertEquals(AiProvider.OLLAMA.defaultBaseUrl, settings.aiBaseUrl)
         assertEquals(AiProvider.OLLAMA.defaultModel, settings.aiModel)
+    }
+
+    /**
+     * Regression: a programmatic provider switch used to latch the
+     * `userEdited*` flags (via the fields' own document listeners), so the
+     * pre-fill only stuck on the *first* switch. Switching providers twice
+     * must keep pre-filling base URL + model until the user edits a field.
+     */
+    fun testProviderSwitchTwiceKeepsPreFilling() {
+        val section = AiAssistantSection()
+        val settings = Settings()
+        section.resetFrom(settings)
+
+        // First switch: OLLAMA defaults appear.
+        section.selectProvider(AiProvider.OLLAMA)
+        assertEquals(AiProvider.OLLAMA.defaultBaseUrl, section.baseUrlText())
+        assertEquals(AiProvider.OLLAMA.defaultModel, section.modelText())
+
+        // Second switch: GEMINI defaults must also appear (the bug froze the fields).
+        section.selectProvider(AiProvider.GEMINI)
+        assertEquals(AiProvider.GEMINI.defaultBaseUrl ?: "", section.baseUrlText())
+        assertEquals(AiProvider.GEMINI.defaultModel ?: "", section.modelText())
+    }
+
+    /**
+     * A real manual edit is sticky: once the user types a custom base URL,
+     * subsequent provider switches leave it alone.
+     */
+    fun testManualEditSticksAcrossProviderSwitch() {
+        val section = AiAssistantSection()
+        val settings = Settings()
+        section.resetFrom(settings)
+
+        section.selectProvider(AiProvider.CUSTOM)
+        section.setBaseUrl("http://my-litellm:4000/v1") // user edit
+        section.selectProvider(AiProvider.OPENAI)
+
+        assertEquals(
+            "manually edited base URL must survive a provider switch",
+            "http://my-litellm:4000/v1",
+            section.baseUrlText()
+        )
     }
 
     fun testCustomFieldsRoundTrip() {
@@ -79,6 +121,60 @@ class AiAssistantSectionTest : EasyApiLightCodeInsightFixtureTestCase() {
         section.resetFrom(roundTripped)
         assertFalse("after round-trip nothing modified", section.isModified(roundTripped))
         assertEquals(200_000, roundTripped.aiContextWindow)
+    }
+
+    // --- API key: provider switch clears it ---
+
+    /**
+     * Switching provider always clears the API key — a key is provider-specific
+     * and reusing it would just produce a 401.
+     */
+    fun testProviderSwitchClearsApiKey() {
+        val section = AiAssistantSection()
+        val settings = Settings()
+        section.resetFrom(settings)
+
+        section.setApiKey("sk-original")
+        assertEquals("sk-original", section.apiKeyText())
+
+        section.selectProvider(AiProvider.OLLAMA)
+        assertEquals("API key should be cleared on provider switch", "", section.apiKeyText())
+    }
+
+    /**
+     * The clear must not latch `userEditedApiKey`: a later Auto-detect hit
+     * should still be able to pre-fill the key.
+     */
+    fun testProviderSwitchClearDoesNotLatchEditedFlag() {
+        val section = AiAssistantSection()
+        val settings = Settings()
+        section.resetFrom(settings)
+
+        section.selectProvider(AiProvider.OLLAMA) // clears (empty) key, must not latch
+        section.setApiKey("sk-after")
+        assertEquals("a manual edit after a switch still works", "sk-after", section.apiKeyText())
+    }
+
+    // --- API key: eye-icon reveal toggle ---
+
+    fun testApiKeyMaskedByDefault() {
+        val section = AiAssistantSection()
+        section.resetFrom(Settings())
+        assertFalse("API key must be masked by default", section.isApiKeyRevealedForTest())
+    }
+
+    fun testRevealToggleShowsThenHidesApiKey() {
+        val section = AiAssistantSection()
+        section.resetFrom(Settings())
+        section.setApiKey("sk-secret")
+
+        section.toggleRevealApiKeyForTest()
+        assertTrue("key should be revealed after toggling", section.isApiKeyRevealedForTest())
+        assertEquals("reveal must not alter the value", "sk-secret", section.apiKeyText())
+
+        section.toggleRevealApiKeyForTest()
+        assertFalse("key should be re-masked on second toggle", section.isApiKeyRevealedForTest())
+        assertEquals("re-mask must not alter the value", "sk-secret", section.apiKeyText())
     }
 
     // --- Test Connection ---

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/RuleFileSupportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/RuleFileSupportTest.kt
@@ -8,7 +8,11 @@ import java.nio.file.Files
 
 /**
  * Unit tests for the pure-logic helpers in [RuleFileSupport]
- * (`formatSize`, `nameOf`, `fileSize`, `nextAvailableName`).
+ * (`nameOf`, `fileSize`, `nextAvailableName`).
+ *
+ * Byte-size formatting (`formatSize`) has been consolidated into
+ * [com.itangcent.easyapi.util.text.ByteSizeUtil] — see
+ * [com.itangcent.easyapi.util.text.ByteSizeUtilTest] for coverage.
  *
  * The UI-touched helpers (`copyPathToClipboard`, `deleteFile`,
  * `installRowInteractions`) require an IntelliJ [com.intellij.openapi.project.Project]
@@ -19,37 +23,6 @@ class RuleFileSupportTest {
 
     @get:Rule
     val tempFolder = TemporaryFolder()
-
-    // --- formatSize ---
-
-    @Test
-    fun formatSizeBytesUnderOneKb() {
-        assertEquals("0 B", RuleFileSupport.formatSize(0))
-        assertEquals("1 B", RuleFileSupport.formatSize(1))
-        assertEquals("512 B", RuleFileSupport.formatSize(512))
-        assertEquals("1023 B", RuleFileSupport.formatSize(1023))
-    }
-
-    @Test
-    fun formatSizeKilobytes() {
-        assertEquals("1.0 KB", RuleFileSupport.formatSize(1024))
-        assertEquals("1.5 KB", RuleFileSupport.formatSize(1536))
-        assertEquals("512.0 KB", RuleFileSupport.formatSize(512 * 1024))
-    }
-
-    @Test
-    fun formatSizeMegabytes() {
-        val oneMb = 1024L * 1024
-        assertEquals("1.0 MB", RuleFileSupport.formatSize(oneMb))
-        assertEquals("2.5 MB", RuleFileSupport.formatSize(oneMb * 5 / 2))
-    }
-
-    @Test
-    fun formatSizeGigabytes() {
-        val oneGb = 1024L * 1024 * 1024
-        assertEquals("1.0 GB", RuleFileSupport.formatSize(oneGb))
-        assertEquals("2.0 GB", RuleFileSupport.formatSize(oneGb * 2))
-    }
 
     // --- nameOf ---
 

--- a/src/test/kotlin/com/itangcent/easyapi/util/text/ByteSizeUtilTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/text/ByteSizeUtilTest.kt
@@ -1,0 +1,203 @@
+package com.itangcent.easyapi.util.text
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure unit tests for [ByteSizeUtil]. No IntelliJ fixture needed — the
+ * helper is a pure function with no Swing/PSI dependency.
+ */
+class ByteSizeUtilTest {
+
+    // --- parse(): bare numbers ---
+
+    @Test
+    fun testParseEmptyStringReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse(""))
+    }
+
+    @Test
+    fun testParseBlankStringReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("   "))
+    }
+
+    @Test
+    fun testParseZeroReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("0"))
+    }
+
+    @Test
+    fun testParsePlainNumber() {
+        assertEquals(1024L, ByteSizeUtil.parse("1024"))
+    }
+
+    @Test
+    fun testParsePlainNumberWithSurroundingWhitespace() {
+        assertEquals(128_000L, ByteSizeUtil.parse("  128000  "))
+    }
+
+    @Test
+    fun testParseCommaGroupedNumber() {
+        assertEquals(1_024L, ByteSizeUtil.parse("1,024"))
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1,048,576"))
+    }
+
+    // --- parse(): k/kb shorthand (binary multipliers, x1024) ---
+
+    @Test
+    fun testParseLowercaseKShorthand() {
+        assertEquals(1024L, ByteSizeUtil.parse("1k"))
+        assertEquals(8192L, ByteSizeUtil.parse("8k"))
+    }
+
+    @Test
+    fun testParseUppercaseKShorthand() {
+        assertEquals(1024L, ByteSizeUtil.parse("1K"))
+        assertEquals(8192L, ByteSizeUtil.parse("8K"))
+    }
+
+    @Test
+    fun testParseLowercaseKbShorthand() {
+        assertEquals(1024L, ByteSizeUtil.parse("1kb"))
+        assertEquals(8192L, ByteSizeUtil.parse("8kb"))
+    }
+
+    @Test
+    fun testParseUppercaseKbShorthand() {
+        assertEquals(1024L, ByteSizeUtil.parse("1KB"))
+        assertEquals(8192L, ByteSizeUtil.parse("8KB"))
+    }
+
+    // --- parse(): m/mb shorthand (binary multipliers) ---
+
+    @Test
+    fun testParseLowercaseMShorthand() {
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1m"))
+    }
+
+    @Test
+    fun testParseUppercaseMShorthand() {
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1M"))
+    }
+
+    @Test
+    fun testParseMbShorthand() {
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1MB"))
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1mb"))
+    }
+
+    // --- parse(): g/gb shorthand (binary multipliers) ---
+
+    @Test
+    fun testParseLowercaseGShorthand() {
+        assertEquals(1_073_741_824L, ByteSizeUtil.parse("1g"))
+    }
+
+    @Test
+    fun testParseUppercaseGShorthand() {
+        assertEquals(1_073_741_824L, ByteSizeUtil.parse("1G"))
+    }
+
+    @Test
+    fun testParseGbShorthand() {
+        assertEquals(1_073_741_824L, ByteSizeUtil.parse("1GB"))
+        assertEquals(1_073_741_824L, ByteSizeUtil.parse("1gb"))
+    }
+
+    // --- parse(): whitespace between number and unit ---
+
+    @Test
+    fun testParseShorthandWithSpace() {
+        assertEquals(1024L, ByteSizeUtil.parse("1 KB"))
+        assertEquals(1_048_576L, ByteSizeUtil.parse("1 MB"))
+    }
+
+    @Test
+    fun testParseDecimalFormattedInput() {
+        // format() produces decimals like "1.5 KB" — parse should round-trip.
+        assertEquals(1536L, ByteSizeUtil.parse("1.5 KB"))
+        assertEquals(1024L, ByteSizeUtil.parse("1.0 KB"))
+    }
+
+    @Test
+    fun testParseShorthandWithSurroundingWhitespace() {
+        assertEquals(8192L, ByteSizeUtil.parse("  8k  "))
+    }
+
+    // --- parse(): invalid input ---
+
+    @Test
+    fun testParseNonNumericReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("abc"))
+    }
+
+    @Test
+    fun testParseKShorthandWithoutNumberReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("k"))
+        assertEquals(0L, ByteSizeUtil.parse("kb"))
+    }
+
+    @Test
+    fun testParseMShorthandWithoutNumberReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("m"))
+        assertEquals(0L, ByteSizeUtil.parse("mb"))
+    }
+
+    @Test
+    fun testParseNegativeNumberIsPassedThrough() {
+        assertEquals(-1L, ByteSizeUtil.parse("-1"))
+    }
+
+    @Test
+    fun testParseMixedAlphaSuffixReturnsZero() {
+        assertEquals(0L, ByteSizeUtil.parse("8kk"))
+        assertEquals(0L, ByteSizeUtil.parse("8km"))
+    }
+
+    // --- format() ---
+
+    @Test
+    fun testFormatZeroBytes() {
+        assertEquals("0 B", ByteSizeUtil.format(0))
+    }
+
+    @Test
+    fun testFormatBytesUnderOneKb() {
+        assertEquals("1 B", ByteSizeUtil.format(1))
+        assertEquals("512 B", ByteSizeUtil.format(512))
+        assertEquals("1023 B", ByteSizeUtil.format(1023))
+    }
+
+    @Test
+    fun testFormatKilobytes() {
+        assertEquals("1.0 KB", ByteSizeUtil.format(1024))
+        assertEquals("1.5 KB", ByteSizeUtil.format(1536))
+        assertEquals("512.0 KB", ByteSizeUtil.format(512L * 1024))
+    }
+
+    @Test
+    fun testFormatMegabytes() {
+        val oneMb = 1024L * 1024
+        assertEquals("1.0 MB", ByteSizeUtil.format(oneMb))
+        assertEquals("2.5 MB", ByteSizeUtil.format(oneMb * 5 / 2))
+    }
+
+    @Test
+    fun testFormatGigabytes() {
+        val oneGb = 1024L * 1024 * 1024
+        assertEquals("1.0 GB", ByteSizeUtil.format(oneGb))
+        assertEquals("2.0 GB", ByteSizeUtil.format(oneGb * 2))
+    }
+
+    // --- round-trip: parse(format(x)) == x for representative sizes ---
+
+    @Test
+    fun testParseFormatRoundTrip() {
+        val sizes = listOf(0L, 512L, 1024L, 1536L, 1024L * 1024, 2L * 1024 * 1024, 1024L * 1024 * 1024)
+        sizes.forEach { size ->
+            val formatted = ByteSizeUtil.format(size)
+            val parsed = ByteSizeUtil.parse(formatted)
+            assertEquals("parse(format($size)) should round-trip (formatted='$formatted')", size, parsed)
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Refactor SettingsPanels layout and formatting for improved readability
- Extract `ByteSizeUtil` and `TokenSizeUtils` as shared utility classes
- Replace inline `formatFileSize()` with `ByteSizeUtil.format()`
- Update RulesTabPanel to use `ByteSizeUtil` for file size display
- Add unit tests for `ByteSizeUtil` and `TokenSizeUtils`