### PR TITLE
fix: settings/AI-panel UI interactions (modality, stale proposals, unsaved edits)

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanel.kt
@@ -117,6 +117,15 @@ class AiChatPanel(
     private var session: ConversationSession? = null
 
     /**
+     * The button panel of the most recent proposal card, while its actions
+     * (Apply/Save/Copy) are still live. Nulled once the proposal is consumed
+     * — either by clicking "Apply to editor" or by starting a new turn, since
+     * a consumed/superseded proposal is stale and its actions should no longer
+     * be reachable. The card itself stays in the transcript (read-only).
+     */
+    private var liveProposalButtonPanel: JPanel? = null
+
+    /**
      * True while a clarification card is awaiting the user. While set,
      * the input area stays enabled and a typed reply resolves the pending
      * clarification instead of starting a new turn.
@@ -350,6 +359,9 @@ class AiChatPanel(
      */
     private fun startTurn(displayText: String, agentMessage: String) {
         if (turnJob?.isActive == true) return
+        // Committing to a new turn supersedes any pending proposal — freeze its
+        // actions before doing anything else, so a stale card can't be acted on.
+        freezeLiveProposalButtons(outdated = true)
         val sess = bindSession() ?: run {
             // AI not configured — show the banner instead of a (suppressed) balloon.
             refreshConfiguredState()
@@ -744,6 +756,9 @@ class AiChatPanel(
         text.trim().removeSuffix("?").let { if (it.length > 24) it.take(24) + "…" else it }
 
     private fun appendProposalCard(content: String, suggestedFileName: String) {
+        // A fresh proposal supersedes any previous one: freeze its actions so the
+        // user can't act on a stale card.
+        freezeLiveProposalButtons()
         val card = JPanel(BorderLayout(4, 4)).apply {
             border = EmptyBorder(6, 12, 6, 6)
             alignmentX = Component.LEFT_ALIGNMENT
@@ -764,6 +779,8 @@ class AiChatPanel(
         val copyBtn = JButton("Copy")
         applyBtn.addActionListener {
             onApplyProposal?.invoke(area.text)
+            // The proposal is consumed — its actions are now stale.
+            freezeLiveProposalButtons()
             NotificationUtils.notifyInfo(project, "EasyApi AI Assistant", "Applied to editor.")
         }
         saveBtn.addActionListener { saveProposal(content, suggestedFileName) }
@@ -780,8 +797,30 @@ class AiChatPanel(
         buttons.add(saveBtn)
         buttons.add(copyBtn)
         card.add(buttons, BorderLayout.SOUTH)
+        liveProposalButtonPanel = buttons
         transcriptBox.add(card)
         transcriptBox.add(Box.createVerticalStrut(4))
+    }
+
+    /**
+     * Replaces the live proposal card's action buttons (Apply/Save/Copy) with a
+     * small "(applied)" / "(outdated)" hint and stops tracking it. The proposal
+     * content stays visible read-only — only the now-stale actions are removed.
+     * Safe to call when no proposal is live (no-op).
+     */
+    private fun freezeLiveProposalButtons(outdated: Boolean = false) {
+        val buttons = liveProposalButtonPanel ?: return
+        val card = buttons.parent ?: run {
+            liveProposalButtonPanel = null
+            return
+        }
+        buttons.removeAll()
+        buttons.add(JLabel(if (outdated) "(outdated)" else "(applied)").apply {
+            foreground = UIUtil.getContextHelpForeground()
+        })
+        card.revalidate()
+        card.repaint()
+        liveProposalButtonPanel = null
     }
 
     // -------------------------------------------------------------------------
@@ -843,6 +882,7 @@ class AiChatPanel(
         cancelRunningTurn()
         AiAssistantService.getInstance(project).resetConversation()
         session = null
+        liveProposalButtonPanel = null
         transcriptBox.removeAll()
         transcriptBox.revalidate()
         transcriptBox.repaint()

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/RuleFileEditDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/RuleFileEditDialog.kt
@@ -3,6 +3,7 @@ package com.itangcent.easyapi.settings.ui
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.Messages
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import com.itangcent.easyapi.ai.ui.AiChatPanel
@@ -59,6 +60,14 @@ class RuleFileEditDialog(
         columns = 80
         isEditable = true
     }
+
+    /**
+     * Snapshot of the file's content/name as last loaded (or saved), used by
+     * [isContentModified] to detect unsaved edits before closing. Null until the
+     * initial load completes — treated as "no changes yet" while still loading.
+     */
+    private var loadedName: String? = null
+    private var loadedContent: String? = null
 
     /**
      * Inline AI assistant. Hidden until the user
@@ -177,8 +186,12 @@ class RuleFileEditDialog(
                     .getOrElse { "" }
             }
             withContext(Dispatchers.Main) {
-                nameField.text = Paths.get(filePath).fileName.toString()
+                val name = Paths.get(filePath).fileName.toString()
+                nameField.text = name
                 contentArea.text = content
+                // Snapshot the loaded state so unsaved-change detection works.
+                loadedName = name
+                loadedContent = content
             }
         }
     }
@@ -270,8 +283,48 @@ class RuleFileEditDialog(
                     .onFailure { LOG.warn("ConfigReader.reload failed after edit", it) }
             }
             withContext(Dispatchers.Main) {
+                // Refresh the snapshot so a subsequent Cancel isn't flagged as unsaved.
+                loadedName = newName
+                loadedContent = content
                 close(OK_EXIT_CODE)
             }
+        }
+    }
+
+    /**
+     * True if the on-screen name or content differs from what was last loaded
+     * (or saved). While the initial load is still in flight (`loadedContent ==
+     * null`), reports false — there's nothing to discard yet.
+     */
+    internal fun isContentModified(): Boolean {
+        val savedContent = loadedContent ?: return false
+        val savedName = loadedName ?: return false
+        return nameField.text.trim() != savedName.trim() || contentArea.text != savedContent
+    }
+
+    /**
+     * Intercepts Cancel / window-close (X). If there are unsaved edits, asks the
+     * user whether to save before closing or discard the changes; "Cancel" in
+     * that prompt keeps the editor open.
+     */
+    override fun doCancelAction() {
+        if (!isContentModified()) {
+            super.doCancelAction()
+            return
+        }
+        val choice = Messages.showYesNoCancelDialog(
+            this.contentPane,
+            "The rule file has unsaved changes.\nSave before closing?",
+            "Unsaved Changes",
+            "Save",
+            "Discard",
+            "Cancel",
+            Messages.getQuestionIcon()
+        )
+        when (choice) {
+            Messages.YES -> doOKAction()
+            Messages.NO -> super.doCancelAction()
+            // CANCEL (or closed): stay in the editor.
         }
     }
 
@@ -279,5 +332,37 @@ class RuleFileEditDialog(
         runCatching { aiChatPanel.dispose() }
         scope.cancel()
         super.dispose()
+    }
+
+    // --- Test helpers ---
+
+    /** Sets the content area text directly (test-only). */
+    internal fun setContentForTest(content: String) {
+        contentArea.text = content
+    }
+
+    /** Sets the name field text directly (test-only). */
+    internal fun setNameForTest(name: String) {
+        nameField.text = name
+    }
+
+    /** Returns the snapshot content captured on load (test-only). */
+    internal fun snapshotContent(): String? = loadedContent
+
+    /**
+     * Simulates the async load having completed — sets the form fields and the
+     * snapshot (test-only). Avoids depending on [Dispatchers.Main] scheduling,
+     * which plain `runBlocking` does not advance.
+     */
+    internal fun simulateLoadedForTest(name: String, content: String) {
+        nameField.text = name
+        contentArea.text = content
+        loadedName = name
+        loadedContent = content
+    }
+
+    /** Disposes the dialog from tests (dispose() is protected on DialogWrapper). */
+    internal fun disposeForTest() {
+        dispose()
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/settings/ui/SettingsPanels.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.settings.ui
 
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
@@ -1308,7 +1309,10 @@ class AiAssistantSection : SettingsPanel {
         backgroundAsync {
             val result = runCatching { aiServiceFactory(settings).testConnection() }
                 .getOrElse { Result.failure(it) }
-            swingAsync {
+            // The Settings dialog is modal, so a plain `swingAsync` (which uses
+            // ModalityState.nonModal()) would be deferred until the dialog closes.
+            // Use ModalityState.any() so the result surfaces while the dialog is open.
+            swingAsync(ModalityState.any()) {
                 testConnectionButton.isEnabled = true
                 testConnectionButton.text = previousLabel
                 if (testConnectionResultHandler != null) {
@@ -1359,12 +1363,14 @@ class AiAssistantSection : SettingsPanel {
         backgroundAsync {
             val result = runCatching { credentialScanner.scan() }
                 .getOrElse {
-                    swingAsync {
+                    // ModalityState.any(): see onTestConnectionClicked for rationale.
+                    swingAsync(ModalityState.any()) {
                         setStatus("Auto-detect failed: ${it.message}", ok = false)
                     }
                     DetectionResult.Miss
                 }
-            swingAsync {
+            // ModalityState.any(): see onTestConnectionClicked for rationale.
+            swingAsync(ModalityState.any()) {
                 autoDetectButton.isEnabled = true
                 autoDetectButton.text = previousLabel
                 if (detectHandler != null) {

--- a/src/test/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/ui/AiChatPanelTest.kt
@@ -126,6 +126,55 @@ class AiChatPanelTest : EasyApiLightCodeInsightFixtureTestCase() {
             panel.clickApplyToEditorForTest()
         )
         assertEquals("api.name=cool", applied)
+        // The proposal is consumed — its actions must be removed so it can't be
+        // applied again (it's now stale).
+        assertFalse(
+            "Apply-to-editor button should be gone after it was applied",
+            panel.clickApplyToEditorForTest()
+        )
+        panel.dispose()
+    }
+
+    fun testNewProposalFreezesPreviousProposal() {
+        val panel = AiChatPanel(project)
+        val applied = mutableListOf<String>()
+        panel.onApplyProposal = { applied.add(it) }
+        panel.renderEventForTest(
+            AgentEvent.ProposalReady(Proposal("api.name=first", "custom.rules"))
+        )
+        // Render a second proposal — it supersedes the first.
+        panel.renderEventForTest(
+            AgentEvent.ProposalReady(Proposal("api.name=second", "custom.rules"))
+        )
+        // Only the latest proposal's apply button should remain; clicking it
+        // applies "second", proving the first proposal's actions were frozen.
+        assertTrue(
+            "latest proposal's apply button should still be present",
+            panel.clickApplyToEditorForTest()
+        )
+        assertEquals(
+            "second apply should win after the first was superseded",
+            listOf("api.name=second"),
+            applied
+        )
+        panel.dispose()
+    }
+
+    fun testNewMessageFreezesPendingProposal() {
+        val panel = AiChatPanel(project)
+        val applied = mutableListOf<String>()
+        panel.onApplyProposal = { applied.add(it) }
+        panel.renderEventForTest(
+            AgentEvent.ProposalReady(Proposal("api.name=cool", "custom.rules"))
+        )
+        // Sending a new message supersedes the pending proposal: its apply
+        // button must be gone even if the new turn never runs (no session).
+        panel.typeAndSendForTest("anything")
+        assertFalse(
+            "apply button should be gone once a new message is sent",
+            panel.clickApplyToEditorForTest()
+        )
+        assertTrue("no apply should have fired", applied.isEmpty())
         panel.dispose()
     }
 

--- a/src/test/kotlin/com/itangcent/easyapi/settings/ui/RuleFileEditDialogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/settings/ui/RuleFileEditDialogTest.kt
@@ -1,0 +1,75 @@
+package com.itangcent.easyapi.settings.ui
+
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+/**
+ * Tests for [RuleFileEditDialog]'s unsaved-change detection, which backs the
+ * Cancel / close confirmation prompt ([RuleFileEditDialog.doCancelAction]).
+ *
+ * The dialog loads its content asynchronously on a background coroutine then
+ * snapshots the name/content on the EDT. To avoid depending on `Dispatchers.Main`
+ * scheduling (which plain `runBlocking` does not advance), these tests use
+ * [RuleFileEditDialog.simulateLoadedForTest] to exercise the detection logic in
+ * a fully-synchronised state, plus one case for the pre-load window.
+ */
+class RuleFileEditDialogTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun newLoadedDialog(
+        name: String = "demo.rules",
+        content: String = "api.name=demo\n"
+    ): RuleFileEditDialog {
+        val dialog = RuleFileEditDialog(project, "/tmp/$name")
+        dialog.simulateLoadedForTest(name, content)
+        return dialog
+    }
+
+    fun testNoChangesAfterLoad() {
+        val dialog = newLoadedDialog()
+        assertFalse("unmodified content should not be flagged", dialog.isContentModified())
+        dialog.disposeForTest()
+    }
+
+    fun testContentEditDetected() {
+        val dialog = newLoadedDialog()
+        dialog.setContentForTest("api.name=changed\n")
+        assertTrue("edited content should be flagged as modified", dialog.isContentModified())
+        dialog.disposeForTest()
+    }
+
+    fun testNameEditDetected() {
+        val dialog = newLoadedDialog()
+        dialog.setNameForTest("renamed.rules")
+        assertTrue("edited name should be flagged as modified", dialog.isContentModified())
+        dialog.disposeForTest()
+    }
+
+    fun testWhitespaceOnlyNameChangeNotFlagged() {
+        val dialog = newLoadedDialog(name = "demo.rules")
+        // Trailing-space differences in the name are ignored by trim().
+        dialog.setNameForTest("demo.rules  ")
+        assertFalse(
+            "whitespace-only name change should not be flagged",
+            dialog.isContentModified()
+        )
+        dialog.disposeForTest()
+    }
+
+    fun testIdenticalContentNotFlagged() {
+        val dialog = newLoadedDialog(content = "api.name=demo\n")
+        // Re-setting the same content is a no-op for detection.
+        dialog.setContentForTest("api.name=demo\n")
+        assertFalse("identical content should not be flagged", dialog.isContentModified())
+        dialog.disposeForTest()
+    }
+
+    fun testNotFlaggedBeforeLoadCompletes() {
+        // A fresh dialog whose async load has NOT run yet. loadedContent is null,
+        // so isContentModified() must report false — nothing to discard.
+        val dialog = RuleFileEditDialog(project, "/tmp/demo.rules")
+        assertFalse(
+            "should not be flagged before the initial load completes",
+            dialog.isContentModified()
+        )
+        dialog.disposeForTest()
+    }
+}


### PR DESCRIPTION
## Changes

Three independent UI interaction fixes, plus tests.

- **fix: show test-connection/auto-detect result while settings dialog is open**
  The Test Connection and Auto-detect flows dispatched their EDT continuations via `swingAsync` (`ModalityState.nonModal()`). Since the Settings panel is a modal `DialogWrapper`, those runnables were deferred until the dialog closed — so the success/error notification only appeared after dismissing Settings. Switch to `swingAsync(ModalityState.any())` so the result surfaces on the EDT while the modal dialog is still open.

- **fix: retire stale proposal actions after apply or new message**
  The proposal card's action buttons (Apply to editor / Save / Copy) stayed clickable forever. Now they're removed once the proposal becomes stale — applied or superseded by a new turn / new proposal — leaving the proposal text read-only with an `(applied)`/`(outdated)` hint. `freezeLiveProposalButtons` runs first in `startTurn` so a new message retires the proposal even with no agent session bound.

- **fix: confirm before discarding unsaved edits in rule edit dialog**
  Cancel/close on `RuleFileEditDialog` now checks for unsaved changes (name or content vs. the loaded/saved snapshot) and pops a three-way prompt: **Save**, **Discard**, or **Cancel**. The snapshot is refreshed after a successful save; reports no-changes while the initial async load is still in flight.

## Tests

- `AiChatPanelTest` — extended apply test; added new-proposal-supersedes and new-message-freezes cases.
- `RuleFileEditDialogTest` (new) — 6 cases for unsaved-change detection.
- `SettingsPanels` parity/validation suites still green.