### PR TITLE
fix: respect method-level selection when exporting APIs

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/dashboard/ApiScanner.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.itangcent.easyapi.core.threading.IdeDispatchers
@@ -15,10 +16,13 @@ import com.itangcent.easyapi.exporter.ClassExporter
 import com.itangcent.easyapi.exporter.ClassExporterRegistry
 import com.itangcent.easyapi.exporter.core.CompositeApiClassRecognizer
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.cache.api.ApiIndex
 import com.itangcent.easyapi.ide.DumbModeHelper
+import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.ide.support.runWithProgress
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.logging.console
+import com.itangcent.easyapi.psi.type.areMethodsRelated
 import com.itangcent.easyapi.settings.settings
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Semaphore
@@ -126,6 +130,57 @@ class ApiScanner(private val project: Project) {
             }
         }
         return endpoints.asSequence()
+    }
+
+    /**
+     * Scans the current [selection] for API endpoints, respecting method-level
+     * selections.
+     *
+     * Behavior:
+     * - If the selection contains [PsiMethod]s, only the endpoints whose
+     *   `sourceMethod` matches (or is related to) one of the selected methods
+     *   are returned. The containing classes are scanned first to obtain
+     *   candidate endpoints, then the result is filtered. This fixes the issue
+     *   where selecting a subset of controller methods still exported every
+     *   endpoint in the class.
+     * - Otherwise, if the selection contains classes, all endpoints from those
+     *   classes are returned (same as [scanClasses]).
+     * - Otherwise, the cached project endpoints from [ApiIndex] are returned.
+     *
+     * @param selection The resolved user selection, or `null` for whole project.
+     * @param indicator Optional progress indicator from the caller.
+     * @return List of discovered endpoints, filtered by the selection scope.
+     */
+    suspend fun scanSelection(
+        selection: SelectionScope?,
+        indicator: ProgressIndicator? = null
+    ): List<ApiEndpoint> {
+        if (selection == null) {
+            return ApiIndex.getInstance(project).endpoints()
+        }
+
+        val selectedMethods: List<PsiMethod> = selection.methods().toList()
+        if (selectedMethods.isNotEmpty()) {
+            val containingClasses = read {
+                selectedMethods.mapNotNull { it.containingClass }.distinct()
+            }
+            val candidates = if (containingClasses.isNotEmpty()) {
+                scanClasses(containingClasses, indicator).toList()
+            } else {
+                ApiIndex.getInstance(project).endpoints()
+            }
+            return candidates.filter { endpoint ->
+                val source = endpoint.sourceMethod ?: return@filter false
+                selectedMethods.any { selected -> areMethodsRelated(selected, source) }
+            }
+        }
+
+        val classes = selection.classes().toList()
+        return if (classes.isNotEmpty()) {
+            scanClasses(classes, indicator).toList()
+        } else {
+            ApiIndex.getInstance(project).endpoints()
+        }
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/ExportOrchestrator.kt
@@ -4,9 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.core.threading.swing
-import com.itangcent.easyapi.cache.api.ApiIndex
 import com.itangcent.easyapi.dashboard.ApiScanner
 import com.itangcent.easyapi.exporter.channel.ApiChannelRegistry
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
@@ -17,13 +15,11 @@ import com.itangcent.easyapi.ide.support.NotificationUtils
 import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.settings.settings
-import kotlinx.coroutines.withContext
 
 @Service(Service.Level.PROJECT)
 class ExportOrchestrator(private val project: Project) : IdeaLog {
 
     private val apiScanner: ApiScanner = ApiScanner.getInstance(project)
-    private val apiIndex: ApiIndex = ApiIndex.getInstance(project)
     private val channelRegistry: ApiChannelRegistry = ApiChannelRegistry.getInstance(project)
 
     companion object {
@@ -130,14 +126,9 @@ class ExportOrchestrator(private val project: Project) : IdeaLog {
         selection: SelectionScope?,
         indicator: ProgressIndicator? = null
     ): List<ApiEndpoint> {
-        if (selection != null) {
-            val classes = withContext(IdeDispatchers.ReadAction) {
-                selection.classes().toList()
-            }
-            if (classes.isNotEmpty()) {
-                return apiScanner.scanClasses(classes, indicator).toList()
-            }
-        }
-        return apiIndex.endpoints()
+        // scanSelection respects method-level selections (issue #1407): when the
+        // user selects specific controller methods, only those methods' endpoints
+        // are returned instead of every endpoint in the containing class.
+        return apiScanner.scanSelection(selection, indicator)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ChannelExportAction.kt
@@ -3,7 +3,6 @@ package com.itangcent.easyapi.ide.action
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.itangcent.easyapi.cache.api.ApiIndex
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
@@ -37,18 +36,10 @@ class ChannelExportAction(
             if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return@backgroundAsync
 
             val scanner = ApiScanner.getInstance(project)
-            val apiIndex = ApiIndex.getInstance(project)
-
-            val endpoints = if (selection != null) {
-                val classes = selection.classes().toList()
-                if (classes.isNotEmpty()) {
-                    scanner.scanClasses(classes).toList()
-                } else {
-                    apiIndex.endpoints()
-                }
-            } else {
-                apiIndex.endpoints()
-            }
+            // scanSelection respects method-level selections (issue #1407):
+            // when the user selects specific controller methods, only those
+            // methods' endpoints are exported directly, without a dialog.
+            val endpoints = scanner.scanSelection(selection)
 
             if (endpoints.isEmpty()) {
                 swing {

--- a/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/action/ExportApiAction.kt
@@ -12,7 +12,6 @@ import com.itangcent.easyapi.ide.dialog.ExportDialogResult
 import com.itangcent.easyapi.ide.support.SelectedHelper
 import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.ide.support.runWithProgress
-import com.itangcent.easyapi.cache.api.ApiIndex
 import com.itangcent.easyapi.core.threading.backgroundAsync
 import com.itangcent.easyapi.core.threading.swing
 import com.itangcent.easyapi.dashboard.ApiScanner
@@ -32,18 +31,11 @@ class ExportApiAction : AnAction(), IdeaLog {
         backgroundAsync {
             if (!DumbModeHelper.waitForSmartModeOrNotify(project)) return@backgroundAsync
 
-            val apiIndex = ApiIndex.getInstance(project)
             val scanner = ApiScanner.getInstance(project)
-            val endpoints = if (selection != null) {
-                val classes = selection.classes().toList()
-                if (classes.isNotEmpty()) {
-                    scanner.scanClasses(classes).toList()
-                } else {
-                    apiIndex.endpoints()
-                }
-            } else {
-                apiIndex.endpoints()
-            }
+            // scanSelection respects method-level selections (issue #1407):
+            // when the user selects specific controller methods, only those
+            // methods' endpoints are shown in the dialog.
+            val endpoints = scanner.scanSelection(selection)
 
             swing {
                 val result = ExportDialog.show(project, endpoints.size, endpoints)
@@ -67,15 +59,8 @@ class ExportApiAction : AnAction(), IdeaLog {
                 val endpoints = if (dialogResult.selectedEndpoints.isNotEmpty()) {
                     dialogResult.selectedEndpoints.map { it.endpoint }
                 } else {
-                    val apiIndex = ApiIndex.getInstance(project)
-                    if (selection != null) {
-                        val scanner = ApiScanner.getInstance(project)
-                        val classes = selection.classes().toList()
-                        if (classes.isNotEmpty()) scanner.scanClasses(classes).toList()
-                        else apiIndex.endpoints()
-                    } else {
-                        apiIndex.endpoints()
-                    }
+                    val scanner = ApiScanner.getInstance(project)
+                    scanner.scanSelection(selection, indicator)
                 }
 
                 val exportResult = orchestrator.exportViaChannel(

--- a/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ide/support/SelectedHelper.kt
@@ -4,9 +4,10 @@ import com.intellij.ide.projectView.impl.nodes.ClassTreeNode
 import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.util.TextRange
 import com.intellij.pom.Navigatable
 import com.intellij.psi.*
-import com.itangcent.easyapi.core.threading.readAsync
+import com.intellij.psi.util.PsiTreeUtil
 import com.itangcent.easyapi.core.threading.readSync
 import com.itangcent.easyapi.util.FileType
 
@@ -40,6 +41,23 @@ object SelectedHelper {
      * @return A [SelectionScope] containing the selected elements, or null if nothing selected
      */
     fun resolveSelection(event: AnActionEvent): SelectionScope? {
+        // Check for an editor text selection first — if the user has selected
+        // a range spanning one or more methods, include all of them in the
+        // scope. This handles the case where the user selects text across
+        // multiple controller methods in the editor (issue #1407).
+        val editor = event.getData(CommonDataKeys.EDITOR)
+        val psiFile = event.getData(CommonDataKeys.PSI_FILE)
+        if (editor != null && psiFile != null) {
+            val selectionStart = editor.selectionModel.selectionStart
+            val selectionEnd = editor.selectionModel.selectionEnd
+            if (selectionStart < selectionEnd) {
+                val methods = collectMethodsInRange(psiFile, selectionStart, selectionEnd)
+                if (methods.isNotEmpty()) {
+                    return SelectionScope(methods)
+                }
+            }
+        }
+
         // Prefer PSI_ELEMENT — it represents the actual element at the cursor
         // in the source file. This correctly handles clicks on annotations,
         // type references (String, UserInfo, etc.), and other non-class elements.
@@ -62,7 +80,6 @@ object SelectedHelper {
             }
         }
 
-        val psiFile = event.getData(CommonDataKeys.PSI_FILE)
         if (psiFile != null) {
             return SelectionScope(listOf(psiFile))
         }
@@ -94,6 +111,27 @@ object SelectedHelper {
             current = current.parent
         }
         return null
+    }
+
+    /**
+     * Collects all [PsiMethod]s in [psiFile] whose text range intersects
+     * with the range `[startOffset, endOffset)`.
+     *
+     * Used to resolve an editor text selection that spans multiple methods.
+     * Methods are returned in source order (the order they appear in the file).
+     */
+    private fun collectMethodsInRange(
+        psiFile: PsiFile,
+        startOffset: Int,
+        endOffset: Int
+    ): List<PsiMethod> {
+        val selectionRange = TextRange(startOffset, endOffset)
+        return PsiTreeUtil.findChildrenOfType(psiFile, PsiMethod::class.java)
+            .filter { method ->
+                val methodRange = method.textRange
+                methodRange != null && selectionRange.intersects(methodRange)
+            }
+            .sortedBy { it.textOffset }
     }
 
     private fun resolveNavigatable(navigatable: Navigatable): Any? {

--- a/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiScannerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/dashboard/ApiScannerTest.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.dashboard
 
 import com.itangcent.easyapi.cache.api.ApiIndex
 import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.ide.support.SelectionScope
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import com.itangcent.easyapi.settings.update
@@ -116,11 +117,85 @@ class ApiScannerTest : EasyApiLightCodeInsightFixtureTestCase() {
 
     fun testPreClassificationRoutesToCorrectExporter() = runTest {
         val endpoints = apiScanner.scanAll()
-        
+
         endpoints.forEach { endpoint ->
             val httpMeta = endpoint.metadata as? HttpMetadata
             assertNotNull("Endpoint should have HTTP metadata", httpMeta)
             assertTrue("Path should not be empty", httpMeta!!.path.isNotEmpty())
         }
+    }
+
+    // Regression for https://github.com/tangcent/easy-yapi/issues/1407
+    // Selecting specific controller methods must export only those methods,
+    // not every endpoint in the containing class.
+    fun testScanSelectionWithSingleMethodReturnsOnlyThatEndpoint() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val greetingMethod = findMethod(psiClass!!, "greeting")
+        assertNotNull("greeting method should exist", greetingMethod)
+
+        val endpoints = apiScanner.scanSelection(SelectionScope(listOf(greetingMethod!!)))
+
+        assertEquals(
+            "Should export only the selected method's endpoint",
+            1,
+            endpoints.size
+        )
+        assertEquals(
+            "Exported endpoint should come from the selected method",
+            greetingMethod,
+            endpoints.first().sourceMethod
+        )
+    }
+
+    fun testScanSelectionWithMultipleMethodsReturnsOnlyThoseEndpoints() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val greetingMethod = findMethod(psiClass!!, "greeting")!!
+        val createMethod = findMethod(psiClass, "create")!!
+
+        val endpoints = apiScanner.scanSelection(
+            SelectionScope(listOf(greetingMethod, createMethod))
+        )
+
+        // A method with multi-path mappings (e.g. @PostMapping({"/add", "/admin/add"}))
+        // may produce multiple endpoints, so assert on distinct source methods.
+        val exportedMethods = endpoints.mapNotNull { it.sourceMethod }.toSet()
+        assertEquals(
+            "Exported endpoints should come from exactly the two selected methods",
+            setOf(greetingMethod, createMethod),
+            exportedMethods
+        )
+    }
+
+    fun testScanSelectionWithMethodDoesNotExportSiblingMethods() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val greetingMethod = findMethod(psiClass!!, "greeting")!!
+
+        val endpoints = apiScanner.scanSelection(SelectionScope(listOf(greetingMethod)))
+
+        // UserCtrl has many endpoints (greeting, get, create, update, ...).
+        // Only the selected one should be exported.
+        val nonGreetingEndpoints = endpoints.filter { it.sourceMethod != greetingMethod }
+        assertTrue(
+            "No sibling methods should be exported when one method is selected, " +
+                "but found: ${nonGreetingEndpoints.map { it.sourceMethod?.name }}",
+            nonGreetingEndpoints.isEmpty()
+        )
+    }
+
+    fun testScanSelectionWithClassReturnsAllClassEndpoints() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+
+        val selectionEndpoints = apiScanner.scanSelection(SelectionScope(listOf(psiClass!!)))
+        val classEndpoints = apiScanner.scanClasses(listOf(psiClass)).toList()
+
+        assertEquals(
+            "Class selection should export the same endpoints as scanClasses",
+            classEndpoints.size,
+            selectionEndpoints.size
+        )
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/ExportOrchestratorTest.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.exporter
 
 import com.intellij.openapi.ui.TestDialog
 import com.intellij.openapi.ui.TestDialogManager
+import com.intellij.psi.PsiMethod
 import com.itangcent.easyapi.exporter.channel.ChannelConfig
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.ExportResult
@@ -140,6 +141,61 @@ class ExportOrchestratorTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull(result)
         // With real endpoints found, the export should succeed or fail gracefully
         // but either way the notifyInfo path is exercised
+    }
+
+    /**
+     * Verifies that a method-level [SelectionScope] causes the orchestrator
+     * to export only the selected method's endpoints, not every endpoint in
+     * the containing class (issue #1407).
+     */
+    fun testOrchestrateExportWithMethodSelectionExportsOnlySelectedMethod() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val greetingMethod = psiClass!!.findMethodsByName("greeting", false).first() as PsiMethod
+
+        // Export with only the greeting method selected.
+        val methodSelection = SelectionScope(listOf(greetingMethod))
+        val methodResult = orchestrator.orchestrateExport(methodSelection, "markdown", testFileConfig)
+
+        // Export with the entire class selected, for comparison.
+        val classSelection = SelectionScope(listOf(psiClass))
+        val classResult = orchestrator.orchestrateExport(classSelection, "markdown", testFileConfig)
+
+        assertNotNull("Method selection result should not be null", methodResult)
+        assertNotNull("Class selection result should not be null", classResult)
+
+        if (methodResult is ExportResult.Success && classResult is ExportResult.Success) {
+            assertEquals(
+                "Method selection should export exactly 1 endpoint (greeting)",
+                1, methodResult.count
+            )
+            assertTrue(
+                "Class selection ($classResult.count) should export more endpoints than single method (${methodResult.count})",
+                classResult.count > methodResult.count
+            )
+        }
+    }
+
+    /**
+     * Verifies that a multi-method [SelectionScope] exports endpoints from
+     * exactly those methods, not the entire class (issue #1407).
+     */
+    fun testOrchestrateExportWithMultipleMethodSelectionExportsOnlyThoseMethods() = runTest {
+        val psiClass = findClass("com.itangcent.api.UserCtrl")
+        assertNotNull("UserCtrl should be loaded", psiClass)
+        val greetingMethod = psiClass!!.findMethodsByName("greeting", false).first() as PsiMethod
+        val getMethod = psiClass.findMethodsByName("get", false).first() as PsiMethod
+
+        val selection = SelectionScope(listOf(greetingMethod, getMethod))
+        val result = orchestrator.orchestrateExport(selection, "markdown", testFileConfig)
+
+        assertNotNull(result)
+        if (result is ExportResult.Success) {
+            assertEquals(
+                "Should export exactly 2 endpoints (greeting + get)",
+                2, result.count
+            )
+        }
     }
 
     fun testOrchestrateExportWithUnknownChannelReturnsError() = runTest {

--- a/src/test/kotlin/com/itangcent/easyapi/ide/support/SelectedHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ide/support/SelectedHelperTest.kt
@@ -5,9 +5,11 @@ import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.editor.Editor
 import com.intellij.pom.Navigatable
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
@@ -222,17 +224,131 @@ class SelectedHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNull(selection)
     }
 
+    // ---- Editor text selection spanning multiple methods (issue #1407) ----
+
+    /**
+     * Simulates selecting text in the editor that spans multiple controller
+     * methods. The [SelectionScope] should include every [PsiMethod] whose
+     * text range intersects the selection.
+     *
+     * Steps:
+     * a. Load the PSI class (UserCtrl).
+     * b. Get the methods (greeting, get, create).
+     * c. Set the editor selection from greeting's start to create's end.
+     * d. Verify that SelectedHelper resolves a scope containing all three.
+     */
+    fun testResolveSelectionWithEditorSelectionSpanningMultipleMethods() {
+        // a. Load UserCtrl.java and its dependencies, then open it in the editor.
+        loadFile("spring/RestController.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PutMapping.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/ModelAttribute.java")
+        loadFile("annotation/Public.java")
+        loadFile("model/IResult.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/BaseController.java")
+        val userCtrlFile = loadFile("api/UserCtrl.java")
+        myFixture.configureFromExistingVirtualFile(userCtrlFile.virtualFile)
+
+        // b. Get the methods.
+        val userCtrl = findClass("com.itangcent.api.UserCtrl")!!
+        val greetingMethod = userCtrl.findMethodsByName("greeting", false).first()
+        val getMethod = userCtrl.findMethodsByName("get", false).first()
+        val createMethod = userCtrl.findMethodsByName("create", false).first()
+
+        // c. Set the editor selection spanning from greeting to create.
+        val startOffset = greetingMethod.textOffset
+        val endOffset = createMethod.textRange.endOffset
+        myFixture.editor.selectionModel.setSelection(startOffset, endOffset)
+
+        // d. Verify the SelectionScope includes all three methods.
+        val event = createEvent(
+            editor = myFixture.editor,
+            psiFile = userCtrlFile
+        )
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull("Selection should not be null when editor has a selection", selection)
+
+        val selectedMethods = selection!!.methods().toSet()
+        assertTrue(
+            "Scope should include greeting(), actual: ${selectedMethods.map { it.name }}",
+            selectedMethods.contains(greetingMethod)
+        )
+        assertTrue(
+            "Scope should include get(), actual: ${selectedMethods.map { it.name }}",
+            selectedMethods.contains(getMethod)
+        )
+        assertTrue(
+            "Scope should include create(), actual: ${selectedMethods.map { it.name }}",
+            selectedMethods.contains(createMethod)
+        )
+    }
+
+    /**
+     * Simulates selecting text within a single method. The [SelectionScope]
+     * should include exactly that one method.
+     */
+    fun testResolveSelectionWithEditorSelectionWithinSingleMethod() {
+        loadFile("spring/RestController.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/PutMapping.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("spring/ModelAttribute.java")
+        loadFile("annotation/Public.java")
+        loadFile("model/IResult.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/BaseController.java")
+        val userCtrlFile = loadFile("api/UserCtrl.java")
+        myFixture.configureFromExistingVirtualFile(userCtrlFile.virtualFile)
+
+        val userCtrl = findClass("com.itangcent.api.UserCtrl")!!
+        val greetingMethod = userCtrl.findMethodsByName("greeting", false).first()
+        val createMethod = userCtrl.findMethodsByName("create", false).first()
+
+        // Select a small range entirely within greeting().
+        val startOffset = greetingMethod.textOffset + 1
+        val endOffset = greetingMethod.textRange.endOffset - 1
+        myFixture.editor.selectionModel.setSelection(startOffset, endOffset)
+
+        val event = createEvent(
+            editor = myFixture.editor,
+            psiFile = userCtrlFile
+        )
+        val selection = SelectedHelper.resolveSelection(event)
+        assertNotNull(selection)
+
+        val selectedMethods = selection!!.methods().toList()
+        assertEquals(
+            "Should select exactly one method, actual: ${selectedMethods.map { it.name }}",
+            1, selectedMethods.size
+        )
+        assertEquals(greetingMethod, selectedMethods.first())
+        // create() should NOT be in the scope.
+        assertFalse(selectedMethods.contains(createMethod))
+    }
+
     // ---- Helper ----
 
     private fun createEvent(
         psiElement: PsiElement? = null,
         navigatables: Array<Navigatable>? = null,
-        psiFile: com.intellij.psi.PsiFile? = null
+        psiFile: PsiFile? = null,
+        editor: Editor? = null
     ): AnActionEvent {
         val data = mutableMapOf<String, Any?>()
         if (psiElement != null) data[CommonDataKeys.PSI_ELEMENT.name] = psiElement
         if (navigatables != null) data[CommonDataKeys.NAVIGATABLE_ARRAY.name] = navigatables
         if (psiFile != null) data[CommonDataKeys.PSI_FILE.name] = psiFile
+        if (editor != null) data[CommonDataKeys.EDITOR.name] = editor
         return AnActionEvent.createEvent(MapDataContext(data), Presentation(), "test", ActionUiKind.NONE, null)
     }
 


### PR DESCRIPTION
Selecting specific controller methods now exports only those methods' endpoints instead of every endpoint in the containing class.

Changes:
- ExportApiAction still shows the export dialog, but filtered to the selected methods' endpoints
- ChannelExportAction exports the selected methods directly without a dialog
- SelectedHelper now recognizes editor text selections spanning multiple methods
- ApiScanner.scanSelection filters endpoints by selected methods
- ExportOrchestrator delegates to scanSelection

Test coverage added for SelectedHelper, ApiScanner, and ExportOrchestrator.

Closes #1407