### PR TITLE
feat: support `###include <path-or-url>` directive for local files and remote URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin/
 .temp
 __pycache__/
 .easyapi/
+/.codegraph/

--- a/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/DefaultConfigReader.kt
@@ -3,12 +3,9 @@ package com.itangcent.easyapi.config
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.parser.ConfigTextParser
-import com.itangcent.easyapi.config.resource.CachedResourceResolver
 import com.itangcent.easyapi.config.source.*
 import com.itangcent.easyapi.extension.ExtensionConfigRegistry
-import com.itangcent.easyapi.logging.console
 import com.itangcent.easyapi.settings.SettingBinder
-import com.itangcent.easyapi.util.storage.LocalStorage
 
 /**
  * Default implementation of [ConfigReader] that reads configuration from multiple sources
@@ -17,7 +14,7 @@ import com.itangcent.easyapi.util.storage.LocalStorage
  * Configuration sources are queried in order (highest priority first):
  * 1. **ProjectFileConfigSource** (priority 4) - Configuration from local `.easy.api.config` files (auto-detected + custom project files)
  * 2. **ExtensionConfigSource** (priority 3) - Extension configurations (Swagger, Jackson, etc.)
- * 3. **RemoteConfigSource** (priority 3) - Configuration fetched from remote URLs
+ * 3. **UrlConfigSource** (priority 3) - Configuration fetched from remote URLs
  * 4. **GlobalFileConfigSource** (priority 2) - User-managed global rule files
  *
  * (`RuntimeConfigSource` exists at priority 0 but is not registered here.)
@@ -44,9 +41,6 @@ class DefaultConfigReader(
 ) : ConfigReader {
 
     private val settingBinder = SettingBinder.getInstance(project)
-    private val localStorage = LocalStorage.getInstance(project)
-
-    private val cachedResourceResolver by lazy { CachedResourceResolver(localStorage, project.console) }
 
     @Volatile
     private var delegate: LayeredConfigReader = buildDelegate()
@@ -66,29 +60,29 @@ class DefaultConfigReader(
 
     private fun buildDelegate(): LayeredConfigReader {
         val settings = settingBinder.read()
-        val configTextParser = ConfigTextParser(settings)
+        val configTextParser = ConfigTextParser.getInstance(project)
         val disabledAuto = settings.disabledAutoRuleFiles.toSet()
         val globalDir = java.nio.file.Path.of(System.getProperty("user.home"), ".easyapi")
         return LayeredConfigReader(
             sources = listOf(
                 GlobalFileConfigSource(
+                    project,
                     globalDir,
-                    settings.disabledGlobalRuleFiles.toSet(),
-                    configTextParser
+                    settings.disabledGlobalRuleFiles.toSet()
                 ),
                 ExtensionConfigSource(
                     project,
                     ExtensionConfigRegistry.stringToCodes(settings.extensionConfigs),
                     configTextParser
                 ),
-                RemoteConfigSource(
+                UrlConfigSource(
                     parseUrls(settings.remoteConfig.joinToString("\n")),
                     configTextParser,
-                    cachedResourceResolver
+                    project
                 ),
                 ProjectFileConfigSource(
+                    project,
                     project.basePath ?: "",
-                    configTextParser,
                     disabledFiles = disabledAuto
                 )
             )

--- a/src/main/kotlin/com/itangcent/easyapi/config/FileConfigHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/FileConfigHelper.kt
@@ -1,0 +1,33 @@
+package com.itangcent.easyapi.config
+
+import com.itangcent.easyapi.config.model.ConfigEntry
+import com.itangcent.easyapi.config.parser.ConfigTextParser
+import com.itangcent.easyapi.logging.IdeaLog
+import java.nio.file.Files
+import java.nio.file.Path
+
+private object FileConfigHelperLog : IdeaLog
+
+/**
+ * Parses a list of local files into a sequence of [ConfigEntry] objects.
+ *
+ * Reads each file and delegates parsing to this [ConfigTextParser].
+ * Unreadable files are skipped with a warning — never thrown.
+ *
+ * This is the shared building block used by [GlobalFileConfigSource] and
+ * [ProjectFileConfigSource] for the read + parse step.
+ */
+suspend fun ConfigTextParser.parseFiles(
+    files: List<Path>,
+    sourceId: String
+): Sequence<ConfigEntry> {
+    if (files.isEmpty()) return emptySequence()
+    val result = ArrayList<ConfigEntry>()
+    for (file in files) {
+        val content = runCatching { Files.readString(file, Charsets.UTF_8) }
+            .onFailure { FileConfigHelperLog.LOG.warn("parseFiles: failed to read $file", it) }
+            .getOrNull() ?: continue
+        result += parse(content, sourceId, file.parent?.toString())
+    }
+    return result.asSequence()
+}

--- a/src/main/kotlin/com/itangcent/easyapi/config/parser/ConfigTextParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/parser/ConfigTextParser.kt
@@ -1,11 +1,14 @@
 package com.itangcent.easyapi.config.parser
 
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
+import com.itangcent.easyapi.config.resource.ConfigResourceLoader
 import com.itangcent.easyapi.logging.IdeaLog
 import com.itangcent.easyapi.settings.Settings
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
+import com.itangcent.easyapi.settings.settings
+import com.itangcent.easyapi.util.text.KeyValueLineParser
 
 /**
  * Parses configuration text into a sequence of [ConfigEntry] objects.
@@ -14,7 +17,8 @@ import java.nio.file.Paths
  * - Key-value pairs with `=` or `:` separators
  * - Multi-line values using triple backticks
  * - Directive lines starting with `###`
- * - Additional file includes via `properties.additional`
+ * - Additional file includes via `###include` (preferred) or the legacy
+ *   `properties.additional` key
  *
  * ## Format
  * ```
@@ -34,21 +38,41 @@ import java.nio.file.Paths
  * ###endif
  *
  * # Include additional file
+ * ###include ./additional.properties
+ * # Legacy form, kept for backward compatibility:
  * properties.additional=./additional.properties
  * ```
  *
- * @param settings Settings for directive evaluation
+ * Both include forms accept local file paths and remote URLs
+ * (`http://` / `https://`). Resolution is delegated to [ConfigResourceLoader].
+ * The included file is parsed with the same [DirectiveState] as the including
+ * file, so directive settings (e.g. `ignoreUnresolved`) carry into it.
+ *
+ * This is a project-level service. Settings are obtained from
+ * [SettingBinder] on each [parse] call (so directive conditions always
+ * reflect the latest settings), and the resource loader from
+ * [ConfigResourceLoader], both resolved from the [project].
  */
+@Service(Service.Level.PROJECT)
 class ConfigTextParser(
-    private val settings: Settings?
+    private val project: Project
 ) : IdeaLog {
 
-    fun parse(text: String, sourceId: String, baseDir: String? = null): Sequence<ConfigEntry> {
-        return parseLines(text.lines(), sourceId, baseDir, DirectiveState())
+    private val resourceLoader: ConfigResourceLoader get() = ConfigResourceLoader.getInstance(project)
+
+    suspend fun parse(text: String, sourceId: String, baseDir: String? = null): Sequence<ConfigEntry> {
+        return parseLines(text.lines(), sourceId, baseDir, DirectiveState(), project.settings).asSequence()
     }
 
-    private fun parseLines(lines: List<String>, sourceId: String, baseDir: String?, state: DirectiveState): Sequence<ConfigEntry> = sequence {
+    private suspend fun parseLines(
+        lines: List<String>,
+        sourceId: String,
+        baseDir: String?,
+        state: DirectiveState,
+        settings: Settings
+    ): List<ConfigEntry> {
         val directiveParser = DirectiveParser(state, settings)
+        val result = ArrayList<ConfigEntry>()
 
         var i = 0
         while (i < lines.size) {
@@ -59,10 +83,21 @@ class ConfigTextParser(
             if (line.isEmpty()) continue
             if (line.startsWith("#") && !line.startsWith("###")) continue
 
+            // `###include <path-or-url>` — handled before generic directive
+            // parsing so it isn't swallowed by DirectiveParser. Respects the
+            // active conditional state, like any content-affecting line.
+            if (line.startsWith(INCLUDE_DIRECTIVE)) {
+                if (state.isActive()) {
+                    val path = line.removePrefix(INCLUDE_DIRECTIVE).trim()
+                    include(path, sourceId, baseDir, state, settings, result)
+                }
+                continue
+            }
+
             if (directiveParser.handle(line)) continue
             if (!state.isActive()) continue
 
-            val kv = splitKeyValue(line) ?: continue
+            val kv = KeyValueLineParser.splitKeyValue(line) ?: continue
             val key = kv.first
             var value = kv.second
 
@@ -85,55 +120,52 @@ class ConfigTextParser(
                 value = prefix + sb.toString()
             }
 
+            // Legacy include form, kept for backward compatibility.
             if (key == "properties.additional") {
-                val additional = resolveAdditionalPath(value, baseDir)
-                if (additional != null) {
-                    val loaded = runCatching { Files.readString(additional, Charsets.UTF_8) }
-                        .onFailure { LOG.warn("ConfigTextParser: failed to read additional properties: $additional", it) }
-                        .getOrNull()
-                    if (loaded != null) {
-                        yieldAll(parseLines(loaded.lines(), sourceId, additional.parent?.toString(), DirectiveState()))
-                    } else if (!state.ignoreNotFoundFile) {
-                        throw IllegalStateException("Cannot read additional properties: $additional")
-                    }
-                } else if (!state.ignoreNotFoundFile) {
-                    throw IllegalStateException("Cannot resolve additional properties: $value")
-                }
+                include(value, sourceId, baseDir, state, settings, result)
                 continue
             }
 
-            yield(ConfigEntry(key, value, sourceId, state.snapshot()))
+            result.add(ConfigEntry(key, value, sourceId, state.snapshot()))
+        }
+
+        return result
+    }
+
+    /**
+     * Loads the resource at [pathOrUrl] and parses it into [result], reusing
+     * the caller's [state] so directive settings carry into the included file.
+     *
+     * Throws [IllegalStateException] when the resource cannot be resolved,
+     * unless `ignoreNotFoundFile` is set on [state].
+     */
+    private suspend fun include(
+        pathOrUrl: String,
+        sourceId: String,
+        baseDir: String?,
+        state: DirectiveState,
+        settings: Settings,
+        result: MutableList<ConfigEntry>
+    ) {
+        val loaded = resourceLoader.load(pathOrUrl, baseDir)
+        if (loaded != null) {
+            result.addAll(
+                parseLines(
+                    loaded.content.lines(),
+                    sourceId,
+                    loaded.baseDir,
+                    state,
+                    settings
+                )
+            )
+        } else if (!state.ignoreNotFoundFile) {
+            throw IllegalStateException("Cannot resolve include: $pathOrUrl")
         }
     }
 
-    private fun splitKeyValue(line: String): Pair<String, String>? {
-        var bracketDepth = 0
-        var idx = -1
-        for (i in line.indices) {
-            when (line[i]) {
-                '[' -> bracketDepth++
-                ']' -> if (bracketDepth > 0) bracketDepth--
-                '=', ':' -> if (bracketDepth == 0 && i > 0) {
-                    idx = i
-                    break
-                }
-            }
-        }
-        if (idx <= 0) return null
-        val key = line.substring(0, idx).trim()
-        val value = line.substring(idx + 1).trim()
-        return if (key.isEmpty()) null else key to value
-    }
+    companion object {
+        private const val INCLUDE_DIRECTIVE = "###include"
 
-    private fun resolveAdditionalPath(path: String, baseDir: String?): Path? {
-        val p = path.trim().trim('"', '\'')
-        if (p.startsWith("http://") || p.startsWith("https://")) return null
-        val resolved = when {
-            p.startsWith("~/") -> Paths.get(System.getProperty("user.home")).resolve(p.removePrefix("~/"))
-            Paths.get(p).isAbsolute -> Paths.get(p)
-            baseDir != null -> Paths.get(baseDir).resolve(p)
-            else -> Paths.get(p)
-        }
-        return resolved.normalize()
+        fun getInstance(project: Project): ConfigTextParser = project.service()
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolver.kt
@@ -1,9 +1,14 @@
 package com.itangcent.easyapi.config.resource
 
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.components.service
 import com.itangcent.easyapi.core.threading.IdeDispatchers
 import com.itangcent.easyapi.http.HttpRequest
 import com.itangcent.easyapi.http.UrlConnectionHttpClient
 import com.itangcent.easyapi.logging.IdeaConsole
+import com.itangcent.easyapi.logging.console
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.util.storage.LocalStorage
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
@@ -13,7 +18,7 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Resolves and caches remote resources.
  *
- * Fetches content from URLs and caches the results with a configurable TTL.
+ * Fetches content from URLs and caches the results with a fixed TTL.
  * On cache miss or expiration, fetches fresh content; on failure, falls back
  * to stale cache.
  *
@@ -24,31 +29,35 @@ import kotlin.time.Duration.Companion.milliseconds
  * ## Caching Behavior
  * - Cache group: `remote-cache`
  * - Timestamp group: `remote-cache-ts`
- * - Default TTL: 2 hours
+ * - TTL: 2 hours (constant)
+ * - Fetch timeout: read from [Settings.httpTimeOut] (seconds → ms)
  *
- * @param localStorage The local storage for persisting fetched content
- * @param console Console for logging warnings
- * @param ttlMs Time-to-live in milliseconds (default: 2 hours)
+ * This is a project-level service scoped to a specific IntelliJ project.
  */
+@Service(Service.Level.PROJECT)
 class CachedResourceResolver(
-    private val localStorage: LocalStorage,
-    private val console: IdeaConsole,
-    private val ttlMs: Long = 2 * 60 * 60 * 1000L,
-    private val fetchTimeoutMs: Long = 30_000L
+    private val project: Project
 ) {
+    private val localStorage = LocalStorage.getInstance(project)
+    private val console: IdeaConsole get() = project.console
+
+    private fun fetchTimeoutMs(): Long =
+        SettingBinder.getInstance(project).read().httpTimeOut.toLong() * 1000L
+
     suspend fun get(url: String): String? {
         val cached = localStorage.get(CACHE_GROUP, url)?.toString()
         if (cached != null) {
             val fetchedAt = localStorage.get(TIMESTAMP_GROUP, url)?.toString()?.toLongOrNull()
-            if (fetchedAt != null && System.currentTimeMillis() - fetchedAt <= ttlMs) {
+            if (fetchedAt != null && System.currentTimeMillis() - fetchedAt <= TTL_MS) {
                 return cached
             }
         }
 
-        val content = runCatching { fetch(url) }
+        val timeoutMs = fetchTimeoutMs()
+        val content = runCatching { fetch(url, timeoutMs) }
             .onFailure { e ->
                 if (e is TimeoutCancellationException) {
-                    console.warn("Remote config fetch timed out (${fetchTimeoutMs}ms): $url")
+                    console.warn("Remote config fetch timed out (${timeoutMs}ms): $url")
                 } else {
                     console.warn("Remote config unreachable: $url", e)
                 }
@@ -61,8 +70,8 @@ class CachedResourceResolver(
         return content
     }
 
-    private suspend fun fetch(url: String): String {
-        return withTimeout(fetchTimeoutMs.milliseconds) {
+    private suspend fun fetch(url: String, timeoutMs: Long): String {
+        return withTimeout(timeoutMs.milliseconds) {
             withContext(IdeDispatchers.Background) {
                 val request = HttpRequest(
                     url = url,
@@ -79,5 +88,10 @@ class CachedResourceResolver(
     companion object {
         private const val CACHE_GROUP = "remote-cache"
         private const val TIMESTAMP_GROUP = "remote-cache-ts"
+
+        /** Cache time-to-live: 2 hours. */
+        private const val TTL_MS = 2 * 60 * 60 * 1000L
+
+        fun getInstance(project: Project): CachedResourceResolver = project.service()
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/config/resource/ConfigResourceLoader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/resource/ConfigResourceLoader.kt
@@ -1,0 +1,94 @@
+package com.itangcent.easyapi.config.resource
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.logging.IdeaLog
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * A configuration resource loaded from a local file path or remote URL.
+ *
+ * @property content The raw text content of the resource
+ * @property baseDir The base directory for resolving relative includes inside
+ *           [content]; `null` when there is no meaningful base (e.g. the
+ *           resource was loaded from a bare path with no parent).
+ */
+data class LoadedConfigResource(
+    val content: String,
+    val baseDir: String?
+)
+
+/**
+ * Loads configuration content from a local file path or remote URL.
+ *
+ * Supported inputs:
+ * - **Remote URLs** (`http://` / `https://`) — fetched via
+ *   [CachedResourceResolver] obtained from the [project].
+ * - **Local paths** — resolved relative to [baseDir] (or the user home for
+ *   `~/` prefixes, or as absolute paths).
+ *
+ * Returns `null` when the resource cannot be read or the scheme is not
+ * supported. Callers decide whether `null` is an error based on directive
+ * state (e.g. `ignoreNotFoundFile`).
+ *
+ * This is a project-level service scoped to a specific IntelliJ project.
+ */
+@Service(Service.Level.PROJECT)
+class ConfigResourceLoader(
+    private val project: Project
+) : IdeaLog {
+
+    /**
+     * Loads the resource at [pathOrUrl].
+     *
+     * @param pathOrUrl A local file path or a remote URL.
+     * @param baseDir The base directory for resolving relative paths.
+     * @return The loaded resource, or `null` if it could not be read.
+     */
+    suspend fun load(pathOrUrl: String, baseDir: String?): LoadedConfigResource? {
+        val p = pathOrUrl.trim().trim('"', '\'')
+
+        if (p.startsWith("http://") || p.startsWith("https://")) {
+            val resolver = CachedResourceResolver.getInstance(project)
+            val content = resolver.get(p) ?: return null
+            return LoadedConfigResource(content, parentUrl(p))
+        }
+
+        val resolved = resolveLocalPath(p, baseDir) ?: return null
+        return runCatching {
+            val content = Files.readString(resolved, Charsets.UTF_8)
+            LoadedConfigResource(content, resolved.parent?.toString())
+        }.onFailure {
+            LOG.warn("ConfigResourceLoader: failed to read $resolved", it)
+        }.getOrNull()
+    }
+
+    private fun resolveLocalPath(path: String, baseDir: String?): Path? {
+        val resolved = when {
+            path.startsWith("~/") -> Paths.get(System.getProperty("user.home")).resolve(path.removePrefix("~/"))
+            Paths.get(path).isAbsolute -> Paths.get(path)
+            baseDir != null -> Paths.get(baseDir).resolve(path)
+            else -> Paths.get(path)
+        }
+        return resolved.normalize()
+    }
+
+    /**
+     * Returns the parent URL of [url] by stripping the last path segment after
+     * the host. When the URL has no path (e.g. `https://example.com`), the URL
+     * itself is returned so relative includes resolve against the host root.
+     */
+    private fun parentUrl(url: String): String {
+        val schemeEnd = url.indexOf("://")
+        val pathStart = if (schemeEnd >= 0) schemeEnd + 3 else 0
+        val lastSlash = url.lastIndexOf('/')
+        return if (lastSlash > pathStart) url.substring(0, lastSlash) else url
+    }
+
+    companion object {
+        fun getInstance(project: Project): ConfigResourceLoader = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/config/source/GlobalFileConfigSource.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/source/GlobalFileConfigSource.kt
@@ -1,8 +1,10 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.model.ConfigSource
 import com.itangcent.easyapi.config.parser.ConfigTextParser
+import com.itangcent.easyapi.config.parseFiles
 import com.itangcent.easyapi.logging.IdeaLog
 import java.nio.file.Files
 import java.nio.file.Path
@@ -18,16 +20,16 @@ import java.nio.file.Path
  * (3) so bundled framework extensions take precedence, but provides
  * user-managed global defaults that other project-specific sources override.
  *
- * Non-existent or unreadable files are skipped with a warning — never thrown.
+ * File reading and parsing is delegated to [parseFiles].
  *
+ * @param project The IntelliJ project, used to obtain [ConfigTextParser]
  * @param globalDir The `~/.easyapi` directory to scan
  * @param disabledFiles Absolute paths of files to skip (in [disabledGlobalRuleFiles])
- * @param configTextParser Parser for configuration text
  */
 class GlobalFileConfigSource(
+    private val project: Project,
     private val globalDir: Path,
-    private val disabledFiles: Set<String>,
-    private val configTextParser: ConfigTextParser
+    private val disabledFiles: Set<String>
 ) : ConfigSource {
     companion object : IdeaLog {
 
@@ -52,15 +54,6 @@ class GlobalFileConfigSource(
         val files = listFiles(globalDir).filter {
             it.toAbsolutePath().toString() !in disabledFiles
         }
-        if (files.isEmpty()) return emptySequence()
-
-        return sequence {
-            for (file in files) {
-                val content = runCatching { Files.readString(file, Charsets.UTF_8) }
-                    .onFailure { LOG.warn("GlobalFileConfigSource: failed to read $file", it) }
-                    .getOrNull() ?: continue
-                yieldAll(configTextParser.parse(content, sourceId, file.parent?.toString()).toList())
-            }
-        }
+        return ConfigTextParser.getInstance(project).parseFiles(files, sourceId)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/config/source/ProjectFileConfigSource.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/source/ProjectFileConfigSource.kt
@@ -1,8 +1,10 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.model.ConfigSource
 import com.itangcent.easyapi.config.parser.ConfigTextParser
+import com.itangcent.easyapi.config.parseFiles
 import com.itangcent.easyapi.logging.IdeaLog
 import java.nio.file.Files
 import java.nio.file.Path
@@ -25,13 +27,15 @@ import java.nio.file.Paths
  * This source has the highest priority (4) so project-specific rules win
  * over extension, remote, and global sources.
  *
+ * File reading and parsing is delegated to [parseFiles].
+ *
+ * @param project The IntelliJ project, used to obtain [ConfigTextParser]
  * @param projectBasePath The project base directory path
- * @param configTextParser Parser for configuration text
  * @param disabledFiles Absolute paths of files to skip
  */
 class ProjectFileConfigSource(
+    private val project: Project,
     private var projectBasePath: String,
-    private val configTextParser: ConfigTextParser,
     private val disabledFiles: Set<String> = emptySet()
 ) : ConfigSource {
     companion object : IdeaLog {
@@ -81,18 +85,7 @@ class ProjectFileConfigSource(
         val configFiles = (easyapiFolderFiles(projectBasePath) + legacyFiles(projectBasePath))
             .filter { it.toAbsolutePath().toString() !in disabledFiles }
 
-        if (configFiles.isEmpty()) return emptySequence()
-
-        return sequence {
-            for (file in configFiles) {
-                val content = runCatching { Files.readString(file, Charsets.UTF_8) }
-                    .onFailure { LOG.warn("ProjectFileConfigSource: failed to read $file", it) }
-                    .getOrNull() ?: continue
-                val entries = configTextParser.parse(content, sourceId, file.parent?.toString()).toList()
-                LOG.info("Loaded ${entries.size} entries from project config file: $file")
-                yieldAll(entries)
-            }
-        }
+        return ConfigTextParser.getInstance(project).parseFiles(configFiles, sourceId)
     }
 
     fun setProjectBasePath(path: String) {

--- a/src/main/kotlin/com/itangcent/easyapi/config/source/UrlConfigSource.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/config/source/UrlConfigSource.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.model.ConfigSource
 import com.itangcent.easyapi.config.parser.ConfigTextParser
@@ -16,26 +17,25 @@ import com.itangcent.easyapi.config.resource.CachedResourceResolver
  *
  * @param urls List of remote configuration URLs
  * @param configTextParser Parser for configuration text
- * @param cachedResourceResolver Resolver for fetching and caching remote content
+ * @param project The IntelliJ project, used to obtain [CachedResourceResolver]
  */
-class RemoteConfigSource(
+class UrlConfigSource(
     private val urls: List<String>,
     private val configTextParser: ConfigTextParser,
-    private val cachedResourceResolver: CachedResourceResolver
+    private val project: Project
 ) : ConfigSource {
     override val priority: Int = 3
     override val sourceId: String = "remote"
 
     override suspend fun collect(): Sequence<ConfigEntry> {
         if (urls.isEmpty()) return emptySequence()
-        val contents = urls.map { url -> url to cachedResourceResolver.get(url) }
-        return sequence {
-            for ((url, content) in contents) {
-                if (content != null) {
-                    val baseDir = url.substringBeforeLast('/', missingDelimiterValue = url)
-                    yieldAll(configTextParser.parse(content, sourceId, baseDir))
-                }
-            }
+        val resolver = CachedResourceResolver.getInstance(project)
+        val result = ArrayList<ConfigEntry>()
+        for (url in urls) {
+            val content = resolver.get(url) ?: continue
+            val baseDir = url.substringBeforeLast('/', missingDelimiterValue = url)
+            result += configTextParser.parse(content, sourceId, baseDir)
         }
+        return result.asSequence()
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/rule/RuleProposalValidator.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/rule/RuleProposalValidator.kt
@@ -1,6 +1,7 @@
 package com.itangcent.easyapi.rule
 
 import com.itangcent.easyapi.util.json.GsonUtils
+import com.itangcent.easyapi.util.text.KeyValueLineParser
 import kotlin.reflect.full.memberProperties
 
 /**
@@ -70,7 +71,7 @@ object RuleProposalValidator {
             // Plain comment (### is a directive, handled elsewhere; treat as
             // non-rule for this check).
             if (line.startsWith("#")) return@forEachIndexed
-            val parsed = splitKeyFilterValue(line) ?: run {
+            val parsed = KeyValueLineParser.splitKeyFilterValue(line) ?: run {
                 // Not a key=value line — skip (directives, stray text). We do
                 // not error on every non-kv line to avoid false positives on
                 // constructs the parser supports but this checker doesn't model.
@@ -115,37 +116,6 @@ object RuleProposalValidator {
         if (filter.startsWith("class:")) return FilterIssue.Deprecated
         if (VALID_FILTER_PREFIXES.any { filter.startsWith(it) }) return null
         return FilterIssue.Invalid
-    }
-
-    /**
-     * Split a `key[filter]=value` / `key=value` line, honoring bracket depth
-     * so `=`/`:` inside a filter or value don't trip the split. Mirrors the
-     * semantics of `ConfigTextParser.splitKeyValue` without reusing it (that
-     * parser folds `key[...]` into the key and doesn't expose the filter).
-     */
-    private fun splitKeyFilterValue(line: String): Triple<String, String?, String>? {
-        var bracketDepth = 0
-        var eqIdx = -1
-        for (i in line.indices) {
-            when (line[i]) {
-                '[' -> bracketDepth++
-                ']' -> if (bracketDepth > 0) bracketDepth--
-                '=', ':' -> if (bracketDepth == 0 && i > 0) {
-                    eqIdx = i
-                    break
-                }
-            }
-        }
-        if (eqIdx <= 0) return null
-        val left = line.substring(0, eqIdx).trim()
-        val value = line.substring(eqIdx + 1).trim()
-        if (left.isEmpty()) return null
-        val bracketStart = left.indexOf('[')
-        if (bracketStart < 0 || !left.endsWith("]")) return Triple(left, null, value)
-        val key = left.substring(0, bracketStart).trim()
-        val filter = left.substring(bracketStart + 1, left.length - 1).trim()
-        if (key.isEmpty() || filter.isEmpty()) return Triple(left, null, value)
-        return Triple(key, filter, value)
     }
 
     private fun isParsableJson(text: String): Boolean = runCatching {

--- a/src/main/kotlin/com/itangcent/easyapi/util/text/KeyValueLineParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/util/text/KeyValueLineParser.kt
@@ -1,0 +1,61 @@
+package com.itangcent.easyapi.util.text
+
+/**
+ * Shared parsing for the `key[filter]=value` / `key:value` line format used by
+ * both the config parser ([com.itangcent.easyapi.config.parser.ConfigTextParser])
+ * and the rule proposal validator
+ * ([com.itangcent.easyapi.rule.RuleProposalValidator]).
+ *
+ * The split honors bracket depth so that `=` / `:` appearing inside a `[...]`
+ * filter (or anywhere in the value) does not trip the separator detection.
+ */
+object KeyValueLineParser {
+
+    /**
+     * Split [line] at the first top-level `=` / `:` separator, ignoring any
+     * separator nested inside `[...]`.
+     *
+     * @return the trimmed left-hand side (key, possibly including a `[filter]`)
+     *   paired with the trimmed value, or `null` when there is no valid
+     *   separator or the left-hand side is empty.
+     */
+    fun splitKeyValue(line: String): Pair<String, String>? {
+        var bracketDepth = 0
+        var idx = -1
+        for (i in line.indices) {
+            when (line[i]) {
+                '[' -> bracketDepth++
+                ']' -> if (bracketDepth > 0) bracketDepth--
+                '=', ':' -> if (bracketDepth == 0 && i > 0) {
+                    idx = i
+                    break
+                }
+            }
+        }
+        if (idx <= 0) return null
+        val key = line.substring(0, idx).trim()
+        val value = line.substring(idx + 1).trim()
+        return if (key.isEmpty()) null else key to value
+    }
+
+    /**
+     * Like [splitKeyValue], but further decomposes the left-hand side into a
+     * `key` and an optional `[filter]`.
+     *
+     * When the left-hand side is not of the form `key[filter]` (no brackets, or
+     * not terminated by `]`, or an empty key/filter), the whole left-hand side
+     * is returned as the key with a `null` filter.
+     *
+     * @return a triple of `(key, filter, value)`, or `null` when [line] has no
+     *   valid separator.
+     */
+    fun splitKeyFilterValue(line: String): Triple<String, String?, String>? {
+        val (left, value) = splitKeyValue(line) ?: return null
+        val bracketStart = left.indexOf('[')
+        if (bracketStart < 0 || !left.endsWith("]")) return Triple(left, null, value)
+        val key = left.substring(0, bracketStart).trim()
+        val filter = left.substring(bracketStart + 1, left.length - 1).trim()
+        if (key.isEmpty() || filter.isEmpty()) return Triple(left, null, value)
+        return Triple(key, filter, value)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/config/FileConfigHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/FileConfigHelperTest.kt
@@ -1,0 +1,114 @@
+package com.itangcent.easyapi.config
+
+import com.itangcent.easyapi.config.model.ConfigEntry
+import com.itangcent.easyapi.config.parser.ConfigTextParser
+import com.itangcent.easyapi.config.parser.DirectiveSnapshot
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.nio.file.Path
+
+class FileConfigHelperTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val parser: ConfigTextParser = mock()
+
+    @Test
+    fun testEmptyFileListReturnsEmptySequence() = runBlocking {
+        val entries = parser.parseFiles(emptyList(), "test").toList()
+        assertTrue(entries.isEmpty())
+    }
+
+    @Test
+    fun testParseSingleFile() = runBlocking {
+        val file = tempFolder.newFile("rules.properties")
+        file.writeText("api.name=test")
+
+        val expected = sequenceOf(
+            ConfigEntry("api.name", "test", "test", DirectiveSnapshot())
+        )
+        whenever(parser.parse("api.name=test", "test", file.parentFile.absolutePath))
+            .thenReturn(expected)
+
+        val entries = parser.parseFiles(listOf(file.toPath()), "test").toList()
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("test", entries[0].value)
+        assertEquals("test", entries[0].sourceId)
+    }
+
+    @Test
+    fun testParseMultipleFiles() = runBlocking {
+        val file1 = tempFolder.newFile("rules1.properties")
+        file1.writeText("api.name=first")
+        val file2 = tempFolder.newFile("rules2.properties")
+        file2.writeText("api.version=2.0")
+
+        whenever(parser.parse("api.name=first", "test", file1.parentFile.absolutePath))
+            .thenReturn(sequenceOf(ConfigEntry("api.name", "first", "test", DirectiveSnapshot())))
+        whenever(parser.parse("api.version=2.0", "test", file2.parentFile.absolutePath))
+            .thenReturn(sequenceOf(ConfigEntry("api.version", "2.0", "test", DirectiveSnapshot())))
+
+        val entries = parser.parseFiles(listOf(file1.toPath(), file2.toPath()), "test").toList()
+        assertEquals(2, entries.size)
+        assertEquals("first", entries[0].value)
+        assertEquals("2.0", entries[1].value)
+    }
+
+    @Test
+    fun testSourceIdPropagatedToParse() = runBlocking {
+        val file = tempFolder.newFile("rules.properties")
+        file.writeText("api.name=test")
+
+        whenever(parser.parse(any(), any(), anyOrNull()))
+            .thenReturn(sequenceOf(ConfigEntry("api.name", "test", "custom-source", DirectiveSnapshot())))
+
+        val entries = parser.parseFiles(listOf(file.toPath()), "custom-source").toList()
+        assertEquals(1, entries.size)
+        assertEquals("custom-source", entries[0].sourceId)
+    }
+
+    @Test
+    fun testBaseDirIsFileParent() = runBlocking {
+        val file = tempFolder.newFile("rules.properties")
+        file.writeText("api.name=test")
+        val parentDir = file.parentFile.absolutePath
+
+        whenever(parser.parse("api.name=test", "test", parentDir))
+            .thenReturn(sequenceOf(ConfigEntry("api.name", "test", "test", DirectiveSnapshot())))
+
+        val entries = parser.parseFiles(listOf(file.toPath()), "test").toList()
+        assertEquals(1, entries.size)
+    }
+
+    @Test
+    fun testUnreadableFileIsSkipped() = runBlocking {
+        val missingFile = Path.of("/nonexistent/config.properties")
+
+        val entries = parser.parseFiles(listOf(missingFile), "test").toList()
+        assertTrue(entries.isEmpty())
+    }
+
+    @Test
+    fun testMixedReadableAndUnreadableFiles() = runBlocking {
+        val readable = tempFolder.newFile("readable.properties")
+        readable.writeText("api.name=present")
+
+        whenever(parser.parse("api.name=present", "test", readable.parentFile.absolutePath))
+            .thenReturn(sequenceOf(ConfigEntry("api.name", "present", "test", DirectiveSnapshot())))
+
+        val missingFile = Path.of("/nonexistent/config.properties")
+
+        val entries = parser.parseFiles(listOf(missingFile, readable.toPath()), "test").toList()
+        assertEquals(1, entries.size)
+        assertEquals("present", entries[0].value)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/config/LayeredConfigReaderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/LayeredConfigReaderTest.kt
@@ -1,17 +1,27 @@
 package com.itangcent.easyapi.config
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.model.ConfigSource
 import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.config.parser.DirectiveSnapshot
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.Settings
 import org.junit.Assert.*
 import org.junit.Test
 import kotlinx.coroutines.runBlocking
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class LayeredConfigReaderTest {
 
-    private val parser = ConfigTextParser(null)
+    private val parser: ConfigTextParser = run {
+        val project = mock<Project>()
+        val settingBinder = mock<SettingBinder>()
+        whenever(settingBinder.read()).thenReturn(Settings())
+        whenever(project.getService(SettingBinder::class.java)).thenReturn(settingBinder)
+        ConfigTextParser(project)
+    }
 
     @Test
     fun testConfigTextParserMultilineBlock() {
@@ -21,7 +31,7 @@ field.ignore=groovy:```
 ```
 api.name=test
 """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(2, entries.size)
         assertEquals("field.ignore", entries[0].key)
         assertTrue(entries[0].value.startsWith("groovy:"))
@@ -39,7 +49,7 @@ ignored.classes=```
 ```
 api.name=test
 """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(2, entries.size)
         assertEquals("ignored.classes", entries[0].key)
         assertTrue(entries[0].value.contains("java.lang.Class"))
@@ -53,7 +63,7 @@ api.name=test
 field.ignore=groovy:!it.containingClass().name().startsWith("java.lang")
 api.name=test
 """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(2, entries.size)
         assertEquals("field.ignore", entries[0].key)
         assertTrue(entries[0].value.startsWith("groovy:"))

--- a/src/test/kotlin/com/itangcent/easyapi/config/parser/ConfigTextParserTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/parser/ConfigTextParserTest.kt
@@ -1,15 +1,36 @@
 package com.itangcent.easyapi.config.parser
 
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.config.resource.ConfigResourceLoader
+import com.itangcent.easyapi.config.resource.LoadedConfigResource
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.Settings
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class ConfigTextParserTest {
 
+    private fun newParser(
+        settings: Settings = Settings(),
+        loader: ConfigResourceLoader? = null
+    ): ConfigTextParser {
+        val project = mock<Project>()
+        val settingBinder = mock<SettingBinder>()
+        whenever(settingBinder.read()).thenReturn(settings)
+        whenever(project.getService(SettingBinder::class.java)).thenReturn(settingBinder)
+        if (loader != null) {
+            whenever(project.getService(ConfigResourceLoader::class.java)).thenReturn(loader)
+        }
+        return ConfigTextParser(project)
+    }
+
     @Test
     fun testParseSimpleKeyValue() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("api.name=test-api", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("api.name=test-api", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name", entries[0].key)
         assertEquals("test-api", entries[0].value)
@@ -17,8 +38,8 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseColonSeparator() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("api.name:my-api", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("api.name:my-api", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name", entries[0].key)
         assertEquals("my-api", entries[0].value)
@@ -26,27 +47,27 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseSkipsComments() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("# this is a comment\napi.name=test", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("# this is a comment\napi.name=test", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name", entries[0].key)
     }
 
     @Test
     fun testParseSkipsEmptyLines() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("\n\napi.name=test\n\n", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("\n\napi.name=test\n\n", "test").toList() }
         assertEquals(1, entries.size)
     }
 
     @Test
     fun testParseMultipleEntries() {
-        val parser = ConfigTextParser(null)
+        val parser = newParser()
         val text = """
             api.name=test-api
             api.version=1.0
         """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(2, entries.size)
         assertEquals("test-api", entries[0].value)
         assertEquals("1.0", entries[1].value)
@@ -54,14 +75,14 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseMultilineValue() {
-        val parser = ConfigTextParser(null)
+        val parser = newParser()
         val text = """
             api.description=```
             Line 1
             Line 2
             ```
         """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(1, entries.size)
         assertTrue("Should contain Line 1", entries[0].value.contains("Line 1"))
         assertTrue("Should contain Line 2", entries[0].value.contains("Line 2"))
@@ -70,13 +91,13 @@ class ConfigTextParserTest {
     @Test
     fun testParseConditionalWithTrueCondition() {
         val settings = Settings(httpClient = "APACHE")
-        val parser = ConfigTextParser(settings)
+        val parser = newParser(settings)
         val text = """
             ###if httpClient==APACHE
             api.name=conditional-api
             ###endif
         """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("conditional-api", entries[0].value)
     }
@@ -84,32 +105,32 @@ class ConfigTextParserTest {
     @Test
     fun testParseConditionalWithFalseCondition() {
         val settings = Settings(httpClient = "APACHE")
-        val parser = ConfigTextParser(settings)
+        val parser = newParser(settings)
         val text = """
             ###if httpClient==URL_CONNECTION
             api.name=conditional-api
             ###endif
         """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertTrue("Should have no entries for false condition", entries.isEmpty())
     }
 
     @Test
     fun testParseDirectiveNotYielded() {
-        val parser = ConfigTextParser(null)
+        val parser = newParser()
         val text = """
             ###set resolveProperty=false
             api.name=test
         """.trimIndent()
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name", entries[0].key)
     }
 
     @Test
     fun testParseBracketedKeyWithEquals() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("api.name[true]=test-api", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("api.name[true]=test-api", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name[true]", entries[0].key)
         assertEquals("test-api", entries[0].value)
@@ -117,8 +138,8 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseBracketedKeyWithColonSeparator() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("api.name[true]:test-api", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("api.name[true]:test-api", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("api.name[true]", entries[0].key)
         assertEquals("test-api", entries[0].value)
@@ -126,8 +147,8 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseColonInsideBracketsNotTreatedAsSeparator() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("json.rule.convert[#regex:some.Type]=replacement", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("json.rule.convert[#regex:some.Type]=replacement", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("json.rule.convert[#regex:some.Type]", entries[0].key)
         assertEquals("replacement", entries[0].value)
@@ -135,9 +156,9 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseRegexFilterWithAngleBracketsAndCaptureGroups() {
-        val parser = ConfigTextParser(null)
+        val parser = newParser()
         val text = "json.rule.convert[#regex:reactor.core.publisher.Flux<(.*?)>]=java.util.List<\${1}>"
-        val entries = parser.parse(text, "test").toList()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("json.rule.convert[#regex:reactor.core.publisher.Flux<(.*?)>]", entries[0].key)
         assertEquals("java.util.List<\${1}>", entries[0].value)
@@ -145,8 +166,8 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseMultipleColonsInsideBrackets() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("rule[a:b:c]=value", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("rule[a:b:c]=value", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("rule[a:b:c]", entries[0].key)
         assertEquals("value", entries[0].value)
@@ -154,10 +175,193 @@ class ConfigTextParserTest {
 
     @Test
     fun testParseColonInValueAfterBracketedKey() {
-        val parser = ConfigTextParser(null)
-        val entries = parser.parse("rule[filter]=host:port", "test").toList()
+        val parser = newParser()
+        val entries = runBlocking { parser.parse("rule[filter]=host:port", "test").toList() }
         assertEquals(1, entries.size)
         assertEquals("rule[filter]", entries[0].key)
         assertEquals("host:port", entries[0].value)
+    }
+
+    // ── properties.additional ──
+
+    @Test
+    fun testPropertiesAdditionalLoadsLocalFile() {
+        val additionalContent = "api.name=from-additional"
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("./additional.properties", "/base"))
+                .thenReturn(LoadedConfigResource(additionalContent, "/base"))
+        }
+        val parser = newParser(loader = loader)
+        val entries = runBlocking { parser.parse("properties.additional=./additional.properties", "test", "/base").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("from-additional", entries[0].value)
+    }
+
+    @Test
+    fun testPropertiesAdditionalLoadsRemoteUrl() {
+        val additionalContent = "api.name=from-remote"
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("https://example.com/rules.config", "/base"))
+                .thenReturn(LoadedConfigResource(additionalContent, "https://example.com"))
+        }
+        val parser = newParser(loader = loader)
+        val entries = runBlocking { parser.parse("properties.additional=https://example.com/rules.config", "test", "/base").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("from-remote", entries[0].value)
+    }
+
+    @Test
+    fun testPropertiesAdditionalThrowsWhenLoadFails() {
+        val loader = mock<ConfigResourceLoader>()
+        // load() returns null by default for unstubbed mocks
+        val parser = newParser(loader = loader)
+        try {
+            runBlocking { parser.parse("properties.additional=./missing.properties", "test", "/base").toList() }
+            fail("Expected IllegalStateException when additional resource cannot be resolved")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("./missing.properties"))
+        }
+    }
+
+    @Test
+    fun testPropertiesAdditionalIgnoredWhenLoadFailsWithDirective() {
+        val loader = mock<ConfigResourceLoader>()
+        val parser = newParser(loader = loader)
+        val text = """
+            ###set ignoreNotFoundFile=true
+            properties.additional=./missing.properties
+            api.name=still-here
+        """.trimIndent()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("still-here", entries[0].value)
+    }
+
+    @Test
+    fun testPropertiesAdditionalPropagatesBaseDirFromLoadedResource() {
+        // The included file references another relative include; the baseDir
+        // for that nested include should come from the loaded resource, not
+        // the parent's baseDir.
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("./first.properties", "/original")).thenReturn(
+                LoadedConfigResource(
+                    "properties.additional=./second.properties\napi.name=first",
+                    "/first-dir"
+                )
+            )
+            whenever(loader.load("./second.properties", "/first-dir")).thenReturn(
+                LoadedConfigResource("api.version=2.0", "/first-dir")
+            )
+        }
+        val parser = newParser(loader = loader)
+        val entries = runBlocking { parser.parse("properties.additional=./first.properties", "test", "/original").toList() }
+        assertEquals(2, entries.size)
+        // The nested include is processed first (properties.additional line
+        // appears before api.name in first.properties), so api.version comes first.
+        assertEquals("api.version", entries[0].key)
+        assertEquals("2.0", entries[0].value)
+        assertEquals("api.name", entries[1].key)
+        assertEquals("first", entries[1].value)
+    }
+
+    // ── ###include ──
+
+    @Test
+    fun testIncludeDirectiveLoadsLocalFile() {
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("./additional.properties", "/base"))
+                .thenReturn(LoadedConfigResource("api.name=from-include", "/base"))
+        }
+        val parser = newParser(loader = loader)
+        val entries = runBlocking { parser.parse("###include ./additional.properties", "test", "/base").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("from-include", entries[0].value)
+    }
+
+    @Test
+    fun testIncludeDirectiveLoadsRemoteUrl() {
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("https://example.com/rules.config", "/base"))
+                .thenReturn(LoadedConfigResource("api.name=from-remote", "https://example.com"))
+        }
+        val parser = newParser(loader = loader)
+        val entries = runBlocking { parser.parse("###include https://example.com/rules.config", "test", "/base").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("from-remote", entries[0].value)
+    }
+
+    @Test
+    fun testIncludeDirectiveThrowsWhenLoadFails() {
+        val loader = mock<ConfigResourceLoader>()
+        val parser = newParser(loader = loader)
+        try {
+            runBlocking { parser.parse("###include ./missing.properties", "test", "/base").toList() }
+            fail("Expected IllegalStateException when included resource cannot be resolved")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("./missing.properties"))
+        }
+    }
+
+    @Test
+    fun testIncludeDirectiveIgnoredWhenLoadFailsWithDirective() {
+        val loader = mock<ConfigResourceLoader>()
+        val parser = newParser(loader = loader)
+        val text = """
+            ###set ignoreNotFoundFile=true
+            ###include ./missing.properties
+            api.name=still-here
+        """.trimIndent()
+        val entries = runBlocking { parser.parse(text, "test").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("still-here", entries[0].value)
+    }
+
+    @Test
+    fun testIncludeDirectiveSkippedInInactiveConditionalBlock() {
+        val loader = mock<ConfigResourceLoader>()
+        val parser = newParser(loader = loader)
+        val text = """
+            ###if builtInConfig==false
+            ###include ./should-not-load.properties
+            ###endif
+            api.name=outside
+        """.trimIndent()
+        // builtInConfig defaults to null, so the condition is inactive and the
+        // include must not be attempted (loader returns null -> would throw).
+        val entries = runBlocking { parser.parse(text, "test").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertEquals("outside", entries[0].value)
+    }
+
+    @Test
+    fun testIncludeDirectiveInheritsDirectiveState() {
+        // ignoreUnresolved set before the include should carry into the
+        // included file's entries (outer state is reused, not reset).
+        val loader = mock<ConfigResourceLoader>()
+        runBlocking {
+            whenever(loader.load("./additional.properties", "/base"))
+                .thenReturn(LoadedConfigResource("api.name=included", "/base"))
+        }
+        val parser = newParser(loader = loader)
+        val text = """
+            ###set ignoreUnresolved=true
+            ###include ./additional.properties
+        """.trimIndent()
+        val entries = runBlocking { parser.parse(text, "test", "/base").toList() }
+        assertEquals(1, entries.size)
+        assertEquals("api.name", entries[0].key)
+        assertTrue(entries[0].directives.ignoreUnresolved)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolverTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/resource/CachedResourceResolverTest.kt
@@ -1,6 +1,10 @@
 package com.itangcent.easyapi.config.resource
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.logging.IdeaConsole
+import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.Settings
 import com.itangcent.easyapi.util.storage.LocalStorage
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
@@ -8,17 +12,31 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class CachedResourceResolverTest {
 
+    private lateinit var project: Project
     private lateinit var localStorage: LocalStorage
     private lateinit var console: IdeaConsole
     private lateinit var resolver: CachedResourceResolver
 
     @Before
     fun setUp() {
+        project = mock()
         localStorage = mock(LocalStorage::class.java)
         console = mock(IdeaConsole::class.java)
+
+        val ideaConsoleProvider = mock<IdeaConsoleProvider>()
+        whenever(ideaConsoleProvider.getConsole()).thenReturn(console)
+
+        val settingBinder = mock<SettingBinder>()
+        whenever(settingBinder.read()).thenReturn(Settings(httpTimeOut = 60))
+
+        whenever(project.getService(LocalStorage::class.java)).thenReturn(localStorage)
+        whenever(project.getService(IdeaConsoleProvider::class.java)).thenReturn(ideaConsoleProvider)
+        whenever(project.getService(SettingBinder::class.java)).thenReturn(settingBinder)
     }
 
     @Test
@@ -29,7 +47,7 @@ class CachedResourceResolverTest {
         `when`(localStorage.get("remote-cache", url)).thenReturn(cachedContent)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(System.currentTimeMillis().toString())
 
-        resolver = CachedResourceResolver(localStorage, console, 60000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             val result = resolver.get(url)
@@ -41,12 +59,13 @@ class CachedResourceResolverTest {
     fun testGetWithExpiredCache() {
         val url = "https://fake-local-test.example/config.txt"
         val cachedContent = "cached content"
-        val oldTimestamp = (System.currentTimeMillis() - 100000).toString()
+        // TTL is 2 hours; use a timestamp 3 hours ago to ensure expiry
+        val oldTimestamp = (System.currentTimeMillis() - 3 * 60 * 60 * 1000L).toString()
 
         `when`(localStorage.get("remote-cache", url)).thenReturn(cachedContent)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(oldTimestamp)
 
-        resolver = CachedResourceResolver(localStorage, console, 1000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             val result = resolver.get(url)
@@ -61,7 +80,7 @@ class CachedResourceResolverTest {
         `when`(localStorage.get("remote-cache", url)).thenReturn(null)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(null)
 
-        resolver = CachedResourceResolver(localStorage, console, 60000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             val result = resolver.get(url)
@@ -76,7 +95,7 @@ class CachedResourceResolverTest {
         `when`(localStorage.get("remote-cache", url)).thenReturn(null)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(null)
 
-        resolver = CachedResourceResolver(localStorage, console, 60000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             resolver.get(url)
@@ -91,7 +110,7 @@ class CachedResourceResolverTest {
         `when`(localStorage.get("remote-cache", url)).thenReturn("content")
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(System.currentTimeMillis().toString())
 
-        resolver = CachedResourceResolver(localStorage, console, 60000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             resolver.get(url)
@@ -106,7 +125,7 @@ class CachedResourceResolverTest {
         `when`(localStorage.get("remote-cache", url)).thenReturn(null)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(null)
 
-        resolver = CachedResourceResolver(localStorage, console, 60000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             val result = resolver.get(url)
@@ -120,12 +139,13 @@ class CachedResourceResolverTest {
     fun testFetchFailureWithExpiredCacheReturnsStaleContent() {
         val url = "https://fake-local-test.example/config.txt"
         val staleContent = "stale content"
-        val oldTimestamp = (System.currentTimeMillis() - 100000).toString()
+        // TTL is 2 hours; use a timestamp 3 hours ago to ensure expiry
+        val oldTimestamp = (System.currentTimeMillis() - 3 * 60 * 60 * 1000L).toString()
 
         `when`(localStorage.get("remote-cache", url)).thenReturn(staleContent)
         `when`(localStorage.get("remote-cache-ts", url)).thenReturn(oldTimestamp)
 
-        resolver = CachedResourceResolver(localStorage, console, 1000L)
+        resolver = CachedResourceResolver(project)
 
         runBlocking {
             val result = resolver.get(url)

--- a/src/test/kotlin/com/itangcent/easyapi/config/resource/ConfigResourceLoaderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/resource/ConfigResourceLoaderTest.kt
@@ -1,0 +1,125 @@
+package com.itangcent.easyapi.config.resource
+
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ConfigResourceLoaderTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var project: Project
+    private lateinit var cachedResourceResolver: CachedResourceResolver
+
+    @Before
+    fun setUp() {
+        project = mock()
+        cachedResourceResolver = mock()
+        whenever(project.getService(CachedResourceResolver::class.java))
+            .thenReturn(cachedResourceResolver)
+    }
+
+    @Test
+    fun testLoadLocalAbsoluteFile() {
+        val file = tempFolder.newFile("rules.properties")
+        file.writeText("api.name=test")
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load(file.absolutePath, null) }
+
+        assertNotNull(result)
+        assertEquals("api.name=test", result!!.content)
+        assertEquals(file.parentFile.absolutePath, result.baseDir)
+    }
+
+    @Test
+    fun testLoadLocalRelativeFileWithBaseDir() {
+        val subDir = tempFolder.newFolder("sub")
+        val file = java.io.File(subDir, "additional.properties")
+        file.writeText("api.version=1.0")
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load("additional.properties", subDir.absolutePath) }
+
+        assertNotNull(result)
+        assertEquals("api.version=1.0", result!!.content)
+        assertEquals(subDir.absolutePath, result.baseDir)
+    }
+
+    @Test
+    fun testLoadLocalFileTrimsQuotes() {
+        val file = tempFolder.newFile("rules.properties")
+        file.writeText("api.name=quoted")
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load("\"${file.absolutePath}\"", null) }
+
+        assertNotNull(result)
+        assertEquals("api.name=quoted", result!!.content)
+    }
+
+    @Test
+    fun testLoadReturnsNullForMissingFile() {
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load("/nonexistent/path/to/file.properties", null) }
+        assertNull(result)
+    }
+
+    @Test
+    fun testLoadRemoteUrlWithResolver() {
+        val url = "https://example.com/config/rules.properties"
+        val content = "api.name=remote"
+        runBlocking { whenever(cachedResourceResolver.get(url)).thenReturn(content) }
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load(url, null) }
+
+        assertNotNull(result)
+        assertEquals(content, result!!.content)
+        assertEquals("https://example.com/config", result.baseDir)
+    }
+
+    @Test
+    fun testLoadRemoteUrlWhenFetchFailsReturnsNull() {
+        val url = "https://example.com/config/rules.properties"
+        runBlocking { whenever(cachedResourceResolver.get(url)).thenReturn(null) }
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load(url, null) }
+        assertNull(result)
+    }
+
+    @Test
+    fun testLoadRemoteUrlBaseDirIsParentUrl() {
+        val url = "https://cdn.example.com/a/b/c/rules.properties"
+        runBlocking { whenever(cachedResourceResolver.get(url)).thenReturn("content") }
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load(url, "/some/base") }
+
+        assertNotNull(result)
+        // baseDir should be derived from the URL, not the passed-in baseDir
+        assertEquals("https://cdn.example.com/a/b/c", result!!.baseDir)
+    }
+
+    @Test
+    fun testLoadRemoteUrlWithNoPathSeparator() {
+        val url = "https://example.com"
+        runBlocking { whenever(cachedResourceResolver.get(url)).thenReturn("content") }
+
+        val loader = ConfigResourceLoader(project)
+        val result = runBlocking { loader.load(url, null) }
+
+        assertNotNull(result)
+        assertEquals("content", result!!.content)
+        // When there's no path after the host, the baseDir is the URL itself
+        assertEquals(url, result.baseDir)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/ExtensionConfigSourceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/ExtensionConfigSourceTest.kt
@@ -7,7 +7,12 @@ import kotlinx.coroutines.runBlocking
 
 class ExtensionConfigSourceTest : EasyApiLightCodeInsightFixtureTestCase() {
 
-    private val configTextParser = ConfigTextParser(null)
+    private lateinit var configTextParser: ConfigTextParser
+
+    override fun setUp() {
+        super.setUp()
+        configTextParser = ConfigTextParser.getInstance(project)
+    }
 
     fun testPriority() {
         val source = ExtensionConfigSource(project, null, configTextParser)

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/GlobalFileConfigSourceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/GlobalFileConfigSourceTest.kt
@@ -1,8 +1,10 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.config.parser.DirectiveSnapshot
+import com.itangcent.easyapi.settings.SettingBinder
 import com.itangcent.easyapi.settings.Settings
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
@@ -21,30 +23,43 @@ class GlobalFileConfigSourceTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
-    private lateinit var realParser: ConfigTextParser
+    private lateinit var realParserProject: Project
+    private lateinit var mockParserProject: Project
     private lateinit var mockParser: ConfigTextParser
 
     @Before
     fun setUp() {
-        realParser = ConfigTextParser(Settings())
+        realParserProject = newProjectWithRealParser()
         mockParser = mock()
+        mockParserProject = mock()
+        whenever(mockParserProject.getService(ConfigTextParser::class.java)).thenReturn(mockParser)
+    }
+
+    private fun newProjectWithRealParser(): Project {
+        val project = mock<Project>()
+        val settingBinder = mock<SettingBinder>()
+        whenever(settingBinder.read()).thenReturn(Settings())
+        whenever(project.getService(SettingBinder::class.java)).thenReturn(settingBinder)
+        val realParser = ConfigTextParser(project)
+        whenever(project.getService(ConfigTextParser::class.java)).thenReturn(realParser)
+        return project
     }
 
     @Test
     fun testPriority() {
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         assertEquals(2, source.priority)
     }
 
     @Test
     fun testSourceId() {
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         assertEquals("global-file", source.sourceId)
     }
 
     @Test
     fun testEmptyFileList() = runBlocking {
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
         assertTrue(entries.isEmpty())
     }
@@ -54,7 +69,7 @@ class GlobalFileConfigSourceTest {
         val configFile = tempFolder.newFile("global.easy.api.config")
         configFile.writeText("api.name=Test API\napi.version=1.0.0")
 
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
 
         assertEquals(2, entries.size)
@@ -79,7 +94,7 @@ class GlobalFileConfigSourceTest {
             .thenReturn(parsedEntries1)
             .thenReturn(parsedEntries2)
 
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), mockParser)
+        val source = GlobalFileConfigSource(mockParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
 
         assertEquals(2, entries.size)
@@ -95,9 +110,9 @@ class GlobalFileConfigSourceTest {
         disabled.writeText("api.name=Hidden")
 
         val source = GlobalFileConfigSource(
+            realParserProject,
             tempFolder.root.toPath(),
-            disabledFiles = setOf(disabled.absolutePath),
-            configTextParser = realParser
+            disabledFiles = setOf(disabled.absolutePath)
         )
         val entries = source.collect().toList()
 
@@ -111,7 +126,7 @@ class GlobalFileConfigSourceTest {
         val realFile = tempFolder.newFile("real.config")
         realFile.writeText("api.name=Real")
 
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
 
         assertEquals(1, entries.size)
@@ -123,7 +138,7 @@ class GlobalFileConfigSourceTest {
         val configFile = tempFolder.newFile("check.config")
         configFile.writeText("api.name=Check")
 
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), realParser)
+        val source = GlobalFileConfigSource(realParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
 
         assertTrue(entries.isNotEmpty())
@@ -139,7 +154,7 @@ class GlobalFileConfigSourceTest {
             sequenceOf(ConfigEntry("api.name", "YamlTest", "global-file", DirectiveSnapshot()))
         )
 
-        val source = GlobalFileConfigSource(tempFolder.root.toPath(), emptySet(), mockParser)
+        val source = GlobalFileConfigSource(mockParserProject, tempFolder.root.toPath(), emptySet())
         val entries = source.collect().toList()
 
         assertEquals(1, entries.size)

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/JacksonConfigIntegrationTest.kt
@@ -2,7 +2,6 @@ package com.itangcent.easyapi.config.source
 
 import com.itangcent.easyapi.config.ConfigReader
 import com.itangcent.easyapi.config.LayeredConfigReader
-import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.exporter.model.HttpMethod
 import com.itangcent.easyapi.exporter.model.httpMetadata
 import com.itangcent.easyapi.exporter.springmvc.SpringMvcClassExporter

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/ProjectFileConfigSourceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/ProjectFileConfigSourceTest.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.config.parser.DirectiveSnapshot
@@ -19,29 +20,32 @@ class ProjectFileConfigSourceTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
+    private lateinit var project: Project
     private lateinit var configTextParser: ConfigTextParser
     private lateinit var projectFileConfigSource: ProjectFileConfigSource
 
     @Before
     fun setUp() {
         configTextParser = mock()
+        project = mock()
+        whenever(project.getService(ConfigTextParser::class.java)).thenReturn(configTextParser)
     }
 
     @Test
     fun testPriority() {
-        projectFileConfigSource = ProjectFileConfigSource("/tmp", configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, "/tmp")
         assertEquals(4, projectFileConfigSource.priority)
     }
 
     @Test
     fun testSourceId() {
-        projectFileConfigSource = ProjectFileConfigSource("/tmp", configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, "/tmp")
         assertEquals("project", projectFileConfigSource.sourceId)
     }
 
     @Test
     fun testCollectWithNoConfigFiles() {
-        projectFileConfigSource = ProjectFileConfigSource(tempFolder.root.absolutePath, configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, tempFolder.root.absolutePath)
 
         runBlocking {
             val entries = projectFileConfigSource.collect().toList()
@@ -58,11 +62,11 @@ class ProjectFileConfigSourceTest {
             ConfigEntry("server", "https://api.example.com", "project", DirectiveSnapshot())
         )
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
-
-        projectFileConfigSource = ProjectFileConfigSource(tempFolder.root.absolutePath, configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, tempFolder.root.absolutePath)
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(1, entries.size)
             assertEquals("server", entries[0].key)
@@ -79,11 +83,11 @@ class ProjectFileConfigSourceTest {
             ConfigEntry("timeout", "30000", "project", DirectiveSnapshot())
         )
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
-
-        projectFileConfigSource = ProjectFileConfigSource(tempFolder.root.absolutePath, configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, tempFolder.root.absolutePath)
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(1, entries.size)
             assertEquals("timeout", entries[0].key)
@@ -99,11 +103,11 @@ class ProjectFileConfigSourceTest {
             ConfigEntry("server", "https://api.example.com", "project", DirectiveSnapshot())
         )
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
-
-        projectFileConfigSource = ProjectFileConfigSource(tempFolder.root.absolutePath, configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, tempFolder.root.absolutePath)
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(parsedEntries)
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(1, entries.size)
         }
@@ -111,7 +115,7 @@ class ProjectFileConfigSourceTest {
 
     @Test
     fun testSetProjectBasePath() {
-        projectFileConfigSource = ProjectFileConfigSource("/tmp", configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, "/tmp")
         assertEquals("project", projectFileConfigSource.sourceId)
 
         projectFileConfigSource.setProjectBasePath("/new/path")
@@ -133,13 +137,13 @@ class ProjectFileConfigSourceTest {
             ConfigEntry("timeout", "30000", "project", DirectiveSnapshot())
         )
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull()))
-.thenReturn(parsedEntries1)
-.thenReturn(parsedEntries2)
-
-        projectFileConfigSource = ProjectFileConfigSource(tempFolder.root.absolutePath, configTextParser)
+        projectFileConfigSource = ProjectFileConfigSource(project, tempFolder.root.absolutePath)
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull()))
+                .thenReturn(parsedEntries1)
+                .thenReturn(parsedEntries2)
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(2, entries.size)
         }
@@ -184,17 +188,17 @@ class ProjectFileConfigSourceTest {
         val configFile = tempFolder.newFile(".easy.api.config")
         configFile.writeText("api.name=SkipMe")
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
-            sequenceOf(ConfigEntry("api.name", "SkipMe", "project", DirectiveSnapshot()))
-        )
-
         projectFileConfigSource = ProjectFileConfigSource(
+            project,
             tempFolder.root.absolutePath,
-            configTextParser,
             disabledFiles = setOf(configFile.absolutePath)
         )
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
+                sequenceOf(ConfigEntry("api.name", "SkipMe", "project", DirectiveSnapshot()))
+            )
+
             val entries = projectFileConfigSource.collect().toList()
             assertTrue("disabled file should be skipped", entries.isEmpty())
         }
@@ -205,16 +209,16 @@ class ProjectFileConfigSourceTest {
         val easyapiDir = tempFolder.newFolder(".easyapi")
         val ruleFile = java.io.File(easyapiDir, "rule.properties").apply { writeText("api.name=FromFolder") }
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
-            sequenceOf(ConfigEntry("api.name", "FromFolder", "project", DirectiveSnapshot()))
-        )
-
         projectFileConfigSource = ProjectFileConfigSource(
-            tempFolder.root.absolutePath,
-            configTextParser
+            project,
+            tempFolder.root.absolutePath
         )
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
+                sequenceOf(ConfigEntry("api.name", "FromFolder", "project", DirectiveSnapshot()))
+            )
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(1, entries.size)
             assertEquals("FromFolder", entries[0].value)
@@ -228,16 +232,16 @@ class ProjectFileConfigSourceTest {
         val legacyFile = tempFolder.newFile(".easy.api.config")
         legacyFile.writeText("api.name=Legacy")
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull()))
-.thenReturn(sequenceOf(ConfigEntry("api.name", "Folder", "project", DirectiveSnapshot())))
-.thenReturn(sequenceOf(ConfigEntry("api.name", "Legacy", "project", DirectiveSnapshot())))
-
         projectFileConfigSource = ProjectFileConfigSource(
-            tempFolder.root.absolutePath,
-            configTextParser
+            project,
+            tempFolder.root.absolutePath
         )
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull()))
+                .thenReturn(sequenceOf(ConfigEntry("api.name", "Folder", "project", DirectiveSnapshot())))
+                .thenReturn(sequenceOf(ConfigEntry("api.name", "Legacy", "project", DirectiveSnapshot())))
+
             val entries = projectFileConfigSource.collect().toList()
             assertEquals(2, entries.size)
         }
@@ -248,17 +252,17 @@ class ProjectFileConfigSourceTest {
         val easyapiDir = tempFolder.newFolder(".easyapi")
         val ruleFile = java.io.File(easyapiDir, "rule.properties").apply { writeText("api.name=Skip") }
 
-        whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
-            sequenceOf(ConfigEntry("api.name", "Skip", "project", DirectiveSnapshot()))
-        )
-
         projectFileConfigSource = ProjectFileConfigSource(
+            project,
             tempFolder.root.absolutePath,
-            configTextParser,
             disabledFiles = setOf(ruleFile.absolutePath)
         )
 
         runBlocking {
+            whenever(configTextParser.parse(any(), any(), anyOrNull())).thenReturn(
+                sequenceOf(ConfigEntry("api.name", "Skip", "project", DirectiveSnapshot()))
+            )
+
             val entries = projectFileConfigSource.collect().toList()
             assertTrue("disabled folder file should be skipped", entries.isEmpty())
         }

--- a/src/test/kotlin/com/itangcent/easyapi/config/source/UrlConfigSourceTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/config/source/UrlConfigSourceTest.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.config.source
 
+import com.intellij.openapi.project.Project
 import com.itangcent.easyapi.config.model.ConfigEntry
 import com.itangcent.easyapi.config.parser.ConfigTextParser
 import com.itangcent.easyapi.config.parser.DirectiveSnapshot
@@ -14,36 +15,40 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-class RemoteConfigSourceTest {
+class UrlConfigSourceTest {
 
+    private lateinit var project: Project
     private lateinit var cachedResourceResolver: CachedResourceResolver
     private lateinit var configTextParser: ConfigTextParser
-    private lateinit var remoteConfigSource: RemoteConfigSource
+    private lateinit var urlConfigSource: UrlConfigSource
 
     @Before
     fun setUp() {
+        project = mock()
         cachedResourceResolver = mock()
         configTextParser = mock()
+        whenever(project.getService(CachedResourceResolver::class.java))
+            .thenReturn(cachedResourceResolver)
     }
 
     @Test
     fun testPriority() {
-        remoteConfigSource = RemoteConfigSource(emptyList(), configTextParser, cachedResourceResolver)
-        assertEquals(3, remoteConfigSource.priority)
+        urlConfigSource = UrlConfigSource(emptyList(), configTextParser, project)
+        assertEquals(3, urlConfigSource.priority)
     }
 
     @Test
     fun testSourceId() {
-        remoteConfigSource = RemoteConfigSource(emptyList(), configTextParser, cachedResourceResolver)
-        assertEquals("remote", remoteConfigSource.sourceId)
+        urlConfigSource = UrlConfigSource(emptyList(), configTextParser, project)
+        assertEquals("remote", urlConfigSource.sourceId)
     }
 
     @Test
     fun testCollectWithEmptyUrls() {
-        remoteConfigSource = RemoteConfigSource(emptyList(), configTextParser, cachedResourceResolver)
-        
+        urlConfigSource = UrlConfigSource(emptyList(), configTextParser, project)
+
         runBlocking {
-            val entries = remoteConfigSource.collect().toList()
+            val entries = urlConfigSource.collect().toList()
             assertTrue(entries.isEmpty())
         }
     }
@@ -55,16 +60,16 @@ class RemoteConfigSourceTest {
         val parsedEntries = sequenceOf(
             ConfigEntry("server", "https://api.example.com", "remote", DirectiveSnapshot())
         )
-        
+
         runBlocking {
             whenever(cachedResourceResolver.get(url)).thenReturn(content)
             whenever(configTextParser.parse(content, "remote", "https://fake-local-test.example")).thenReturn(parsedEntries)
         }
-        
-        remoteConfigSource = RemoteConfigSource(listOf(url), configTextParser, cachedResourceResolver)
-        
+
+        urlConfigSource = UrlConfigSource(listOf(url), configTextParser, project)
+
         runBlocking {
-            val entries = remoteConfigSource.collect().toList()
+            val entries = urlConfigSource.collect().toList()
             assertEquals(1, entries.size)
             assertEquals("server", entries[0].key)
             assertEquals("https://api.example.com", entries[0].value)
@@ -77,7 +82,7 @@ class RemoteConfigSourceTest {
         val url2 = "https://fake-local-test.example/config2.txt"
         val content1 = "server=https://api1.example.com"
         val content2 = "token=abc123"
-        
+
         runBlocking {
             whenever(cachedResourceResolver.get(url1)).thenReturn(content1)
             whenever(cachedResourceResolver.get(url2)).thenReturn(content2)
@@ -88,11 +93,11 @@ class RemoteConfigSourceTest {
                 sequenceOf(ConfigEntry("token", "abc123", "remote", DirectiveSnapshot()))
             )
         }
-        
-        remoteConfigSource = RemoteConfigSource(listOf(url1, url2), configTextParser, cachedResourceResolver)
-        
+
+        urlConfigSource = UrlConfigSource(listOf(url1, url2), configTextParser, project)
+
         runBlocking {
-            val entries = remoteConfigSource.collect().toList()
+            val entries = urlConfigSource.collect().toList()
             assertEquals(2, entries.size)
         }
     }
@@ -100,15 +105,15 @@ class RemoteConfigSourceTest {
     @Test
     fun testCollectWithNullContent() {
         val url = "https://fake-local-test.example/config.txt"
-        
+
         runBlocking {
             whenever(cachedResourceResolver.get(url)).thenReturn(null)
         }
-        
-        remoteConfigSource = RemoteConfigSource(listOf(url), configTextParser, cachedResourceResolver)
-        
+
+        urlConfigSource = UrlConfigSource(listOf(url), configTextParser, project)
+
         runBlocking {
-            val entries = remoteConfigSource.collect().toList()
+            val entries = urlConfigSource.collect().toList()
             assertTrue(entries.isEmpty())
             verify(configTextParser, never()).parse(any(), any(), any())
         }
@@ -119,7 +124,7 @@ class RemoteConfigSourceTest {
         val url1 = "https://fake-local-test.example/config1.txt"
         val url2 = "https://fake-local-test.example/config2.txt"
         val content2 = "token=abc123"
-        
+
         runBlocking {
             whenever(cachedResourceResolver.get(url1)).thenReturn(null)
             whenever(cachedResourceResolver.get(url2)).thenReturn(content2)
@@ -127,11 +132,11 @@ class RemoteConfigSourceTest {
                 sequenceOf(ConfigEntry("token", "abc123", "remote", DirectiveSnapshot()))
             )
         }
-        
-        remoteConfigSource = RemoteConfigSource(listOf(url1, url2), configTextParser, cachedResourceResolver)
-        
+
+        urlConfigSource = UrlConfigSource(listOf(url1, url2), configTextParser, project)
+
         runBlocking {
-            val entries = remoteConfigSource.collect().toList()
+            val entries = urlConfigSource.collect().toList()
             assertEquals(1, entries.size)
             assertEquals("token", entries[0].key)
         }

--- a/src/test/kotlin/com/itangcent/easyapi/util/text/KeyValueLineParserTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/util/text/KeyValueLineParserTest.kt
@@ -1,0 +1,178 @@
+package com.itangcent.easyapi.util.text
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Unit tests for [KeyValueLineParser].
+ */
+class KeyValueLineParserTest {
+
+    // ── splitKeyValue ──
+
+    @Test
+    fun testSplitKeyValueWithEquals() {
+        val result = KeyValueLineParser.splitKeyValue("api.name=test-api")
+        assertEquals("api.name" to "test-api", result)
+    }
+
+    @Test
+    fun testSplitKeyValueWithColon() {
+        val result = KeyValueLineParser.splitKeyValue("api.name:test-api")
+        assertEquals("api.name" to "test-api", result)
+    }
+
+    @Test
+    fun testSplitKeyValueUsesFirstSeparator() {
+        // The first top-level separator wins; a later '=' becomes part of the value.
+        val result = KeyValueLineParser.splitKeyValue("key=a=b")
+        assertEquals("key" to "a=b", result)
+    }
+
+    @Test
+    fun testSplitKeyValueEqualsBeforeColonWins() {
+        val result = KeyValueLineParser.splitKeyValue("key=host:port")
+        assertEquals("key" to "host:port", result)
+    }
+
+    @Test
+    fun testSplitKeyValueColonBeforeEqualsWins() {
+        val result = KeyValueLineParser.splitKeyValue("key:a=b")
+        assertEquals("key" to "a=b", result)
+    }
+
+    @Test
+    fun testSplitKeyValueTrimsKeyAndValue() {
+        val result = KeyValueLineParser.splitKeyValue("  key  =  value  ")
+        assertEquals("key" to "value", result)
+    }
+
+    @Test
+    fun testSplitKeyValueEmptyValue() {
+        val result = KeyValueLineParser.splitKeyValue("key=")
+        assertEquals("key" to "", result)
+    }
+
+    @Test
+    fun testSplitKeyValueSeparatorInsideBracketsIgnored() {
+        val result = KeyValueLineParser.splitKeyValue("rule[#regex:some.Type]=replacement")
+        assertEquals("rule[#regex:some.Type]" to "replacement", result)
+    }
+
+    @Test
+    fun testSplitKeyValueMultipleSeparatorsInsideBracketsIgnored() {
+        val result = KeyValueLineParser.splitKeyValue("rule[a:b:c]=value")
+        assertEquals("rule[a:b:c]" to "value", result)
+    }
+
+    @Test
+    fun testSplitKeyValueNestedBrackets() {
+        val result = KeyValueLineParser.splitKeyValue("rule[a[b:c]d]=value")
+        assertEquals("rule[a[b:c]d]" to "value", result)
+    }
+
+    @Test
+    fun testSplitKeyValueNoSeparatorReturnsNull() {
+        assertNull(KeyValueLineParser.splitKeyValue("just-a-key"))
+    }
+
+    @Test
+    fun testSplitKeyValueOnlySeparatorInsideBracketsReturnsNull() {
+        // The only separators are nested in brackets, so there is no top-level split.
+        assertNull(KeyValueLineParser.splitKeyValue("rule[a:b]"))
+    }
+
+    @Test
+    fun testSplitKeyValueSeparatorAtStartReturnsNull() {
+        // i > 0 guard: a leading separator does not produce an empty key split.
+        assertNull(KeyValueLineParser.splitKeyValue("=value"))
+    }
+
+    @Test
+    fun testSplitKeyValueBlankKeyReturnsNull() {
+        assertNull(KeyValueLineParser.splitKeyValue("   =value"))
+    }
+
+    @Test
+    fun testSplitKeyValueEmptyStringReturnsNull() {
+        assertNull(KeyValueLineParser.splitKeyValue(""))
+    }
+
+    @Test
+    fun testSplitKeyValueUnbalancedClosingBracket() {
+        // Stray ']' keeps bracketDepth at 0, so the '=' is a valid top-level separator.
+        val result = KeyValueLineParser.splitKeyValue("key]=value")
+        assertEquals("key]" to "value", result)
+    }
+
+    // ── splitKeyFilterValue ──
+
+    @Test
+    fun testSplitKeyFilterValueWithFilter() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key[filter]=value")
+        assertEquals(Triple("key", "filter", "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueWithoutFilter() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key=value")
+        assertEquals(Triple("key", null, "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueColonSeparator() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key[filter]:value")
+        assertEquals(Triple("key", "filter", "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueFilterContainingSeparators() {
+        val result = KeyValueLineParser.splitKeyFilterValue("json.rule.convert[#regex:some.Type]=replacement")
+        assertEquals(Triple("json.rule.convert", "#regex:some.Type", "replacement"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueUnterminatedBracketSwallowsSeparator() {
+        // The '[' is never closed, so the '=' is treated as nested inside the
+        // bracket and no top-level separator is found -> null.
+        assertNull(KeyValueLineParser.splitKeyFilterValue("key[filter=value"))
+    }
+
+    @Test
+    fun testSplitKeyFilterValueBracketNotAtEndTreatedAsKey() {
+        // Left-hand side contains a closed '[...]' but does not end with ']',
+        // so the whole left-hand side is returned as the key.
+        val result = KeyValueLineParser.splitKeyFilterValue("key[filter]suffix=value")
+        assertEquals(Triple("key[filter]suffix", null, "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueEmptyKeyTreatedAsKey() {
+        // Empty key before '[' → whole left-hand side returned as key, null filter.
+        val result = KeyValueLineParser.splitKeyFilterValue("[filter]=value")
+        assertEquals(Triple("[filter]", null, "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueEmptyFilterTreatedAsKey() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key[]=value")
+        assertEquals(Triple("key[]", null, "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueTrimsKeyAndFilter() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key[ filter ]=value")
+        assertEquals(Triple("key", "filter", "value"), result)
+    }
+
+    @Test
+    fun testSplitKeyFilterValueNoSeparatorReturnsNull() {
+        assertNull(KeyValueLineParser.splitKeyFilterValue("key[filter]"))
+    }
+
+    @Test
+    fun testSplitKeyFilterValueEmptyValue() {
+        val result = KeyValueLineParser.splitKeyFilterValue("key[filter]=")
+        assertEquals(Triple("key", "filter", ""), result)
+    }
+}


### PR DESCRIPTION
## Description

The `###include` directive in `.easy.api.config` files now supports both local file paths and remote URLs, allowing shared rule snippets to be sourced from anywhere. Previously, `properties.additional` could only reference local paths.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Fixes #

## Changes Made

- Added `###include <path-or-url>` directive support in `ConfigTextParser`, enabling config files to include other configs by local path or URL.
- Introduced `ConfigResourceLoader` (project service) to uniformly load config content from local files and remote URLs.
- Renamed `RemoteConfigSource` to `UrlConfigSource` and refactored it as a project-scoped source.
- Refactored `CachedResourceResolver` as a project service with TTL/timeout driven by project settings.
- Added `FileConfigHelper` and `KeyValueLineParser` utilities for file resolution and `properties.additional` parsing.
- Updated `FileConfigSource`, `GlobalFileConfigSource`, and `ProjectFileConfigSource` to delegate read/parse through the new loader.

## Testing

- [x] Unit tests pass
- [ ] Manual testing completed
- [x] New tests added for new functionality

Added/updated tests: `ConfigTextParserTest`, `ConfigResourceLoaderTest`, `UrlConfigSourceTest`, `FileConfigHelperTest`, `KeyValueLineParserTest`, `CachedResourceResolverTest`, `LayeredConfigReaderTest`, `GlobalFileConfigSourceTest`, `ProjectFileConfigSourceTest`, `ExtensionConfigSourceTest`, `JacksonConfigIntegrationTest`.

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The `###include` directive is processed before generic directives in `ConfigTextParser`, so included content is inlined into the parsing stream. Remote URL fetches go through `CachedResourceResolver` to avoid redundant network calls.
