### PR TITLE
docs(readme): sync Architecture section with v3.0 channel EP and add YAML field conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Convert class fields to various formats:
 - **To JSON** — Standard JSON with default values
 - **To JSON5** — JSON5 format with comments support
 - **To Properties** — Java `.properties` format
+- **To YAML** — YAML format with Spring Boot `application.yml` semantics (honors `@ConfigurationProperties` prefix)
 
 ### Supported Frameworks
 
@@ -146,7 +147,7 @@ Support for gRPC service implementations:
 ### Convert Fields
 
 1. Right-click on a class in the editor
-2. Select **EasyApi → ToJson / ToJson5 / ToProperties**
+2. Select **EasyApi → ToJson / ToJson5 / ToProperties / ToYaml**
 
 ## Configuration
 
@@ -222,12 +223,12 @@ The built-in assistant reads [`docs/knowledge-base/rule-guide.md`](src/main/reso
 
 ## Architecture
 
-The plugin follows a layered architecture:
+The plugin follows a layered, extension-point-driven architecture:
 
 ```mermaid
 graph TB
-    IDE["IDE Integration Layer<br/>(Actions, Dashboard, Line Markers, Search)"]
-    Export["Export Layer<br/>(ExportOrchestrator → ClassExporter → ApiExporter)"]
+    IDE["IDE Integration Layer<br/>(Actions, Dashboard, Line Markers, Search, AI Assistant)"]
+    Export["Export Layer<br/>(ExportOrchestrator → ClassExporter EP + Channel EP)"]
     Core["Core Services<br/>(RuleEngine, ConfigReader, ApiIndex, HttpClient)"]
     PSI["PSI Analysis<br/>(TypeResolver, DocHelper, AnnotationHelper)"]
 
@@ -236,11 +237,12 @@ graph TB
     Core --> PSI
 ```
 
-- **ClassExporter** — Extracts `ApiEndpoint` models from PSI classes (Spring MVC, JAX-RS, Feign, gRPC)
-- **ApiExporter** — Converts `ApiEndpoint` models to output formats (YApi, Postman, Markdown, cURL, HTTP Client)
-- **ExportOrchestrator** — Coordinates the full export pipeline from scanning to output
+- **ExportOrchestrator** — Coordinates the full export pipeline: scans endpoints via `ApiScanner`, then hands them to the selected `Channel` for output
+- **ClassExporter** *(extension point)* — Extracts `ApiEndpoint` models from PSI classes; built-in implementations: Spring MVC, Spring Cloud OpenFeign, JAX-RS, Spring Actuator, gRPC
+- **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: YApi, Postman, Markdown, cURL, HTTP Client. Adding a new output target only requires implementing `Channel` — no core edits
 - **ApiIndex** — Caches discovered endpoints for fast search and dashboard access
-- **RuleEngine** — Evaluates rule expressions to customize parsing behavior
+- **RuleEngine** — Evaluates rule expressions (Groovy, regex, annotation, tag) to customize parsing behavior
+- **AI Assistant** — Optional built-in agent that inspects the project via PSI tools and authors rule files; see the [Skills](#skills) section for the external-skill equivalent
 
 ## Documentation
 


### PR DESCRIPTION
## Release Changes

* release v3.2.0 (#1413)
* fix: YAML export drops @ConfigurationProperties prefix
* fix: FieldsTo* resolves caret class instead of first class in file
* feat: refactor BodyView to carry ObjectModel with render helpers
* fix: converge markdown channel template files to byte-identity with easy-api
* refactor: restructure settings modules, rename Intelligent tab, group panel sections
* refactor: consolidate exporters into self-contained channel folders with modular settings (#1412)
* feat: free-form Markdown export templates with i18n and remote source support (#1411)
* feat: support `###include <path-or-url>` directive for loading config from local files and remote URLs (#1410)
* fix: respect method-level selection when exporting APIs (#1407) (#1408)
* docs: add DeepWiki badge to READMEs (#1409)