### PR TITLE
feat: add Hoppscotch export channel as beta feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Export API endpoints from your source code to multiple formats:
 | [Markdown](https://easyyapi.github.io/guide/export2markdown) | ✓ | ✓ | .md documentation file |
 | cURL | ✓ | ✓ | Executable shell command |
 | HTTP Client | ✓ | ✓ | IntelliJ HTTP Client scratch file |
+| **Hoppscotch** *(Beta)* | ✓ | — | JSON file or direct upload to Hoppscotch |
 
 ### API Dashboard
 
@@ -123,7 +124,7 @@ Support for gRPC service implementations:
 
 1. Right-click on a controller file, class, or method in the editor or project view
 2. Select **EasyApi → Export** (or press `Ctrl+E` on macOS / `Alt+Shift+E`)
-3. Choose the target format (YApi / Postman / Markdown / cURL / HTTP Client)
+3. Choose the target format (YApi / Postman / Hoppscotch *(Beta)* / Markdown / cURL / HTTP Client)
 4. The APIs will be exported automatically
 
 ### Call an API
@@ -239,7 +240,7 @@ graph TB
 
 - **ExportOrchestrator** — Coordinates the full export pipeline: scans endpoints via `ApiScanner`, then hands them to the selected `Channel` for output
 - **ClassExporter** *(extension point)* — Extracts `ApiEndpoint` models from PSI classes; built-in implementations: Spring MVC, Spring Cloud OpenFeign, JAX-RS, Spring Actuator, gRPC
-- **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: YApi, Postman, Markdown, cURL, HTTP Client. Adding a new output target only requires implementing `Channel` — no core edits
+- **Channel** *(extension point)* — Converts `ApiEndpoint` models to an output format and handles file write / remote upload; built-in channels: YApi, Postman, Markdown, cURL, HTTP Client, Hoppscotch *(Beta)*. Adding a new output target only requires implementing `Channel` — no core edits
 - **ApiIndex** — Caches discovered endpoints for fast search and dashboard access
 - **RuleEngine** — Evaluates rule expressions (Groovy, regex, annotation, tag) to customize parsing behavior
 - **AI Assistant** — Optional built-in agent that inspects the project via PSI tools and authors rule files; see the [Skills](#skills) section for the external-skill equivalent

--- a/docs/knowledge-base/rule-guide.md
+++ b/docs/knowledge-base/rule-guide.md
@@ -193,6 +193,19 @@ Every key below is sourced from [RuleKeys.kt](../../src/main/kotlin/com/itangcen
 | `yapi.save.before` | event | throw-in-error | Hook fired before each YApi save |
 | `yapi.save.after` | event | throw-in-error | Hook fired after each YApi save |
 
+### Hoppscotch rules
+
+| Key | Type | Mode | Description |
+|-----|------|------|-------------|
+| `hopp.prerequest` | string | merge | Pre-request script (Hoppscotch) |
+| `hopp.class.prerequest` | string | merge | Class-level pre-request script (alias: `class.hopp.prerequest`) |
+| `hopp.collection.prerequest` | event | — | Collection-level pre-request script (alias: `collection.hopp.prerequest`) |
+| `hopp.test` | string | merge | Post-response test script |
+| `hopp.class.test` | string | merge | Class-level test script (alias: `class.hopp.test`) |
+| `hopp.collection.test` | event | — | Collection-level test script (alias: `collection.hopp.test`) |
+| `hopp.host` | string | replace | Host override for Hoppscotch export |
+| `hopp.format.after` | event | throw-in-error | Hook fired after Hoppscotch collection formatting |
+
 ### Enum / constant rules
 
 | Key | Type | Mode | Description |

--- a/skills/easy-yapi-assistant/docs/rule-guide.md
+++ b/skills/easy-yapi-assistant/docs/rule-guide.md
@@ -193,6 +193,19 @@ Every key below is sourced from [RuleKeys.kt](../../src/main/kotlin/com/itangcen
 | `yapi.save.before` | event | throw-in-error | Hook fired before each YApi save |
 | `yapi.save.after` | event | throw-in-error | Hook fired after each YApi save |
 
+### Hoppscotch rules
+
+| Key | Type | Mode | Description |
+|-----|------|------|-------------|
+| `hopp.prerequest` | string | merge | Pre-request script (Hoppscotch) |
+| `hopp.class.prerequest` | string | merge | Class-level pre-request script (alias: `class.hopp.prerequest`) |
+| `hopp.collection.prerequest` | event | — | Collection-level pre-request script (alias: `collection.hopp.prerequest`) |
+| `hopp.test` | string | merge | Post-response test script |
+| `hopp.class.test` | string | merge | Class-level test script (alias: `class.hopp.test`) |
+| `hopp.collection.test` | event | — | Collection-level test script (alias: `collection.hopp.test`) |
+| `hopp.host` | string | replace | Host override for Hoppscotch export |
+| `hopp.format.after` | event | throw-in-error | Hook fired after Hoppscotch collection formatting |
+
 ### Enum / constant rules
 
 | Key | Type | Mode | Description |

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/CachedHoppscotchApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/CachedHoppscotchApiClient.kt
@@ -1,0 +1,145 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.cache.AppCacheRepository
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.util.json.GsonUtils
+
+/**
+ * Caching decorator for [HoppscotchApiClient].
+ *
+ * Caches [listTeams] and [listCollections] results in [AppCacheRepository] to reduce
+ * API calls and improve UI responsiveness. Write operations (upload, update, delete)
+ * are delegated directly to the underlying client without caching.
+ *
+ * Use the [asCached] extension function to create an instance:
+ * ```kotlin
+ * val client = HoppscotchApiClient(token, serverUrl, httpClient).asCached()
+ * ```
+ *
+ * @property client the underlying API client to delegate to
+ * @see HoppscotchApiClient
+ */
+class CachedHoppscotchApiClient(
+    private val client: HoppscotchApiClient
+) : IdeaLog {
+
+    companion object : IdeaLog {
+        private const val TEAMS_CACHE_KEY = "hoppscotch/teams.json"
+        private const val COLLECTIONS_CACHE_KEY_PREFIX = "hoppscotch/collections_"
+    }
+
+    suspend fun listTeams(useCache: Boolean = true): List<HoppTeam> {
+        if (useCache) {
+            val cached = loadCachedTeams()
+            if (cached.isNotEmpty()) {
+                LOG.info("Returning ${cached.size} cached Hoppscotch teams")
+                return cached
+            }
+        }
+
+        val teams = client.listTeams()
+        if (teams.isNotEmpty()) {
+            cacheTeams(teams)
+        }
+        return teams
+    }
+
+    private fun cacheTeams(teams: List<HoppTeam>) {
+        try {
+            AppCacheRepository.getInstance().write(TEAMS_CACHE_KEY, GsonUtils.toJson(teams))
+        } catch (e: Exception) {
+            LOG.warn("Failed to cache Hoppscotch teams", e)
+        }
+    }
+
+    private fun loadCachedTeams(): List<HoppTeam> {
+        return try {
+            val cached = AppCacheRepository.getInstance().read(TEAMS_CACHE_KEY)
+            if (cached != null) {
+                GsonUtils.fromJson<Array<HoppTeam>>(cached, Array<HoppTeam>::class.java).toList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to load cached Hoppscotch teams", e)
+            emptyList()
+        }
+    }
+
+    fun clearTeamsCache() {
+        AppCacheRepository.getInstance().delete(TEAMS_CACHE_KEY)
+    }
+
+    suspend fun listCollections(teamId: String? = null, useCache: Boolean = true): List<HoppCollectionInfo> {
+        val cacheKey = if (teamId != null) {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}${teamId}.json"
+        } else {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}personal.json"
+        }
+
+        if (useCache) {
+            val cached = loadCachedCollections(cacheKey)
+            if (cached.isNotEmpty()) {
+                LOG.info("Returning ${cached.size} cached Hoppscotch collections")
+                return cached
+            }
+        }
+
+        val collections = client.listCollections(teamId)
+        if (collections.isNotEmpty()) {
+            cacheCollections(cacheKey, collections)
+        }
+        return collections
+    }
+
+    private fun cacheCollections(cacheKey: String, collections: List<HoppCollectionInfo>) {
+        try {
+            AppCacheRepository.getInstance().write(cacheKey, GsonUtils.toJson(collections))
+        } catch (e: Exception) {
+            LOG.warn("Failed to cache Hoppscotch collections", e)
+        }
+    }
+
+    private fun loadCachedCollections(cacheKey: String): List<HoppCollectionInfo> {
+        return try {
+            val cached = AppCacheRepository.getInstance().read(cacheKey)
+            if (cached != null) {
+                GsonUtils.fromJson<Array<HoppCollectionInfo>>(cached, Array<HoppCollectionInfo>::class.java).toList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to load cached Hoppscotch collections", e)
+            emptyList()
+        }
+    }
+
+    fun clearCollectionsCache(teamId: String? = null) {
+        val cacheKey = if (teamId != null) {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}${teamId}.json"
+        } else {
+            "${COLLECTIONS_CACHE_KEY_PREFIX}personal.json"
+        }
+        AppCacheRepository.getInstance().delete(cacheKey)
+    }
+
+    suspend fun testConnection(): Boolean = client.testConnection()
+
+    suspend fun uploadCollection(collection: HoppCollection, teamId: String? = null): HoppUploadResult {
+        return client.uploadCollection(collection, teamId)
+    }
+
+    suspend fun updateCollection(collectionId: String, collection: HoppCollection): HoppUploadResult {
+        return client.updateCollection(collectionId, collection)
+    }
+
+    suspend fun deleteCollection(collectionId: String, teamId: String? = null): Boolean {
+        return client.deleteCollection(collectionId, teamId)
+    }
+}
+
+/**
+ * Wraps this [HoppscotchApiClient] with a caching decorator.
+ */
+fun HoppscotchApiClient.asCached() = CachedHoppscotchApiClient(this)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClient.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClient.kt
@@ -1,0 +1,425 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.hoppscotchGson
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.KeyValue
+import com.itangcent.easyapi.logging.IdeaLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * GraphQL API client for Hoppscotch cloud operations.
+ *
+ * Communicates with Hoppscotch's GraphQL endpoint to manage collections and teams.
+ * Uses the project's [HttpClient] interface (not `java.net.http.HttpClient`) for all
+ * network requests, and always includes an `Authorization: Bearer <token>` header.
+ *
+ * Supports custom server URLs for self-hosted Hoppscotch instances via [serverUrl].
+ *
+ * ## Cloud vs Self-Hosted URL Resolution
+ * - **Cloud** (`https://hoppscotch.io`): API calls go to `https://api.hoppscotch.io`
+ * - **Self-hosted** (`https://your-instance.com`): API calls go to the same URL
+ *
+ * This matches the Hoppscotch frontend's `VITE_BACKEND_GQL_URL` default:
+ * `https://api.hoppscotch.io/graphql`
+ *
+ * ## Key operations
+ * - [testConnection] — validate the access token
+ * - [listTeams] / [listCollections] — discover workspaces and collections
+ * - [uploadCollection] — import a collection via JSON
+ * - [updateCollection] — replace an existing collection (create-first-then-delete)
+ * - [deleteCollection] — remove a collection by ID
+ *
+ * @property token Hoppscotch access token (Bearer token)
+ * @property serverUrl Hoppscotch server base URL (default: https://hoppscotch.io)
+ * @property HttpClient the HTTP client used for network requests
+ * @see CachedHoppscotchApiClient for a caching decorator
+ * @see HoppscotchAuthException thrown on 401 responses
+ */
+class HoppscotchApiClient(
+    private val token: String,
+    private val serverUrl: String = DEFAULT_SERVER_URL,
+    private val backendUrl: String? = null,
+    private val httpClient: HttpClient
+) : IdeaLog {
+
+    private val gson = hoppscotchGson(prettyPrint = false)
+
+    private val apiBaseUrl: String
+        get() = resolveApiBaseUrl(serverUrl)
+
+    suspend fun testConnection(): Boolean {
+        if (token.isBlank()) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = """{ me { uid displayName } }"""
+                val response = executeGraphQL(query)
+                response != null && !response.has("errors")
+            } catch (e: Exception) {
+                LOG.warn("Hoppscotch connection test failed", e)
+                false
+            }
+        }
+    }
+
+    suspend fun listTeams(): List<HoppTeam> {
+        if (token.isBlank()) return emptyList()
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = """{ myTeams { id name } }"""
+                val response = executeGraphQL(query) ?: return@withContext emptyList()
+                val data = response.getAsJsonObject("data") ?: return@withContext emptyList()
+                val teamsArray = data.getAsJsonArray("myTeams") ?: return@withContext emptyList()
+                teamsArray.map { element ->
+                    val obj = element.asJsonObject
+                    HoppTeam(
+                        id = obj.get("id").asString,
+                        name = obj.get("name").asString
+                    )
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to list Hoppscotch teams", e)
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun listCollections(teamId: String? = null): List<HoppCollectionInfo> {
+        if (token.isBlank()) return emptyList()
+        return withContext(Dispatchers.IO) {
+            try {
+                val query = if (teamId != null) {
+                    """{ rootCollectionsOfTeam(teamID: "$teamId") { id title } }"""
+                } else {
+                    """{ rootCollectionsOfTeam { id title } }"""
+                }
+                val response = executeGraphQL(query) ?: return@withContext emptyList()
+                val data = response.getAsJsonObject("data") ?: return@withContext emptyList()
+                val collectionsArray = data.getAsJsonArray("rootCollectionsOfTeam")
+                    ?: return@withContext emptyList()
+                collectionsArray.map { element ->
+                    val obj = element.asJsonObject
+                    HoppCollectionInfo(
+                        id = obj.get("id").asString,
+                        name = obj.get("title").asString
+                    )
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to list Hoppscotch collections", e)
+                emptyList()
+            }
+        }
+    }
+
+    suspend fun uploadCollection(collection: HoppCollection, teamId: String? = null): HoppUploadResult {
+        if (token.isBlank()) {
+            return HoppUploadResult(success = false, message = "No access token configured")
+        }
+        return withContext(Dispatchers.IO) {
+            try {
+                // Transform to personal collection format: move auth/headers/variables/etc.
+                // into a "data" sub-object, matching Hoppscotch's translateToPersonalCollectionFormat.
+                val transformed = translateToPersonalCollectionFormat(collection)
+                // Server expects a JSON array of CollectionFolder objects
+                val jsonArray = JsonArray()
+                jsonArray.add(transformed)
+                val collectionJson = gson.toJson(jsonArray)
+                val escapedJson = gson.toJson(collectionJson)
+
+                val mutation = if (teamId != null) {
+                    """mutation { importCollectionsFromJSON(
+                        teamID: "$teamId",
+                        jsonString: $escapedJson
+                    ) }"""
+                } else {
+                    """mutation { importUserCollectionsFromJSON(
+                        jsonString: $escapedJson,
+                        reqType: REST
+                    ) { exportedCollection collectionType } }"""
+                }
+
+                val response = executeGraphQL(mutation) ?: return@withContext HoppUploadResult(
+                    success = false,
+                    message = "Empty response from server"
+                )
+
+                if (response.has("errors")) {
+                    val errors = response.getAsJsonArray("errors")
+                    val message = errors?.firstOrNull()?.asJsonObject?.get("message")?.asString
+                        ?: "Unknown GraphQL error"
+                    HoppUploadResult(success = false, message = message)
+                } else {
+                    val data = response.getAsJsonObject("data")
+                    if (teamId != null) {
+                        // Team import returns Boolean
+                        val success = data?.get("importCollectionsFromJSON")?.asBoolean ?: false
+                        HoppUploadResult(
+                            success = success,
+                            message = if (success) "Collection uploaded to team successfully" else "Upload failed"
+                        )
+                    } else {
+                        // User import returns { exportedCollection, collectionType }
+                        val importResult = data?.getAsJsonObject("importUserCollectionsFromJSON")
+                        val collectionId = importResult?.get("exportedCollection")?.asString
+                        HoppUploadResult(
+                            success = true,
+                            message = "Collection uploaded successfully",
+                            collectionId = collectionId
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to upload Hoppscotch collection", e)
+                HoppUploadResult(success = false, message = e.message)
+            }
+        }
+    }
+
+    suspend fun updateCollection(collectionId: String, collection: HoppCollection): HoppUploadResult {
+        if (token.isBlank()) {
+            return HoppUploadResult(success = false, message = "No access token configured")
+        }
+
+        val uploadResult = uploadCollection(collection)
+        if (uploadResult.success && uploadResult.collectionId != null) {
+            deleteCollection(collectionId)
+            return uploadResult.copy(message = "Collection updated successfully (new ID: ${uploadResult.collectionId})")
+        }
+        return uploadResult
+    }
+
+    suspend fun deleteCollection(collectionId: String, teamId: String? = null): Boolean {
+        if (token.isBlank()) return false
+        return withContext(Dispatchers.IO) {
+            try {
+                val mutation = if (teamId != null) {
+                    """mutation { deleteCollection(collectionID: "$collectionId") }"""
+                } else {
+                    """mutation { deleteUserCollection(id: "$collectionId") }"""
+                }
+                val response = executeGraphQL(mutation)
+                response != null && !response.has("errors")
+            } catch (e: Exception) {
+                LOG.warn("Failed to delete Hoppscotch collection", e)
+                false
+            }
+        }
+    }
+
+    private val isCloudInstance: Boolean
+        get() = isCloudServer(serverUrl)
+
+    private suspend fun executeGraphQL(query: String): JsonObject? {
+        val graphqlUrl = resolveGraphQLUrl(serverUrl, backendUrl)
+        val body = gson.toJson(mapOf("query" to query))
+
+        LOG.info("call:$graphqlUrl \nbody:$body")
+
+        val request = HttpRequest(
+            url = graphqlUrl,
+            method = "POST",
+            headers = listOf(
+                KeyValue("Content-Type", "application/json"),
+                KeyValue("Authorization", "Bearer $token")
+            ),
+            body = body
+        )
+
+        val response = httpClient.execute(request)
+
+        if (response.code == 401) {
+            LOG.warn("Hoppscotch API returned 401 Unauthorized")
+            throw HoppscotchAuthException("Authentication failed - token may be expired")
+        }
+
+        if (response.code == 405) {
+            LOG.warn("Hoppscotch API returned 405 Method Not Allowed - check endpoint URL")
+            return null
+        }
+
+        if (response.code != 200) {
+            LOG.warn("Hoppscotch API returned HTTP ${response.code}")
+            return null
+        }
+
+        return try {
+            gson.fromJson(response.body, JsonObject::class.java)
+        } catch (e: Exception) {
+            LOG.warn("Failed to parse Hoppscotch API response", e)
+            null
+        }
+    }
+
+    /**
+     * Transforms a [HoppCollection] into the "personal collection" format expected
+     * by Hoppscotch's `importUserCollectionsFromJSON` / `importCollectionsFromJSON` mutations.
+     *
+     * This mirrors the frontend's `translateToPersonalCollectionFormat`:
+     * - `auth`, `headers`, `variables`, `description`, `preRequestScript`, `testScript`
+     *   are moved into a `data` sub-object
+     * - `v`, `name`, `_ref_id`, `folders`, `requests` remain at the top level
+     * - `folders` are recursively transformed
+     */
+    private fun translateToPersonalCollectionFormat(collection: HoppCollection): JsonObject {
+        val obj = JsonObject()
+
+        obj.addProperty("v", collection.v)
+        obj.addProperty("name", collection.name)
+        obj.addProperty("_ref_id", collection._ref_id)
+
+        // Recursively transform folders
+        val foldersArray = JsonArray()
+        collection.folders.forEach { folder ->
+            foldersArray.add(translateToPersonalCollectionFormat(folder))
+        }
+        obj.add("folders", foldersArray)
+
+        // Requests stay at top level as-is
+        obj.add("requests", gson.toJsonTree(collection.requests))
+
+        // Move auth/headers/variables/description/scripts into "data" sub-object
+        val data = JsonObject()
+        data.add("auth", gson.toJsonTree(collection.auth))
+        data.add("headers", gson.toJsonTree(collection.headers))
+        data.add("variables", gson.toJsonTree(collection.variables))
+        data.addProperty("description", collection.description ?: "")
+        data.addProperty("preRequestScript", collection.preRequestScript)
+        data.addProperty("testScript", collection.testScript)
+        obj.add("data", data)
+
+        return obj
+    }
+
+    companion object : IdeaLog {
+        private const val DEFAULT_SERVER_URL = "https://hoppscotch.io"
+        private const val CLOUD_SERVER_HOST = "hoppscotch.io"
+        private const val CLOUD_API_BASE_URL = "https://api.hoppscotch.io"
+
+        /**
+         * Resolves the API base URL for a given Hoppscotch server URL.
+         *
+         * - For the cloud instance (`https://hoppscotch.io`), returns `https://api.hoppscotch.io`
+         * - For self-hosted instances with a configured backend URL, returns the backend URL
+         * - For self-hosted instances without a backend URL, returns the server URL
+         *
+         * The backend URL corresponds to Hoppscotch's `VITE_BACKEND_API_URL` env variable,
+         * e.g., `http://localhost:3170/v1` for a default self-hosted setup.
+         */
+        fun resolveApiBaseUrl(serverUrl: String, backendUrl: String? = null): String {
+            val normalized = serverUrl.trimEnd('/')
+            val host = try {
+                java.net.URI(normalized).host
+            } catch (e: Exception) {
+                normalized
+            }
+            if (host == CLOUD_SERVER_HOST) {
+                return CLOUD_API_BASE_URL
+            }
+            if (!backendUrl.isNullOrBlank()) {
+                return backendUrl.trimEnd('/')
+            }
+            return normalized
+        }
+
+        /**
+         * Resolves the REST API v1 base URL for a given Hoppscotch server URL.
+         *
+         * This corresponds to Hoppscotch's `VITE_BACKEND_API_URL` env variable:
+         * - Cloud: `https://api.hoppscotch.io/v1`
+         * - Self-hosted with backend URL: returns the backend URL as-is (already includes `/v1`)
+         * - Self-hosted without backend URL: `{serverUrl}/v1`
+         *
+         * Auth endpoints like `/auth/signin` and `/auth/verify` are under this base.
+         */
+        fun resolveApiV1BaseUrl(serverUrl: String, backendUrl: String? = null): String {
+            val apiBase = resolveApiBaseUrl(serverUrl, backendUrl)
+            // For cloud, resolveApiBaseUrl returns https://api.hoppscotch.io (no /v1)
+            // For self-hosted with backendUrl, it already includes /v1 (e.g., http://localhost:3170/v1)
+            // For self-hosted without backendUrl, it returns the server URL (no /v1)
+            if (isCloudServer(serverUrl)) {
+                return "$apiBase/v1"
+            }
+            if (!backendUrl.isNullOrBlank()) {
+                // Backend URL already includes /v1
+                return apiBase
+            }
+            return "$apiBase/v1"
+        }
+
+        /**
+         * Resolves the GraphQL endpoint URL.
+         *
+         * - Cloud: `https://api.hoppscotch.io/graphql`
+         * - Self-hosted with backend URL: `{backendUrl}/graphql`
+         * - Self-hosted without backend URL: `{serverUrl}/graphql`
+         *
+         * This matches the Hoppscotch frontend's `VITE_BACKEND_GQL_URL` default:
+         * `https://api.hoppscotch.io/graphql` for cloud,
+         * `http://localhost:3170/graphql` for self-hosted
+         */
+        fun resolveGraphQLUrl(serverUrl: String, backendUrl: String? = null): String {
+            val apiBase = resolveApiBaseUrl(serverUrl, backendUrl)
+            return "$apiBase/graphql"
+        }
+
+        fun isCloudServer(serverUrl: String): Boolean {
+            val normalized = serverUrl.trimEnd('/')
+            val host = try {
+                java.net.URI(normalized).host
+            } catch (e: Exception) {
+                normalized
+            }
+            return host == CLOUD_SERVER_HOST
+        }
+    }
+}
+
+/**
+ * A Hoppscotch team (workspace).
+ *
+ * @property id unique team identifier
+ * @property name display name of the team
+ */
+data class HoppTeam(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Summary info for a Hoppscotch collection returned by list queries.
+ *
+ * @property id unique collection identifier
+ * @property name display name (title) of the collection
+ */
+data class HoppCollectionInfo(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Result of a Hoppscotch collection upload or update operation.
+ *
+ * @property success whether the operation succeeded
+ * @property message human-readable result or error message
+ * @property collectionId the ID of the created collection (on success)
+ */
+data class HoppUploadResult(
+    val success: Boolean,
+    val message: String? = null,
+    val collectionId: String? = null
+)
+
+/**
+ * Thrown when the Hoppscotch API returns a 401 Unauthorized response.
+ *
+ * This indicates the access token has expired or is invalid.
+ * Callers should attempt token refresh via [HoppscotchAuthService.refreshToken]
+ * or prompt the user to re-authenticate.
+ *
+ * @param message description of the authentication failure
+ */
+class HoppscotchAuthException(message: String) : Exception(message)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthService.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthService.kt
@@ -1,0 +1,846 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.google.gson.JsonObject
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.itangcent.easyapi.core.threading.backgroundAsync
+import com.itangcent.easyapi.core.threading.swing
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettings
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
+import com.itangcent.easyapi.settings.update
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Application-level service for Hoppscotch authentication.
+ *
+ * Manages the Hoppscotch login lifecycle:
+ * 1. **Login** — attempts JBCefBrowser-based login first (captures `access_token` and
+ *    `refresh_token` from cookies), falls back to manual token input when JCEF is unavailable
+ * 2. **Token refresh** — uses the stored `refresh_token` to obtain a new `access_token`
+ * 3. **Logout** — clears stored tokens
+ *
+ * Tokens are persisted in the unified [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState]
+ * (application-level state), accessed exclusively via `project.settings<HoppscotchSettings>()`
+ * — never read directly.
+ *
+ * @see HoppscotchLoginDialog for the JCEF browser-based login UI
+ */
+@Service(Service.Level.PROJECT)
+class HoppscotchAuthService(private val project: Project) : IdeaLog {
+
+    fun getServerUrl(): String {
+        return project.settings<HoppscotchSettings>().hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: DEFAULT_SERVER_URL
+    }
+
+    suspend fun login(parent: java.awt.Component? = null): Boolean {
+        val jcefAvailable = isJcefAvailable()
+        return swing(ModalityState.any()) {
+            val choice = HoppscotchLoginMethodDialog.showDialog(project, parent, jcefAvailable)
+            when (choice) {
+                HoppscotchLoginMethodDialog.Method.MAGIC_LINK -> {
+                    closeSwingDialog()
+                    loginWithMagicLink(parent)
+                }
+                HoppscotchLoginMethodDialog.Method.BROWSER -> {
+                    closeSwingDialog()
+                    loginWithBrowser(parent)
+                }
+                HoppscotchLoginMethodDialog.Method.MANUAL_TOKEN -> {
+                    closeSwingDialog()
+                    loginWithManualToken()
+                }
+                null -> false
+            }
+        }
+    }
+
+    private suspend fun loginWithMagicLink(parent: java.awt.Component? = null): Boolean {
+        // First check if the server supports email (magic link) auth
+        val providerCheck = checkAuthProviders()
+        if (providerCheck == AuthProviderCheckResult.NOT_SUPPORTED) {
+            swing(ModalityState.any()) {
+                Messages.showWarningDialog(
+                    project,
+                    "This Hoppscotch server does not support magic link (email) login. " +
+                        "Please use Browser Login or Manual Token instead.",
+                    "Magic Link Not Available"
+                )
+            }
+            return false
+        }
+        if (providerCheck == AuthProviderCheckResult.EMAIL_NOT_ENABLED) {
+            swing(ModalityState.any()) {
+                Messages.showWarningDialog(
+                    project,
+                    "Email login is not enabled on this Hoppscotch server. " +
+                        "Please contact your administrator or use another login method.",
+                    "Email Login Not Enabled"
+                )
+            }
+            return false
+        }
+
+        val isCloud = providerCheck == AuthProviderCheckResult.CLOUD
+
+        // For cloud, discover Firebase config
+        var firebaseConfig: FirebaseConfig? = null
+        if (isCloud) {
+            firebaseConfig = discoverFirebaseConfig()
+            if (firebaseConfig == null) {
+                // Fallback to hardcoded config for hoppscotch.io
+                firebaseConfig = FirebaseConfig(
+                    apiKey = "AIzaSyCMsFreESs58-hRxTtiqQrIcimh4i1wbsM",
+                    projectId = "postwoman-api",
+                    authDomain = "postwoman-api.firebaseapp.com"
+                )
+            }
+        }
+
+        return swing(ModalityState.any()) {
+            val dialog = if (parent != null) {
+                HoppscotchMagicLinkLoginDialog(project, parent, isCloud)
+            } else {
+                HoppscotchMagicLinkLoginDialog(project, isCloud = isCloud)
+            }
+
+            var deviceIdentifier: String? = null
+            var storedEmail: String? = null
+            val storedFirebaseConfig = firebaseConfig
+
+            dialog.onEmailSubmitted = { email ->
+                dialog.showSendingStep()
+                storedEmail = email
+                backgroundAsync {
+                    try {
+                        val result = if (isCloud && storedFirebaseConfig != null) {
+                            sendFirebaseMagicLink(email, storedFirebaseConfig)
+                        } else {
+                            sendMagicLinkRequest(email)
+                        }
+                        swing(ModalityState.any()) {
+                            if (result.success) {
+                                deviceIdentifier = result.deviceIdentifier
+                                dialog.showLinkInputStep(result.deviceIdentifier!!, email)
+                            } else {
+                                dialog.showEmailError(result.errorMessage ?: "Failed to send magic link. Please try again.")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        LOG.warn("Magic link send failed", e)
+                        swing(ModalityState.any()) {
+                            dialog.showEmailError("Network error: ${e.message}. Please try again.")
+                        }
+                    }
+                }
+            }
+
+            dialog.onLinkSubmitted = fun(linkOrToken) {
+                dialog.isOKActionEnabled = false
+                val deviceId = deviceIdentifier
+                val email = storedEmail
+                if (deviceId == null) {
+                    dialog.showLinkError("Session expired. Please close and try again.")
+                    return
+                }
+                backgroundAsync {
+                    try {
+                        val result = if (isCloud && storedFirebaseConfig != null) {
+                            // For cloud Firebase: extract oobCode from the link URL
+                            val oobCode = extractOobCodeFromUrl(linkOrToken)
+                                ?: linkOrToken // fallback: treat input as raw oobCode
+                            verifyFirebaseMagicLink(
+                                email ?: "",
+                                oobCode,
+                                storedFirebaseConfig
+                            )
+                        } else {
+                            // For self-hosted: extract token from the link URL
+                            val token = extractTokenFromUrl(linkOrToken)
+                                ?: linkOrToken // fallback: treat input as raw token
+                            verifyMagicLink(deviceId, token)
+                        }
+                        swing(ModalityState.any()) {
+                            if (result.success) {
+                                saveTokens(result.accessToken, result.refreshToken)
+                                dialog.onLoginSuccess(result.accessToken, result.refreshToken)
+                            } else {
+                                dialog.showLinkError(result.errorMessage ?: "Verification failed. Please try again.")
+                            }
+                        }
+                    } catch (e: Exception) {
+                        LOG.warn("Magic link verification failed", e)
+                        swing(ModalityState.any()) {
+                            dialog.showLinkError("Network error: ${e.message}. Please try again.")
+                        }
+                    }
+                }
+            }
+
+            dialog.show()
+            val token = dialog.getAccessToken()
+            !token.isNullOrBlank()
+        }
+    }
+
+    /**
+     * Extracts the oobCode parameter from a Firebase magic link URL.
+     * Firebase magic links have the format: https://hoppscotch.io/enter?oobCode=XXX&...
+     */
+    private fun extractOobCodeFromUrl(url: String): String? {
+        val match = Regex("[?&]oobCode=([^&]+)").find(url)
+        return match?.groupValues?.get(1)
+    }
+
+    /**
+     * Extracts the token parameter from a self-hosted magic link URL.
+     * Self-hosted magic links have the format: https://example.com/enter?token=XXX&...
+     */
+    private fun extractTokenFromUrl(url: String): String? {
+        val match = Regex("[?&]token=([^&]+)").find(url)
+        return match?.groupValues?.get(1)
+    }
+
+    private fun closeSwingDialog() {
+        // No-op: used as a placeholder for swing context cleanup
+    }
+
+    internal suspend fun sendMagicLinkRequest(email: String): MagicLinkSendResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val serverUrl = getServerUrl()
+                val backendUrl = project.settings<HoppscotchSettings>().hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf("email" to email)
+                )
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/signin?origin=app",
+                    method = "POST",
+                    headers = listOf("Content-Type" to "application/json"),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val deviceId = json?.get("deviceIdentifier")?.asString
+                        if (!deviceId.isNullOrBlank()) {
+                            MagicLinkSendResult(success = true, deviceIdentifier = deviceId)
+                        } else {
+                            MagicLinkSendResult(success = false, errorMessage = "Unexpected response from server.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkSendResult(success = false, errorMessage = when (msg) {
+                            "INVALID_EMAIL" -> "Invalid email address. Please check and try again."
+                            else -> msg ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    response.code == 404 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkSendResult(success = false, errorMessage = when (msg) {
+                            "AUTH_PROVIDER_NOT_SPECIFIED" -> "Email login is not enabled on this Hoppscotch instance. Please use another login method."
+                            else -> "Magic link login is not available on this server (HTTP 404). The server may not support email authentication."
+                        })
+                    }
+                    else -> {
+                        MagicLinkSendResult(success = false, errorMessage = "Server error (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to send magic link", e)
+                MagicLinkSendResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    internal suspend fun verifyMagicLink(deviceIdentifier: String, token: String): MagicLinkVerifyResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val serverUrl = getServerUrl()
+                val backendUrl = project.settings<HoppscotchSettings>().hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf("deviceIdentifier" to deviceIdentifier, "token" to token)
+                )
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/verify",
+                    method = "POST",
+                    headers = listOf("Content-Type" to "application/json"),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val accessToken = extractTokenFromCookieHeader(response, "access_token")
+                        val refreshToken = extractTokenFromCookieHeader(response, "refresh_token")
+                        if (!accessToken.isNullOrBlank()) {
+                            MagicLinkVerifyResult(
+                                success = true,
+                                accessToken = accessToken,
+                                refreshToken = refreshToken
+                            )
+                        } else {
+                            MagicLinkVerifyResult(success = false, errorMessage = "Login succeeded but no access token was received.")
+                        }
+                    }
+                    response.code == 401 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkVerifyResult(success = false, errorMessage = when (msg) {
+                            "MAGIC_LINK_EXPIRED" -> "This magic link has expired. Please request a new one."
+                            else -> msg ?: "Unauthorized (HTTP 401)."
+                        })
+                    }
+                    response.code == 404 -> {
+                        val json = parseJson(response.body)
+                        val msg = getJsonString(json, "message")
+                        MagicLinkVerifyResult(success = false, errorMessage = when (msg) {
+                            "INVALID_MAGIC_LINK_DATA" -> "This magic link has already been used or is invalid. Please request a new one."
+                            else -> msg ?: "Not found (HTTP 404)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkVerifyResult(success = false, errorMessage = "Verification failed (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to verify magic link", e)
+                MagicLinkVerifyResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    private fun parseJson(body: String?): JsonObject? {
+        if (body.isNullOrBlank()) return null
+        return try {
+            com.itangcent.easyapi.util.json.GsonUtils.GSON.fromJson(body, JsonObject::class.java)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    internal enum class AuthProviderCheckResult {
+        SUPPORTED,       // EMAIL provider is available (self-hosted backend)
+        EMAIL_NOT_ENABLED, // Server has auth but EMAIL is not in the providers list
+        NOT_SUPPORTED,   // Server doesn't have the auth providers endpoint (cloud instance — use Firebase)
+        CLOUD            // Cloud instance detected — use Firebase Identity Toolkit
+    }
+
+    /**
+     * Checks if the Hoppscotch server supports email (magic link) authentication.
+     * - For self-hosted: calls GET /v1/auth/providers to check available auth methods.
+     * - For cloud (hoppscotch.io): returns CLOUD to indicate Firebase should be used.
+     */
+    internal suspend fun checkAuthProviders(): AuthProviderCheckResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val serverUrl = getServerUrl()
+
+                // Check if this is the cloud instance
+                if (isCloudInstance(serverUrl)) {
+                    return@withContext AuthProviderCheckResult.CLOUD
+                }
+
+                val backendUrl = project.settings<HoppscotchSettings>().hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val request = HttpRequest(
+                    url = "$apiBaseUrl/auth/providers",
+                    method = "GET"
+                )
+                val response = httpClient.execute(request)
+
+                if (response.code == 200) {
+                    val json = parseJson(response.body)
+                    val providers = json?.getAsJsonArray("providers")
+                    val hasEmail = providers?.any { it.isJsonPrimitive && it.asString == "EMAIL" } ?: false
+                    if (hasEmail) AuthProviderCheckResult.SUPPORTED else AuthProviderCheckResult.EMAIL_NOT_ENABLED
+                } else {
+                    // Auth providers endpoint doesn't exist — might be cloud
+                    if (isCloudInstance(serverUrl)) {
+                        AuthProviderCheckResult.CLOUD
+                    } else {
+                        AuthProviderCheckResult.NOT_SUPPORTED
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to check auth providers", e)
+                AuthProviderCheckResult.NOT_SUPPORTED
+            }
+        }
+    }
+
+    /**
+     * Checks if the given server URL points to the Hoppscotch cloud instance.
+     */
+    internal fun isCloudInstance(serverUrl: String): Boolean {
+        val host = try {
+            java.net.URL(serverUrl).host
+        } catch (e: Exception) {
+            serverUrl
+        }
+        return host.equals("hoppscotch.io", ignoreCase = true) ||
+                host.endsWith(".hoppscotch.io", ignoreCase = true)
+    }
+
+    /**
+     * Discovers the Firebase API key from the Hoppscotch cloud web app's JavaScript bundle.
+     * The key is public (embedded in client-side code) and is needed for the Identity Toolkit REST API.
+     */
+    internal suspend fun discoverFirebaseConfig(): FirebaseConfig? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                // Step 1: Fetch the main page to find the JS bundle URL
+                val pageRequest = HttpRequest(
+                    url = "https://hoppscotch.io",
+                    method = "GET"
+                )
+                val pageResponse = httpClient.execute(pageRequest)
+                if (pageResponse.code != 200) return@withContext null
+
+                val pageBody = pageResponse.body ?: return@withContext null
+                val jsBundlePattern = Regex("""src="(/assets/index-[^"]+\.js)"""")
+                val jsBundleMatch = jsBundlePattern.find(pageBody) ?: return@withContext null
+                val jsBundleUrl = "https://hoppscotch.io${jsBundleMatch.groupValues[1]}"
+
+                // Step 2: Fetch the JS bundle and extract Firebase config
+                val jsRequest = HttpRequest(
+                    url = jsBundleUrl,
+                    method = "GET"
+                )
+                val jsResponse = httpClient.execute(jsRequest)
+                if (jsResponse.code != 200) return@withContext null
+
+                val jsBody = jsResponse.body ?: return@withContext null
+
+                val apiKey = Regex("""apiKey:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+                val projectId = Regex("""projectId:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+                val authDomain = Regex("""authDomain:"([^"]+)"""").find(jsBody)?.groupValues?.get(1)
+
+                if (apiKey != null && projectId != null) {
+                    FirebaseConfig(apiKey = apiKey, projectId = projectId, authDomain = authDomain)
+                } else {
+                    null
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to discover Firebase config", e)
+                null
+            }
+        }
+    }
+
+    /**
+     * Sends a magic link email using the Firebase Identity Toolkit REST API.
+     * Used for the Hoppscotch cloud instance.
+     */
+    internal suspend fun sendFirebaseMagicLink(
+        email: String,
+        firebaseConfig: FirebaseConfig
+    ): MagicLinkSendResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "requestType" to "EMAIL_SIGNIN",
+                        "email" to email,
+                        "continueUrl" to "https://hoppscotch.io/enter"
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://identitytoolkit.googleapis.com/v1/accounts:sendOobCode?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val emailSent = json?.get("email")?.asString
+                        if (!emailSent.isNullOrBlank()) {
+                            MagicLinkSendResult(success = true, deviceIdentifier = "firebase:${firebaseConfig.apiKey}")
+                        } else {
+                            MagicLinkSendResult(success = false, errorMessage = "Unexpected response from Firebase.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val error = json?.getAsJsonObject("error")
+                        val message = error?.get("message")?.asString
+                        MagicLinkSendResult(success = false, errorMessage = when (message) {
+                            "EMAIL_NOT_FOUND" -> "No account found with this email address."
+                            "INVALID_EMAIL" -> "Invalid email address. Please check and try again."
+                            "TOO_MANY_ATTEMPTS_TRY_LATER" -> "Too many attempts. Please try again later."
+                            else -> message ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkSendResult(success = false, errorMessage = "Server error (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to send Firebase magic link", e)
+                MagicLinkSendResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Verifies a Firebase magic link using the Identity Toolkit REST API.
+     * The user provides the oobCode from the email link.
+     */
+    internal suspend fun verifyFirebaseMagicLink(
+        email: String,
+        oobCode: String,
+        firebaseConfig: FirebaseConfig
+    ): MagicLinkVerifyResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "email" to email,
+                        "oobCode" to oobCode
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                when {
+                    response.code == 200 -> {
+                        val json = parseJson(response.body)
+                        val idToken = json?.get("idToken")?.asString
+                        val refreshToken = json?.get("refreshToken")?.asString
+                        if (!idToken.isNullOrBlank()) {
+                            MagicLinkVerifyResult(
+                                success = true,
+                                accessToken = idToken,
+                                refreshToken = refreshToken
+                            )
+                        } else {
+                            MagicLinkVerifyResult(success = false, errorMessage = "Login succeeded but no token was received.")
+                        }
+                    }
+                    response.code == 400 -> {
+                        val json = parseJson(response.body)
+                        val error = json?.getAsJsonObject("error")
+                        val message = error?.get("message")?.asString
+                        MagicLinkVerifyResult(success = false, errorMessage = when (message) {
+                            "INVALID_OOB_CODE" -> "This magic link has expired or already been used. Please request a new one."
+                            "EXPIRED_OOB_CODE" -> "This magic link has expired. Please request a new one."
+                            "INVALID_EMAIL" -> "The email doesn't match the magic link. Please use the same email you entered."
+                            else -> message ?: "Bad request (HTTP 400)."
+                        })
+                    }
+                    else -> {
+                        MagicLinkVerifyResult(success = false, errorMessage = "Verification failed (HTTP ${response.code}). Please try again.")
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to verify Firebase magic link", e)
+                MagicLinkVerifyResult(success = false, errorMessage = "Network error: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Refreshes a Firebase ID token using the Secure Token REST API.
+     */
+    internal suspend fun refreshFirebaseToken(
+        firebaseRefreshToken: String,
+        firebaseConfig: FirebaseConfig
+    ): Pair<String?, String?>? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+
+                val requestBody = com.itangcent.easyapi.util.json.GsonUtils.GSON.toJson(
+                    mapOf(
+                        "grant_type" to "refresh_token",
+                        "refresh_token" to firebaseRefreshToken
+                    )
+                )
+                val request = HttpRequest(
+                    url = "https://securetoken.googleapis.com/v1/token?key=${firebaseConfig.apiKey}",
+                    method = "POST",
+                    headers = listOf(
+                        "Content-Type" to "application/json",
+                        "Referer" to "https://hoppscotch.io/",
+                        "Origin" to "https://hoppscotch.io"
+                    ),
+                    body = requestBody
+                )
+                val response = httpClient.execute(request)
+
+                if (response.code == 200) {
+                    val json = parseJson(response.body)
+                    val idToken = json?.get("id_token")?.asString
+                    val newRefreshToken = json?.get("refresh_token")?.asString
+                    Pair(idToken, newRefreshToken)
+                } else {
+                    LOG.warn("Firebase token refresh failed: HTTP ${response.code}")
+                    null
+                }
+            } catch (e: Exception) {
+                LOG.warn("Firebase token refresh error", e)
+                null
+            }
+        }
+    }
+
+    /**
+     * Safely extracts a string value from a JSON field.
+     * Handles cases where the field is a JsonPrimitive string or a nested JsonObject
+     * (e.g., error responses like `{"message":{"message":"...","statusCode":404}}`).
+     */
+    private fun getJsonString(json: JsonObject?, field: String): String? {
+        val element = json?.get(field) ?: return null
+        return if (element.isJsonPrimitive) {
+            element.asString
+        } else if (element.isJsonObject) {
+            // Try to extract the inner "message" field from nested objects
+            val innerMsg = element.asJsonObject.get("message")
+            if (innerMsg != null && innerMsg.isJsonPrimitive) innerMsg.asString else element.toString()
+        } else {
+            element.toString()
+        }
+    }
+
+    private fun isJcefAvailable(): Boolean {
+        return try {
+            val jcefAppClass = Class.forName("com.intellij.ui.jcef.JBCefApp")
+            val isSupportedMethod = jcefAppClass.getMethod("isSupported")
+            isSupportedMethod.invoke(null) as Boolean
+        } catch (e: Throwable) {
+            LOG.info("JCEF not available, falling back to manual token input", e)
+            false
+        }
+    }
+
+    private suspend fun loginWithBrowser(parent: java.awt.Component? = null): Boolean {
+        return swing(ModalityState.any()) {
+            try {
+                val dialog = if (parent != null) {
+                    HoppscotchLoginDialog(project, parent)
+                } else {
+                    HoppscotchLoginDialog(project)
+                }
+                dialog.show()
+                val token = dialog.getAccessToken()
+                val refreshToken = dialog.getRefreshToken()
+                if (!token.isNullOrBlank()) {
+                    saveTokens(token, refreshToken)
+                    true
+                } else {
+                    false
+                }
+            } catch (e: Exception) {
+                LOG.warn("Browser login failed, falling back to manual input", e)
+                false
+            }
+        }
+    }
+
+    private suspend fun loginWithManualToken(): Boolean {
+        return swing(ModalityState.any()) {
+            val token = Messages.showInputDialog(
+                project,
+                "Enter your Hoppscotch access token:\n" +
+                        "(You can find it in Hoppscotch > Settings > Access Tokens)",
+                "Hoppscotch Login",
+                Messages.getInformationIcon()
+            )
+            if (!token.isNullOrBlank()) {
+                saveTokens(token.trim(), null)
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fun saveTokens(accessToken: String?, refreshToken: String?) {
+        SettingBinder.getInstance(project).update(HoppscotchSettings::class) {
+            hoppscotchToken = accessToken
+            hoppscotchRefreshToken = refreshToken
+        }
+        LOG.info("Hoppscotch tokens saved")
+    }
+
+    suspend fun refreshToken(): Boolean {
+        val storedRefreshToken = project.settings<HoppscotchSettings>().hoppscotchRefreshToken
+
+        if (storedRefreshToken.isNullOrBlank()) {
+            LOG.info("No refresh token available, cannot refresh")
+            return false
+        }
+
+        val serverUrl = getServerUrl()
+
+        // For cloud instances, use Firebase Secure Token API
+        if (isCloudInstance(serverUrl)) {
+            return refreshFirebaseTokenFlow(storedRefreshToken)
+        }
+
+        // For self-hosted instances, use backend refresh endpoint
+        return try {
+            val backendUrl = project.settings<HoppscotchSettings>().hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+            val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(serverUrl, backendUrl)
+            val httpClient = com.itangcent.easyapi.http.HttpClientProvider.getInstance(project).getClient()
+            val request = com.itangcent.easyapi.http.HttpRequest(
+                url = "$apiBaseUrl/auth/refresh",
+                method = "GET",
+                headers = listOf(
+                    "Cookie" to "refresh_token=$storedRefreshToken"
+                )
+            )
+            val response = httpClient.execute(request)
+            if (response.code == 200) {
+                val newAccessToken = extractTokenFromCookieHeader(response, "access_token")
+                    ?: extractTokenFromResponseBody(response)
+                val newRefreshToken = extractTokenFromCookieHeader(response, "refresh_token")
+                if (!newAccessToken.isNullOrBlank()) {
+                    saveTokens(newAccessToken, newRefreshToken ?: storedRefreshToken)
+                    LOG.info("Hoppscotch token refreshed successfully")
+                    true
+                } else {
+                    LOG.warn("Token refresh response missing access_token")
+                    false
+                }
+            } else {
+                LOG.warn("Token refresh failed: HTTP ${response.code}")
+                false
+            }
+        } catch (e: Exception) {
+            LOG.warn("Token refresh error", e)
+            false
+        }
+    }
+
+    /**
+     * Refreshes a Firebase ID token for cloud instances.
+     */
+    private suspend fun refreshFirebaseTokenFlow(firebaseRefreshToken: String): Boolean {
+        val firebaseConfig = discoverFirebaseConfig()
+            ?: FirebaseConfig(
+                apiKey = "AIzaSyCMsFreESs58-hRxTtiqQrIcimh4i1wbsM",
+                projectId = "postwoman-api",
+                authDomain = "postwoman-api.firebaseapp.com"
+            )
+        val result = refreshFirebaseToken(firebaseRefreshToken, firebaseConfig)
+        if (result != null) {
+            val newIdToken = result.first
+            val newRefreshToken = result.second
+            if (!newIdToken.isNullOrBlank()) {
+                saveTokens(newIdToken, newRefreshToken ?: firebaseRefreshToken)
+                LOG.info("Firebase token refreshed successfully")
+                return true
+            }
+        }
+        LOG.warn("Firebase token refresh failed")
+        return false
+    }
+
+    private fun extractTokenFromCookieHeader(
+        response: com.itangcent.easyapi.http.HttpResponse,
+        tokenName: String
+    ): String? {
+        val setCookieValues = response.headers["Set-Cookie"] ?: response.headers["set-cookie"] ?: return null
+        for (cookieValue in setCookieValues) {
+            if (cookieValue.startsWith("$tokenName=")) {
+                return cookieValue.substringAfter("$tokenName=").substringBefore(";")
+            }
+        }
+        return null
+    }
+
+    private fun extractTokenFromResponseBody(response: com.itangcent.easyapi.http.HttpResponse): String? {
+        if (response.body.isNullOrBlank()) return null
+        return try {
+            val json = com.itangcent.easyapi.util.json.GsonUtils.GSON.fromJson(
+                response.body, com.google.gson.JsonObject::class.java
+            )
+            json.get("access_token")?.asString
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun logout() {
+        saveTokens(null, null)
+        LOG.info("Hoppscotch logged out")
+    }
+
+    companion object {
+        private const val DEFAULT_SERVER_URL = "https://hoppscotch.io"
+
+        fun getInstance(project: Project): HoppscotchAuthService =
+            project.getService(HoppscotchAuthService::class.java)
+    }
+}
+
+/**
+ * Result of sending a magic link request.
+ */
+data class MagicLinkSendResult(
+    val success: Boolean,
+    val deviceIdentifier: String? = null,
+    val errorMessage: String? = null
+)
+
+/**
+ * Result of verifying a magic link.
+ */
+data class MagicLinkVerifyResult(
+    val success: Boolean,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val errorMessage: String? = null
+)
+
+/**
+ * Firebase configuration for the Hoppscotch cloud instance.
+ * These values are public (embedded in the client-side JavaScript bundle).
+ */
+data class FirebaseConfig(
+    val apiKey: String,
+    val projectId: String,
+    val authDomain: String?
+)

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannel.kt
@@ -1,0 +1,347 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.fileChooser.FileSaverDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileWrapper
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.swing
+import com.itangcent.easyapi.exporter.channel.Channel
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
+import com.itangcent.easyapi.exporter.channel.hoppscotch.*
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.hoppscotchGson
+import com.itangcent.easyapi.exporter.model.ExportContext
+import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.rule.RuleKey
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.ide.support.NotificationUtils
+import com.itangcent.easyapi.logging.IdeaConsoleProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.settings
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.reflect.KClass
+
+/**
+ * [Channel] implementation for exporting API endpoints to Hoppscotch.
+ *
+ * Supports two export modes:
+ * 1. **File export** — when no Hoppscotch access token is configured, serializes the
+ *    collection to a JSON file using [hoppscotchGson]
+ * 2. **Cloud upload** — when an access token is available, uploads the collection to
+ *    Hoppscotch via the GraphQL API. Supports both creating new collections and
+ *    updating existing ones (create-first-then-delete strategy).
+ *
+ * ## Cloud upload flow
+ * - On 401 errors, automatically attempts token refresh via [HoppscotchAuthService.refreshToken]
+ * - If refresh fails, prompts the user to re-authenticate
+ * - Progress is reported via [IdeaConsoleProvider]
+ * - GraphQL errors are translated to user-friendly messages via [formatGraphQLError]
+ *
+ * @see HoppscotchFormatter for the ApiEndpoint → HoppCollection conversion
+ * @see HoppscotchOptionsPanel for the dual-mode options UI
+ * @see HoppscotchApiClient for the GraphQL API client
+ */
+class HoppscotchChannel : Channel, IdeaLog {
+
+    override val id: String = "hoppscotch"
+    override val displayName: String = "Hoppscotch (Beta)"
+    override val supportsGrpc: Boolean = false
+    override val exposeAsAction: Boolean = true
+    override val actionText: String = "Export to Hoppscotch (Beta)"
+    override val settingsType: KClass<out com.itangcent.easyapi.settings.Settings> = HoppscotchSettings::class
+
+    override fun createOptionsPanel(project: Project): ChannelOptionsPanel {
+        return HoppscotchOptionsPanel(project)
+    }
+
+    override fun createSettingsPanel(project: Project): com.itangcent.easyapi.settings.ui.SettingsPanel<*>? =
+        HoppscotchSettingsPanel(project)
+
+    override fun configFiles(): List<String> = emptyList()
+
+    override fun ruleKeys(): List<RuleKey<*>> = RuleKey.collectFrom(HoppscotchRuleKeys)
+
+    override suspend fun export(context: ExportContext): ExportResult {
+        val project = context.project
+        val hoppscotchSettings = project.settings<HoppscotchSettings>()
+        val token = hoppscotchSettings.hoppscotchToken
+        val collectionName = project.name
+
+        val formatter = HoppscotchFormatter(project)
+        val collection = formatter.format(context.endpointsToExport, collectionName)
+
+        if (token.isNullOrBlank()) {
+            return ExportResult.Success(
+                count = countRequests(collection),
+                target = "Hoppscotch Collection",
+                metadata = HoppscotchExportMetadata(
+                    collectionName = collection.name,
+                    collectionData = collection
+                )
+            )
+        }
+
+        val hoppscotchConfig = context.channelConfig as? HoppscotchConfig
+        return uploadToHoppscotch(project, token, collection, hoppscotchSettings, hoppscotchConfig)
+    }
+
+    private suspend fun uploadToHoppscotch(
+        project: Project,
+        token: String,
+        collection: HoppCollection,
+        settings: HoppscotchSettings,
+        hoppscotchConfig: HoppscotchConfig?
+    ): ExportResult {
+        val console = IdeaConsoleProvider.getInstance(project).getConsole()
+        val serverUrl = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+        val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+        val httpClient = HttpClientProvider.getInstance(project).getClient()
+        val client = HoppscotchApiClient(token, serverUrl, backendUrl, httpClient).asCached()
+
+        val collectionId = hoppscotchConfig?.collectionId
+        val isUpdate = hoppscotchConfig?.isUpdate == true && collectionId != null
+
+        if (isUpdate) {
+            console.info("Updating Hoppscotch collection \"${hoppscotchConfig.collectionName}\"...")
+            val confirmed = swing {
+                val choice = Messages.showYesNoDialog(
+                    project,
+                    "Update existing collection \"${hoppscotchConfig.collectionName}\"?\n" +
+                            "This will create a new collection and delete the old one.\n" +
+                            "Note: The collection ID will change and shared links will break.",
+                    "Confirm Update",
+                    Messages.getQuestionIcon()
+                )
+                choice == Messages.YES
+            }
+            if (!confirmed) {
+                console.info("Update cancelled by user")
+                return ExportResult.Error("Update cancelled by user")
+            }
+
+            console.info("Uploading collection to Hoppscotch...")
+            val result = try {
+                client.updateCollection(collectionId, collection)
+            } catch (e: HoppscotchAuthException) {
+                return handleAuthErrorWithRefresh(project, token, collection, serverUrl, backendUrl, httpClient, hoppscotchConfig, console)
+            }
+            return if (result.success) {
+                console.info("Collection updated successfully (new ID: ${result.collectionId})")
+                ExportResult.Success(
+                    count = countRequests(collection),
+                    target = "Hoppscotch",
+                    metadata = HoppscotchExportMetadata(
+                        collectionName = collection.name,
+                        collectionId = result.collectionId ?: collectionId
+                    )
+                )
+            } else {
+                val userMessage = formatGraphQLError(result.message)
+                console.warn("Upload failed: $userMessage")
+                ExportResult.Error(userMessage)
+            }
+        }
+
+        console.info("Uploading collection \"${collection.name}\" to Hoppscotch...")
+        val result = try {
+            client.uploadCollection(collection)
+        } catch (e: HoppscotchAuthException) {
+            return handleAuthErrorWithRefresh(project, token, collection, serverUrl, backendUrl, httpClient, hoppscotchConfig, console)
+        }
+        return if (result.success) {
+            console.info("Collection uploaded successfully (ID: ${result.collectionId})")
+            ExportResult.Success(
+                count = countRequests(collection),
+                target = "Hoppscotch",
+                metadata = HoppscotchExportMetadata(
+                    collectionName = collection.name,
+                    collectionId = result.collectionId
+                )
+            )
+        } else {
+            val userMessage = formatGraphQLError(result.message)
+            console.warn("Upload failed: $userMessage")
+            ExportResult.Error(userMessage)
+        }
+    }
+
+    private suspend fun handleAuthErrorWithRefresh(
+        project: Project,
+        token: String,
+        collection: HoppCollection,
+        serverUrl: String,
+        backendUrl: String?,
+        httpClient: com.itangcent.easyapi.http.HttpClient,
+        hoppscotchConfig: HoppscotchConfig?,
+        console: com.itangcent.easyapi.logging.IdeaConsole = IdeaConsoleProvider.getInstance(project).getConsole()
+    ): ExportResult {
+        console.info("Token expired, attempting refresh...")
+        LOG.info("Hoppscotch token expired, attempting refresh...")
+        val authService = HoppscotchAuthService.getInstance(project)
+        val refreshed = authService.refreshToken()
+        if (refreshed) {
+            console.info("Token refreshed successfully, retrying upload...")
+            LOG.info("Token refreshed successfully, retrying upload...")
+            val newSettings = SettingBinder.getInstance(project).read(HoppscotchSettings::class)
+            val newToken = newSettings.hoppscotchToken ?: return handleAuthError(
+                project, HoppscotchAuthException("Token lost after refresh"), console
+            )
+            val newClient = HoppscotchApiClient(newToken, serverUrl, backendUrl, httpClient).asCached()
+            val collectionId = hoppscotchConfig?.collectionId
+            val isUpdate = hoppscotchConfig?.isUpdate == true && collectionId != null
+
+            return try {
+                val result = if (isUpdate) {
+                    newClient.updateCollection(collectionId!!, collection)
+                } else {
+                    newClient.uploadCollection(collection)
+                }
+                if (result.success) {
+                    console.info("Collection uploaded successfully after token refresh")
+                    ExportResult.Success(
+                        count = countRequests(collection),
+                        target = "Hoppscotch",
+                        metadata = HoppscotchExportMetadata(
+                            collectionName = collection.name,
+                            collectionId = result.collectionId ?: collectionId
+                        )
+                    )
+                } else {
+                    ExportResult.Error(formatGraphQLError(result.message))
+                }
+            } catch (e: HoppscotchAuthException) {
+                handleAuthError(project, e, console)
+            }
+        }
+        console.warn("Token refresh failed. Please login again.")
+        return handleAuthError(project, HoppscotchAuthException("Token refresh failed"), console)
+    }
+
+    private suspend fun handleAuthError(
+        project: Project,
+        e: HoppscotchAuthException,
+        console: com.itangcent.easyapi.logging.IdeaConsole = IdeaConsoleProvider.getInstance(project).getConsole()
+    ): ExportResult {
+        LOG.warn("Hoppscotch authentication error: ${e.message}")
+        console.error("Authentication failed: ${e.message}")
+        swing {
+            NotificationUtils.notifyWarning(
+                project,
+                "Hoppscotch Authentication Failed",
+                "Your Hoppscotch token has expired. Please login again via Settings > Hoppscotch."
+            )
+        }
+        return ExportResult.Error("Authentication failed: ${e.message}. Please login again.")
+    }
+
+    private fun formatGraphQLError(message: String?): String {
+        if (message.isNullOrBlank()) return "Upload failed with an unknown error"
+        return when {
+            message.contains("UNAUTHENTICATED", ignoreCase = true) ->
+                "Authentication failed. Please login again via Settings > Hoppscotch."
+            message.contains("FORBIDDEN", ignoreCase = true) ->
+                "Permission denied. You may not have access to this collection or team."
+            message.contains("NOT_FOUND", ignoreCase = true) ->
+                "The specified collection was not found on the server."
+            message.contains("already exists", ignoreCase = true) ->
+                "A collection with this name already exists. Try updating instead."
+            message.contains("rate limit", ignoreCase = true) ->
+                "Rate limit exceeded. Please wait a moment and try again."
+            else -> "Upload failed: $message"
+        }
+    }
+
+    override suspend fun handleResult(
+        project: Project,
+        result: ExportResult.Success,
+        config: ChannelConfig
+    ): Boolean {
+        val metadata = result.metadata as? HoppscotchExportMetadata ?: return false
+
+        if (metadata.collectionData != null) {
+            return handleFileExport(project, result, metadata, config)
+        }
+
+        val details = metadata.formatDisplay()
+        val message = buildString {
+            append("Successfully exported ${result.count} endpoints to Hoppscotch")
+            if (!details.isNullOrBlank()) {
+                append("\n$details")
+            }
+        }
+        swing {
+            Messages.showInfoMessage(project, message, "Export API")
+        }
+        return true
+    }
+
+    private suspend fun handleFileExport(
+        project: Project,
+        result: ExportResult.Success,
+        metadata: HoppscotchExportMetadata,
+        config: ChannelConfig
+    ): Boolean {
+        val fileConfig = config as? ChannelConfig.FileConfig
+        val targetFile = resolveTargetFile(project, fileConfig, "hoppscotch_collection.json")
+            ?: throw CancellationException("User cancelled file selection")
+
+        val gson = hoppscotchGson()
+        val content = gson.toJson(metadata.collectionData)
+
+        withContext(IdeDispatchers.Background) {
+            targetFile.writeText(content)
+        }
+
+        swing {
+            Messages.showInfoMessage(
+                project,
+                "Successfully exported ${result.count} endpoints to ${targetFile.absolutePath}",
+                "Export API"
+            )
+        }
+        return true
+    }
+
+    private suspend fun resolveTargetFile(
+        project: Project,
+        fileConfig: ChannelConfig.FileConfig?,
+        defaultFileName: String
+    ): File? {
+        val outputDir = fileConfig?.outputDir
+        val fileName = fileConfig?.fileName
+        if (!outputDir.isNullOrBlank()) {
+            val dir = File(outputDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val name = if (!fileName.isNullOrBlank()) "$fileName.json" else defaultFileName
+            return File(dir, name)
+        }
+        return selectTargetFile(project, defaultFileName)
+    }
+
+    private suspend fun selectTargetFile(project: Project, defaultFileName: String): File? {
+        return swing {
+            val descriptor = FileSaverDescriptor(
+                "Save Hoppscotch Collection",
+                "Choose where to save the Hoppscotch collection file"
+            )
+            val saver = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
+            val wrapper: VirtualFileWrapper? = saver.save(null as VirtualFile?, defaultFileName)
+            wrapper?.file
+        }
+    }
+
+    private fun countRequests(collection: HoppCollection): Int {
+        fun count(coll: HoppCollection): Int =
+            coll.requests.size + coll.folders.sumOf { count(it) }
+        return count(collection)
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchConfig.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchConfig.kt
@@ -1,0 +1,16 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+
+/**
+ * Configuration for Hoppscotch export channel.
+ *
+ * @property collectionId the Hoppscotch collection ID (for updates)
+ * @property collectionName the Hoppscotch collection name
+ * @property isUpdate whether to update an existing collection
+ */
+data class HoppscotchConfig(
+    val collectionId: String? = null,
+    val collectionName: String? = null,
+    val isUpdate: Boolean = false
+) : ChannelConfig()

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchExportMetadata.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchExportMetadata.kt
@@ -1,0 +1,38 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.model.ExportMetadata
+import com.itangcent.easyapi.util.text.append
+
+/**
+ * Export metadata for Hoppscotch channel results.
+ *
+ * Carries information about the exported collection through the export pipeline.
+ * Two usage patterns:
+ * - **File export** — [collectionData] is populated with the [HoppCollection] object
+ *   (not serialized), and [formatDisplay] returns null (file path is shown instead)
+ * - **Cloud upload** — [collectionName], [workspaceName], and [collectionId] are populated,
+ *   and [formatDisplay] returns a "workspace/collection" display string
+ *
+ * @property collectionName the name of the exported collection
+ * @property collectionData the collection object (for file export mode)
+ * @property workspaceName the Hoppscotch workspace/team name (for cloud upload mode)
+ * @property collectionId the Hoppscotch collection ID (for cloud upload mode)
+ */
+data class HoppscotchExportMetadata(
+    val collectionName: String? = null,
+    val collectionData: HoppCollection? = null,
+    val workspaceName: String? = null,
+    val collectionId: String? = null
+) : ExportMetadata {
+    override fun formatDisplay(): String? {
+        if (collectionData != null) {
+            return null
+        }
+
+        val workspaceDisplay = workspaceName
+        val collectionDisplay = collectionName ?: collectionId
+
+        return workspaceDisplay.append(collectionDisplay, separator = "/")
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatter.kt
@@ -1,0 +1,298 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.exporter.model.isHttp
+import com.itangcent.easyapi.psi.model.ObjectModel
+import com.itangcent.easyapi.psi.model.ObjectModelJsonConverter
+import com.itangcent.easyapi.rule.engine.RuleEngine
+import com.itangcent.easyapi.util.json.GsonUtils
+
+/**
+ * Options for customizing the Hoppscotch collection output.
+ *
+ * @property defaultHost the default host URL used when no `hopp.host` rule is defined
+ * @property appendTimestamp whether to append a timestamp to the collection name
+ */
+data class HoppscotchFormatOptions(
+    val defaultHost: String = "https://<<host>>",
+    val appendTimestamp: Boolean = true
+)
+
+/**
+ * Converts [ApiEndpoint]s into a Hoppscotch [HoppCollection].
+ *
+ * ## Conversion logic
+ * - Endpoints are grouped by folder name into nested [HoppCollection] sub-collections
+ * - Each endpoint becomes a [HoppRESTRequest] with method, URL, params, headers, and body
+ * - Request body format is determined by Content-Type: JSON, form-urlencoded, or multipart/form-data
+ * - Pre-request and test scripts are resolved from rule keys ([HoppscotchRuleKeys])
+ * - The host URL is resolved from `hopp.host` rule, falling back to [HoppscotchFormatOptions.defaultHost]
+ * - Collection-level scripts are aggregated from `hopp.collection.prerequest` / `hopp.collection.test` rules
+ *
+ * @param project the IntelliJ project (required for [RuleEngine] access)
+ * @param options formatting options
+ * @param systemTimeProvider injectable time source (for testing)
+ * @see HoppscotchChannel for the channel that uses this formatter
+ * @see HoppscotchRuleKeys for available rule keys
+ */
+class HoppscotchFormatter(
+    private val project: Project,
+    private val options: HoppscotchFormatOptions = HoppscotchFormatOptions(),
+    private val systemTimeProvider: () -> Long = { System.currentTimeMillis() }
+) {
+    private val ruleEngine: RuleEngine by lazy { RuleEngine.getInstance(project) }
+
+    suspend fun format(endpoints: List<ApiEndpoint>, moduleName: String): HoppCollection {
+        val httpEndpoints = endpoints.filter { it.isHttp }
+        val grouped = httpEndpoints.groupBy { it.folder ?: "" }
+
+        val folders = mutableListOf<HoppCollection>()
+        val rootRequests = mutableListOf<HoppRESTRequest>()
+
+        for ((folder, list) in grouped) {
+            val requests = list.map { toRequest(it) }
+            if (folder.isBlank()) {
+                rootRequests.addAll(requests)
+            } else {
+                folders.add(
+                    HoppCollection(
+                        name = folder,
+                        requests = requests
+                    )
+                )
+            }
+        }
+
+        val collectionPreRequest = resolveCollectionScript(
+            HoppscotchRuleKeys.HOPP_COLLECTION_PREREQUEST,
+            HoppscotchRuleKeys.HOPP_CLASS_PREREQUEST,
+            HoppscotchRuleKeys.HOPP_PREREQUEST,
+            httpEndpoints
+        )
+        val collectionTest = resolveCollectionScript(
+            HoppscotchRuleKeys.HOPP_COLLECTION_TEST,
+            HoppscotchRuleKeys.HOPP_CLASS_TEST,
+            HoppscotchRuleKeys.HOPP_TEST,
+            httpEndpoints
+        )
+
+        val collectionName = if (options.appendTimestamp) {
+            "$moduleName-${formatTimestamp(systemTimeProvider())}"
+        } else {
+            moduleName
+        }
+
+        return HoppCollection(
+            name = collectionName,
+            folders = folders,
+            requests = rootRequests,
+            preRequestScript = collectionPreRequest,
+            testScript = collectionTest
+        )
+    }
+
+    private suspend fun toRequest(endpoint: ApiEndpoint): HoppRESTRequest {
+        val meta = endpoint.httpMetadata
+            ?: throw IllegalArgumentException("HoppscotchFormatter only supports HTTP endpoints")
+
+        val host = resolveHost(endpoint)
+        val endpointUrl = buildEndpointUrl(meta, host)
+        val params = buildParams(meta)
+        val headers = buildHeaders(meta)
+        val body = buildBody(meta)
+        val preRequestScript = resolveScript(HoppscotchRuleKeys.HOPP_PREREQUEST, endpoint)
+        val testScript = resolveScript(HoppscotchRuleKeys.HOPP_TEST, endpoint)
+
+        fireEvent(endpoint)
+
+        return HoppRESTRequest(
+            name = endpoint.name ?: "${meta.method.name} ${meta.path}",
+            method = meta.method.name,
+            endpoint = endpointUrl,
+            params = params,
+            headers = headers,
+            body = body,
+            preRequestScript = preRequestScript,
+            testScript = testScript,
+            description = endpoint.description
+        )
+    }
+
+    private suspend fun resolveHost(endpoint: ApiEndpoint): String {
+        val psiClass = endpoint.sourceClass
+        val hostByRule = if (psiClass != null) {
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOPP_HOST, psiClass)
+        } else {
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOPP_HOST)
+        }
+        if (!hostByRule.isNullOrBlank()) {
+            return convertToHoppscotchVarSyntax(hostByRule)
+        }
+        return options.defaultHost
+    }
+
+    private fun convertToHoppscotchVarSyntax(value: String): String {
+        return value.trim()
+            .trim('`')
+            .replace("{{", "<<")
+            .replace("}}", ">>")
+    }
+
+    private fun buildEndpointUrl(meta: HttpMetadata, host: String): String {
+        val path = meta.path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        return (host.trimEnd('/') + path)
+            .trim('`')
+            .replace("{{", "<<")
+            .replace("}}", ">>")
+    }
+
+    private fun buildParams(meta: HttpMetadata): List<HoppKeyValue> {
+        return meta.parameters
+            .filter { it.binding == ParameterBinding.Query || it.binding == ParameterBinding.Path }
+            .map { param ->
+                HoppKeyValue(
+                    key = param.name,
+                    value = param.example ?: param.defaultValue ?: "",
+                    active = true,
+                    description = param.description
+                )
+            }
+    }
+
+    private fun buildHeaders(meta: HttpMetadata): List<HoppKeyValue> {
+        return meta.headers.map { header ->
+            HoppKeyValue(
+                key = header.name,
+                value = header.value ?: header.example ?: "",
+                active = true,
+                description = header.description
+            )
+        }
+    }
+
+    private fun buildBody(meta: HttpMetadata): HoppRequestBody {
+        val contentType = meta.contentType?.lowercase().orEmpty()
+        val formParams = meta.parameters.filter { it.binding == ParameterBinding.Form }
+
+        if (contentType.contains("json")) {
+            val raw = when {
+                meta.body != null -> ObjectModelJsonConverter.toJson(meta.body)
+                else -> "{}"
+            }
+            return HoppRequestBody(
+                contentType = "application/json",
+                body = raw
+            )
+        }
+
+        if (contentType.contains("x-www-form-urlencoded")) {
+            return HoppRequestBody(
+                contentType = "application/x-www-form-urlencoded",
+                body = formParams.joinToString("&") {
+                    "${java.net.URLEncoder.encode(it.name, "UTF-8")}=${java.net.URLEncoder.encode(it.example ?: it.defaultValue ?: "", "UTF-8")}"
+                }
+            )
+        }
+
+        if (contentType.contains("multipart") || contentType.contains("form-data")) {
+            return HoppRequestBody(
+                contentType = "multipart/form-data",
+                body = formParams.map {
+                    HoppFormDataEntry(
+                        key = it.name,
+                        value = it.example ?: it.defaultValue ?: "",
+                        active = true,
+                        isFile = false
+                    )
+                }
+            )
+        }
+
+        if (meta.body != null) {
+            return HoppRequestBody(
+                contentType = "application/json",
+                body = ObjectModelJsonConverter.toJson(meta.body)
+            )
+        }
+
+        return HoppRequestBody()
+    }
+
+    private suspend fun resolveScript(ruleKey: com.itangcent.easyapi.rule.RuleKey.StringKey, endpoint: ApiEndpoint): String {
+        val scripts = mutableListOf<String>()
+
+        val psiMethod = endpoint.sourceMethod
+        if (psiMethod != null) {
+            ruleEngine.evaluate(ruleKey, psiMethod)
+                ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+        }
+
+        val psiClass = endpoint.sourceClass
+        if (psiClass != null) {
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOPP_CLASS_PREREQUEST.let {
+                if (ruleKey == HoppscotchRuleKeys.HOPP_TEST) HoppscotchRuleKeys.HOPP_CLASS_TEST else it
+            }, psiClass)
+                ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+        }
+
+        return scripts.flatMap { it.lines().filter { l -> l.isNotBlank() } }.joinToString("\n")
+    }
+
+    private suspend fun resolveCollectionScript(
+        collectionKey: com.itangcent.easyapi.rule.RuleKey.EventKey,
+        classKey: com.itangcent.easyapi.rule.RuleKey.StringKey,
+        methodKey: com.itangcent.easyapi.rule.RuleKey.StringKey,
+        endpoints: List<ApiEndpoint>
+    ): String {
+        val scripts = mutableListOf<String>()
+
+        ruleEngine.evaluate(collectionKey) { ctx ->
+            ctx.setExt("collection", endpoints)
+        }
+
+        for (endpoint in endpoints) {
+            val psiClass = endpoint.sourceClass
+            if (psiClass != null) {
+                ruleEngine.evaluate(classKey, psiClass)
+                    ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+            }
+            val psiMethod = endpoint.sourceMethod
+            if (psiMethod != null) {
+                ruleEngine.evaluate(methodKey, psiMethod)
+                    ?.takeIf { it.isNotBlank() }?.let { scripts.add(it) }
+            }
+        }
+
+        return scripts.flatMap { it.lines().filter { l -> l.isNotBlank() } }.joinToString("\n")
+    }
+
+    private suspend fun fireEvent(endpoint: ApiEndpoint) {
+        endpoint.sourceMethod?.let { element ->
+            ruleEngine.evaluate(HoppscotchRuleKeys.HOPP_FORMAT_AFTER, element) { ctx ->
+                ctx.setExt("endpoint", endpoint)
+            }
+        }
+    }
+
+    companion object {
+        fun parsePath(path: String): List<String> {
+            return path.trim().trim('/').split("/").filter { it.isNotEmpty() }
+        }
+
+        private fun formatTimestamp(millis: Long): String {
+            val instant = java.time.Instant.ofEpochMilli(millis)
+            val formatter = java.time.format.DateTimeFormatter
+                .ofPattern("yyyyMMddHHmmss")
+                .withZone(java.time.ZoneId.systemDefault())
+            return formatter.format(instant)
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchLoginDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchLoginDialog.kt
@@ -1,0 +1,201 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettings
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Dialog for logging into Hoppscotch via an embedded JCEF browser.
+ *
+ * Opens the Hoppscotch login page in a JBCefBrowser and monitors cookies to capture
+ * the `access_token` and `refresh_token` once the user successfully authenticates.
+ *
+ * Uses reflection for all JCEF/CEF API calls to avoid compile-time dependencies on
+ * classes that may not be available on all platforms (e.g., headless Linux, older IDEs).
+ *
+ * If JCEF is not available ([JBCefApp.isSupported] returns false or the class is missing),
+ * a fallback panel is shown with instructions for manual token input.
+ *
+ * The OK button is disabled until an `access_token` cookie is captured.
+ *
+ * @param project the IntelliJ project context
+ * @see HoppscotchAuthService for the service that manages the login flow
+ */
+class HoppscotchLoginDialog(
+    private val project: Project,
+    parent: java.awt.Component? = null
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    private var accessToken: String? = null
+    private var refreshToken: String? = null
+
+    private val modularBinder: SettingBinder by lazy { SettingBinder.getInstance(project) }
+
+    init {
+        title = "Login to Hoppscotch"
+        setOKButtonText("Sign In")
+        setCancelButtonText("Cancel")
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        panel.preferredSize = Dimension(800, 600)
+
+        try {
+            val jbcEfBrowser = createJcefBrowser()
+            if (jbcEfBrowser != null) {
+                val getComponentMethod = jbcEfBrowser.javaClass.getMethod("getComponent")
+                val browserComponent = getComponentMethod.invoke(jbcEfBrowser) as JComponent
+                panel.add(browserComponent, BorderLayout.CENTER)
+                setupCookieMonitoring(jbcEfBrowser)
+            } else {
+                panel.add(createFallbackPanel(), BorderLayout.CENTER)
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to create JCEF browser", e)
+            panel.add(createFallbackPanel(), BorderLayout.CENTER)
+        }
+
+        return panel
+    }
+
+    private fun createJcefBrowser(): Any? {
+        return try {
+            val builderClass = Class.forName("com.intellij.ui.jcef.JBCefBrowserBuilder")
+            val builder = builderClass.getDeclaredConstructor().newInstance()
+            val serverUrl = modularBinder.read(HoppscotchSettings::class).hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+            val setUrlMethod = builderClass.getMethod("setUrl", String::class.java)
+            setUrlMethod.invoke(builder, serverUrl)
+            val buildMethod = builderClass.getMethod("build")
+            buildMethod.invoke(builder)
+        } catch (e: Exception) {
+            LOG.info("Could not create JCEF browser", e)
+            null
+        }
+    }
+
+    private fun setupCookieMonitoring(browser: Any) {
+        try {
+            val timer = javax.swing.Timer(1000) {
+                try {
+                    val cookieManagerClass = Class.forName("org.cef.browser.CefCookieManager")
+                    val getGlobalMethod = cookieManagerClass.getMethod("getGlobalManager")
+                    val manager = getGlobalMethod.invoke(null)
+                    if (manager != null) {
+                        val visitAllCookiesMethod = manager.javaClass.getMethod(
+                            "visitAllCookies",
+                            Class.forName("org.cef.network.CefCookieVisitor")
+                        )
+                        val visitor = createCookieVisitor()
+                        visitAllCookiesMethod.invoke(manager, visitor)
+                    }
+                } catch (e: Exception) {
+                    LOG.info("Cookie monitoring error", e)
+                }
+            }
+            timer.start()
+
+            val window = window
+            window.addWindowListener(object : java.awt.event.WindowAdapter() {
+                override fun windowClosed(e: java.awt.event.WindowEvent?) {
+                    timer.stop()
+                }
+            })
+        } catch (e: Exception) {
+            LOG.warn("Failed to setup cookie monitoring", e)
+        }
+    }
+
+    private fun createCookieVisitor(): Any {
+        val visitorClass = Class.forName("org.cef.network.CefCookieVisitor")
+        val proxy = java.lang.reflect.Proxy.newProxyInstance(
+            visitorClass.classLoader,
+            arrayOf(visitorClass)
+        ) { _, method, args ->
+            if (method.name == "visit") {
+                val cookie = args?.get(0) ?: return@newProxyInstance true
+                try {
+                    val nameMethod = cookie.javaClass.getMethod("getName")
+                    val valueMethod = cookie.javaClass.getMethod("getValue")
+                    val domainMethod = cookie.javaClass.getMethod("getDomain")
+                    val cookieName = nameMethod.invoke(cookie) as? String
+                    val cookieValue = valueMethod.invoke(cookie) as? String
+                    val domain = domainMethod.invoke(cookie) as? String
+
+                    val settings = modularBinder.read(HoppscotchSettings::class)
+                    val serverUrl = settings.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+                    val backendUrl = settings.hoppscotchBackendUrl?.takeIf { it.isNotBlank() }
+                    val serverHost = java.net.URL(serverUrl).host
+                    val backendHost = backendUrl?.let { java.net.URL(it).host }
+                    val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(serverUrl, backendUrl)
+                    val apiHost = try {
+                        java.net.URL(apiBaseUrl).host
+                    } catch (_: Exception) {
+                        null
+                    }
+
+                    val isMatchingDomain = domain != null && (
+                            domain.contains(serverHost) ||
+                                    (backendHost != null && domain.contains(backendHost)) ||
+                                    (apiHost != null && domain.contains(apiHost))
+                            )
+
+                    if (cookieName == "access_token" && isMatchingDomain) {
+                        accessToken = cookieValue
+                    }
+                    if (cookieName == "refresh_token" && isMatchingDomain) {
+                        refreshToken = cookieValue
+                    }
+                    if (accessToken != null) {
+                        LOG.info("Hoppscotch access token captured from browser")
+                    }
+                } catch (e: Exception) {
+                    LOG.info("Cookie parsing error", e)
+                }
+                args?.get(1) as? Boolean ?: true
+            } else {
+                null
+            }
+        }
+        return proxy
+    }
+
+    private fun createFallbackPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        val label = javax.swing.JLabel(
+            "<html><body style='padding: 20px'>" +
+                    "<h2>Browser Login Not Available</h2>" +
+                    "<p>JCEF (Java Chromium Embedded Framework) is not available on this platform.</p>" +
+                    "<p>Please log in manually:</p>" +
+                    "<ol>" +
+                    "<li>Open <a href='https://hoppscotch.io'>hoppscotch.io</a> in your browser</li>" +
+                    "<li>Go to Settings &gt; Access Tokens</li>" +
+                    "<li>Create a new token and paste it in the settings</li>" +
+                    "</ol>" +
+                    "</body></html>"
+        )
+        panel.add(label, BorderLayout.CENTER)
+        return panel
+    }
+
+    override fun doOKAction() {
+        if (accessToken.isNullOrBlank()) {
+            setTitle("Login to Hoppscotch — Waiting for login...")
+            return
+        }
+        super.doOKAction()
+    }
+
+    fun getAccessToken(): String? = accessToken
+    fun getRefreshToken(): String? = refreshToken
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchLoginMethodDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchLoginMethodDialog.kt
@@ -1,0 +1,94 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.logging.IdeaLog
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.*
+
+/**
+ * Dialog for selecting a Hoppscotch login method.
+ *
+ * Presents three options:
+ * 1. **Magic Link (Recommended)** — email-based passwordless login
+ * 2. **Browser Login** — JCEF browser-based login (disabled when JCEF unavailable)
+ * 3. **Manual Token** — manual access token input
+ *
+ * @param project the IntelliJ project context
+ * @param jcefAvailable whether JCEF browser is available on this platform
+ * @see HoppscotchAuthService.login
+ */
+class HoppscotchLoginMethodDialog(
+    private val project: Project,
+    parent: Component?,
+    private val jcefAvailable: Boolean
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    enum class Method { MAGIC_LINK, BROWSER, MANUAL_TOKEN }
+
+    private val buttonGroup = ButtonGroup()
+    private val magicLinkRadio = JRadioButton("Magic Link (Recommended)", true)
+    private val browserRadio = JRadioButton("Browser Login")
+    private val manualTokenRadio = JRadioButton("Manual Token")
+
+    init {
+        title = "Login to Hoppscotch"
+        setOKButtonText("Continue")
+        setCancelButtonText("Cancel")
+
+        buttonGroup.add(magicLinkRadio)
+        buttonGroup.add(browserRadio)
+        buttonGroup.add(manualTokenRadio)
+
+        magicLinkRadio.toolTipText = "Email-based passwordless login (supports both Cloud and Self-hosted)"
+
+        if (!jcefAvailable) {
+            browserRadio.isEnabled = false
+            browserRadio.toolTipText = "JCEF browser is not available on this platform"
+        }
+
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+
+        panel.add(JLabel("Choose a login method:"))
+        panel.add(Box.createVerticalStrut(10))
+        panel.add(magicLinkRadio)
+        panel.add(Box.createVerticalStrut(5))
+        panel.add(browserRadio)
+        panel.add(Box.createVerticalStrut(5))
+        panel.add(manualTokenRadio)
+
+        return panel
+    }
+
+    fun getSelectedMethod(): Method {
+        return when {
+            magicLinkRadio.isSelected -> Method.MAGIC_LINK
+            browserRadio.isSelected -> Method.BROWSER
+            manualTokenRadio.isSelected -> Method.MANUAL_TOKEN
+            else -> Method.MAGIC_LINK
+        }
+    }
+
+    companion object {
+        /**
+         * Shows the login method selection dialog and returns the chosen method,
+         * or null if the user cancelled.
+         */
+        fun showDialog(project: Project, parent: Component?, jcefAvailable: Boolean): Method? {
+            val dialog = HoppscotchLoginMethodDialog(project, parent, jcefAvailable)
+            if (dialog.showAndGet()) {
+                return dialog.getSelectedMethod()
+            }
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchMagicLinkLoginDialog.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchMagicLinkLoginDialog.kt
@@ -1,0 +1,251 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.itangcent.easyapi.logging.IdeaLog
+import com.intellij.openapi.components.service
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Dimension
+import javax.swing.*
+
+/**
+ * Multi-step dialog for Hoppscotch Magic Link authentication.
+ *
+ * Guides the user through three steps:
+ * 1. **EMAIL_INPUT** — Enter email address
+ * 2. **SENDING_LINK** — Progress indicator while sending the magic link request
+ * 3. **LINK_INPUT** — Paste the magic link URL from the email
+ *
+ * Supports both self-hosted and cloud (Firebase) authentication:
+ * - Self-hosted: magic link contains a `token` parameter
+ * - Cloud (Firebase): magic link contains an `oobCode` parameter
+ *
+ * On success, [getAccessToken] and [getRefreshToken] return the extracted tokens.
+ *
+ * @param project the IntelliJ project context
+ * @param isCloud whether this is a cloud (Firebase) login or self-hosted
+ * @see HoppscotchAuthService.loginWithMagicLink
+ */
+class HoppscotchMagicLinkLoginDialog(
+    private val project: Project,
+    parent: java.awt.Component? = null,
+    private val isCloud: Boolean = false
+) : DialogWrapper(
+    parent ?: com.intellij.openapi.wm.WindowManager.getInstance().suggestParentWindow(project)!!,
+    parent != null
+), IdeaLog {
+
+    private enum class Step { EMAIL_INPUT, SENDING_LINK, LINK_INPUT }
+
+    private var currentStep = Step.EMAIL_INPUT
+
+    private val emailField = JTextField().apply { columns = 30 }
+    private val linkUrlField = JTextField().apply { columns = 50 }
+    private val emailLabel = JLabel("Email address:")
+    private val statusLabel = JLabel(" ")
+    private val progressLabel = JLabel("Sending magic link...")
+
+    private var accessToken: String? = null
+    private var refreshToken: String? = null
+    private var deviceIdentifier: String? = null
+    private var userEmail: String? = null
+
+    private val cardLayout = CardLayout()
+    private val cardPanel = JPanel(cardLayout)
+
+    init {
+        title = "Login to Hoppscotch — Magic Link"
+        setOKButtonText("Send Magic Link")
+        setCancelButtonText("Cancel")
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        // Step 1: Email input
+        val emailPanel = JPanel().apply {
+            layout = BorderLayout()
+            add(JPanel(BorderLayout()).apply {
+                add(emailLabel, BorderLayout.WEST)
+                add(emailField, BorderLayout.CENTER)
+            }, BorderLayout.NORTH)
+            add(statusLabel, BorderLayout.SOUTH)
+        }
+
+        // Step 2: Sending link progress
+        val sendingPanel = JPanel().apply {
+            layout = BorderLayout()
+            add(progressLabel, BorderLayout.CENTER)
+        }
+
+        // Step 3: Link URL input
+        val linkPanel = JPanel().apply {
+            layout = BorderLayout()
+            val infoLabel = JLabel()
+            add(infoLabel, BorderLayout.NORTH)
+            add(JPanel(BorderLayout()).apply {
+                add(JLabel("Magic link URL:"), BorderLayout.WEST)
+                add(linkUrlField, BorderLayout.CENTER)
+            }, BorderLayout.CENTER)
+            add(statusLabel, BorderLayout.SOUTH)
+        }
+
+        cardPanel.add(emailPanel, Step.EMAIL_INPUT.name)
+        cardPanel.add(sendingPanel, Step.SENDING_LINK.name)
+        cardPanel.add(linkPanel, Step.LINK_INPUT.name)
+
+        val panel = JPanel(BorderLayout())
+        panel.preferredSize = Dimension(500, 150)
+        panel.add(cardPanel, BorderLayout.CENTER)
+        return panel
+    }
+
+    /**
+     * Transitions to the "sending link" step.
+     * Called by [HoppscotchAuthService] after the user submits their email.
+     */
+    fun showSendingStep() {
+        currentStep = Step.SENDING_LINK
+        cardLayout.show(cardPanel, Step.SENDING_LINK.name)
+        isOKActionEnabled = false
+    }
+
+    /**
+     * Transitions to the "link input" step after the magic link was sent successfully.
+     *
+     * @param deviceIdentifier the device identifier from the signin response
+     * @param email the email address the magic link was sent to
+     */
+    fun showLinkInputStep(deviceIdentifier: String, email: String) {
+        this.deviceIdentifier = deviceIdentifier
+        this.userEmail = email
+        currentStep = Step.LINK_INPUT
+        cardLayout.show(cardPanel, Step.LINK_INPUT.name)
+        setOKButtonText("Sign In")
+        isOKActionEnabled = true
+        statusLabel.text = " "
+    }
+
+    /**
+     * Shows an error and returns to the email input step.
+     *
+     * @param message the error message to display
+     */
+    fun showEmailError(message: String) {
+        currentStep = Step.EMAIL_INPUT
+        cardLayout.show(cardPanel, Step.EMAIL_INPUT.name)
+        setOKButtonText("Send Magic Link")
+        isOKActionEnabled = true
+        statusLabel.text = message
+    }
+
+    /**
+     * Shows an error on the link input step.
+     *
+     * @param message the error message to display
+     */
+    fun showLinkError(message: String) {
+        statusLabel.text = message
+        isOKActionEnabled = true
+    }
+
+    /**
+     * Called when login succeeds — stores tokens and closes the dialog.
+     */
+    fun onLoginSuccess(accessToken: String?, refreshToken: String?) {
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+        close(OK_EXIT_CODE)
+    }
+
+    fun getAccessToken(): String? = accessToken
+    fun getRefreshToken(): String? = refreshToken
+    fun getDeviceIdentifier(): String? = deviceIdentifier
+    fun getEmail(): String = emailField.text.trim()
+    fun getLinkUrl(): String = linkUrlField.text.trim()
+
+    override fun doOKAction() {
+        when (currentStep) {
+            Step.EMAIL_INPUT -> {
+                val email = emailField.text.trim()
+                if (email.isBlank()) {
+                    statusLabel.text = "Please enter your email address."
+                    return
+                }
+                if (!isValidEmail(email)) {
+                    statusLabel.text = "Please enter a valid email address."
+                    return
+                }
+                // Notify the service to send the magic link
+                onEmailSubmitted?.invoke(email)
+            }
+            Step.LINK_INPUT -> {
+                val url = linkUrlField.text.trim()
+                if (url.isBlank()) {
+                    statusLabel.text = "Please paste the magic link URL from your email."
+                    return
+                }
+                // Validate the URL contains the expected parameter
+                val hasValidParam = if (isCloud) {
+                    extractOobCodeFromUrl(url) != null
+                } else {
+                    extractTokenFromUrl(url) != null
+                }
+                if (!hasValidParam) {
+                    if (isCloud) {
+                        statusLabel.text = "Invalid magic link URL. Please paste the full URL from the email (should contain oobCode parameter)."
+                    } else {
+                        statusLabel.text = "Invalid magic link URL. Please paste the full URL from the email (should contain token parameter)."
+                    }
+                    return
+                }
+                // Pass the full URL to the service, which will extract the appropriate parameter
+                onLinkSubmitted?.invoke(url)
+            }
+            Step.SENDING_LINK -> {
+                // No action during sending
+            }
+        }
+    }
+
+    /**
+     * Callback invoked when the user submits their email.
+     * Set by [HoppscotchAuthService] to handle the API call.
+     */
+    var onEmailSubmitted: ((String) -> Unit)? = null
+
+    /**
+     * Callback invoked when the user submits the magic link URL.
+     * Set by [HoppscotchAuthService] to handle the verification API call.
+     * The parameter is the full URL from the email.
+     */
+    var onLinkSubmitted: ((String) -> Unit)? = null
+
+    companion object {
+        private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
+
+        fun isValidEmail(email: String): Boolean = EMAIL_REGEX.matches(email)
+
+        /**
+         * Extracts the `token` query parameter from a self-hosted magic link URL.
+         *
+         * @param url the full URL from the email, e.g. "https://example.com/enter?token=abc123"
+         * @return the token value, or null if not found
+         */
+        fun extractTokenFromUrl(url: String): String? {
+            val match = Regex("[?&]token=([^&]+)").find(url)
+            return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+        }
+
+        /**
+         * Extracts the `oobCode` query parameter from a Firebase magic link URL.
+         *
+         * @param url the full URL from the email, e.g. "https://hoppscotch.io/enter?oobCode=XXX&..."
+         * @return the oobCode value, or null if not found
+         */
+        fun extractOobCodeFromUrl(url: String): String? {
+            val match = Regex("[?&]oobCode=([^&]+)").find(url)
+            return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchOptionsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchOptionsPanel.kt
@@ -1,0 +1,180 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.itangcent.easyapi.core.threading.IdeDispatchers
+import com.itangcent.easyapi.core.threading.backgroundAsync
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.ChannelOptionsPanel
+import com.itangcent.easyapi.exporter.channel.hoppscotch.CachedHoppscotchApiClient
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppCollectionInfo
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchApiClient
+import com.itangcent.easyapi.exporter.channel.hoppscotch.asCached
+import com.itangcent.easyapi.http.HttpClientProvider
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.settings
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.event.ItemEvent
+import javax.swing.*
+
+/**
+ * Dual-mode options panel for the Hoppscotch export channel.
+ *
+ * Automatically switches between two modes based on authentication state:
+ * - **File export mode** — shown when no Hoppscotch access token is configured.
+ *   Provides output directory and file name fields.
+ * - **Cloud upload mode** — shown when an access token is available.
+ *   Provides a collection selector combo box for choosing an existing collection
+ *   to update, or "(New)" to create a new one.
+ *
+ * Implements [ChannelOptionsPanel] with [component] and [buildConfig] methods.
+ *
+ * @param project the IntelliJ project context
+ * @see HoppscotchChannel
+ * @see HoppscotchConfig
+ */
+class HoppscotchOptionsPanel(private val project: Project) : ChannelOptionsPanel, IdeaLog {
+
+    private val cardLayout = CardLayout()
+    private val cardPanel = JPanel(cardLayout)
+
+    private val outputDirField = TextFieldWithBrowseButton().apply {
+        text = project.basePath ?: ""
+        addBrowseFolderListener(
+            project,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                .withTitle("Select Output Directory")
+                .withDescription("Choose the directory to export the Hoppscotch collection to")
+        )
+    }
+
+    private val fileNameField = com.intellij.ui.components.JBTextField().apply {
+        text = "hoppscotch_collection"
+        columns = 30
+    }
+
+    private val collectionComboBox = ComboBox<String>()
+    private var collectionItems: List<HoppCollectionInfo> = emptyList()
+    private var selectedCollection: HoppCollectionInfo? = null
+
+    private val filePanel = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("Output Directory:"), BorderLayout.WEST)
+            add(outputDirField, BorderLayout.CENTER)
+        })
+        add(Box.createVerticalStrut(5))
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("File Name (without extension):"), BorderLayout.WEST)
+            add(fileNameField, BorderLayout.CENTER)
+        })
+    }
+
+    private val cloudPanel = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(JPanel(BorderLayout()).apply {
+            add(JLabel("Collection:"), BorderLayout.WEST)
+            add(collectionComboBox, BorderLayout.CENTER)
+        })
+        add(Box.createVerticalStrut(5))
+        add(JLabel("Select an existing collection to update, or choose (New) to create a new one."))
+    }
+
+    private val modeLabel = JLabel()
+
+    init {
+        cardPanel.add(filePanel, FILE_CARD)
+        cardPanel.add(cloudPanel, CLOUD_CARD)
+
+        collectionComboBox.addItemListener { e ->
+            if (e.stateChange == ItemEvent.SELECTED) {
+                val idx = collectionComboBox.selectedIndex
+                val hasNewEntry = collectionItems.isEmpty()
+                        || collectionComboBox.getItemAt(0)?.startsWith("(New)") == true
+                val collectionIdx = if (hasNewEntry) idx - 1 else idx
+                if (collectionIdx >= 0 && collectionIdx < collectionItems.size) {
+                    selectedCollection = collectionItems[collectionIdx]
+                } else {
+                    selectedCollection = null
+                }
+            }
+        }
+    }
+
+    override fun onShown() {
+        initializeMode()
+    }
+
+    private fun initializeMode() {
+        val settings = project.settings<HoppscotchSettings>()
+        val token = settings.hoppscotchToken
+
+        if (token.isNullOrBlank()) {
+            cardLayout.show(cardPanel, FILE_CARD)
+            modeLabel.text = "Mode: File Export (login to enable cloud upload)"
+        } else {
+            cardLayout.show(cardPanel, CLOUD_CARD)
+            modeLabel.text = "Mode: Cloud Upload"
+            loadCollections(token, settings.hoppscotchServerUrl, settings.hoppscotchBackendUrl)
+        }
+    }
+
+    private fun loadCollections(token: String, serverUrl: String?, backendUrl: String? = null) {
+        val url = serverUrl?.takeIf { it.isNotBlank() } ?: "https://hoppscotch.io"
+        backgroundAsync {
+            try {
+                val httpClient = HttpClientProvider.getInstance(project).getClient()
+                val client = HoppscotchApiClient(token, url, backendUrl, httpClient).asCached()
+                val collections = client.listCollections(useCache = true)
+                swing {
+                    collectionItems = collections
+                    collectionComboBox.removeAllItems()
+                    collectionComboBox.addItem("(New) Create new collection")
+                    collections.forEach { collectionComboBox.addItem(it.name) }
+                    if (collections.isNotEmpty()) {
+                        collectionComboBox.selectedIndex = 0
+                    }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Failed to load Hoppscotch collections", e)
+            }
+        }
+    }
+
+    private fun swing(block: () -> Unit) {
+        com.itangcent.easyapi.core.threading.swingSync { block() }
+    }
+
+    override val component: JComponent = JPanel().apply {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(modeLabel)
+        add(Box.createVerticalStrut(5))
+        add(cardPanel)
+    }
+
+    override fun buildConfig(): ChannelConfig {
+        val settings = project.settings<HoppscotchSettings>()
+        val token = settings.hoppscotchToken
+
+        return if (token.isNullOrBlank()) {
+            ChannelConfig.FileConfig(
+                outputDir = outputDirField.text.takeIf { it.isNotBlank() },
+                fileName = fileNameField.text.takeIf { it.isNotBlank() }
+            )
+        } else {
+            HoppscotchConfig(
+                collectionId = selectedCollection?.id,
+                collectionName = selectedCollection?.name,
+                isUpdate = selectedCollection != null
+            )
+        }
+    }
+
+    companion object {
+        private const val FILE_CARD = "file"
+        private const val CLOUD_CARD = "cloud"
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchRuleKeys.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchRuleKeys.kt
@@ -1,0 +1,38 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.rule.EventRuleMode
+import com.itangcent.easyapi.rule.RuleKey
+import com.itangcent.easyapi.rule.StringRuleMode
+
+/**
+ * Hoppscotch-specific rule keys.
+ *
+ * These rule keys allow users to customize Hoppscotch export behavior via
+ * the rule engine (e.g., in `.easy.api.yml` files):
+ *
+ * | Rule Key | Purpose |
+ * |----------|---------|
+ * | `hopp.prerequest` | Pre-request script for a method |
+ * | `hopp.class.prerequest` | Pre-request script for all methods in a class |
+ * | `hopp.collection.prerequest` | Pre-request script for the entire collection |
+ * | `hopp.test` | Test script for a method |
+ * | `hopp.class.test` | Test script for all methods in a class |
+ * | `hopp.collection.test` | Test script for the entire collection |
+ * | `hopp.host` | Base URL override for endpoints |
+ * | `hopp.format.after` | Post-format hook |
+ *
+ * @see com.itangcent.easyapi.rule.RuleKeys for general (shared) rule keys
+ */
+object HoppscotchRuleKeys {
+    val HOPP_PREREQUEST = RuleKey.string("hopp.prerequest", StringRuleMode.MERGE)
+    val HOPP_CLASS_PREREQUEST =
+        RuleKey.string("hopp.class.prerequest", StringRuleMode.MERGE, aliases = listOf("class.hopp.prerequest"))
+    val HOPP_COLLECTION_PREREQUEST =
+        RuleKey.event("hopp.collection.prerequest", aliases = listOf("collection.hopp.prerequest"))
+    val HOPP_TEST = RuleKey.string("hopp.test", StringRuleMode.MERGE)
+    val HOPP_CLASS_TEST =
+        RuleKey.string("hopp.class.test", StringRuleMode.MERGE, aliases = listOf("class.hopp.test"))
+    val HOPP_COLLECTION_TEST = RuleKey.event("hopp.collection.test", aliases = listOf("collection.hopp.test"))
+    val HOPP_HOST = RuleKey.string("hopp.host")
+    val HOPP_FORMAT_AFTER = RuleKey.event("hopp.format.after", EventRuleMode.THROW_IN_ERROR)
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettings.kt
@@ -1,0 +1,19 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.settings.Scope
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.StorageScope
+
+/**
+ * Hoppscotch channel settings.
+ *
+ * All fields are APPLICATION scope, persisted via the unified [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState].
+ *
+ * Replaces the old `var Settings.hoppscotchToken` extension accessors.
+ */
+data class HoppscotchSettings(
+    @StorageScope(Scope.APPLICATION) var hoppscotchToken: String? = null,
+    @StorageScope(Scope.APPLICATION) var hoppscotchServerUrl: String? = "https://hoppscotch.io",
+    @StorageScope(Scope.APPLICATION) var hoppscotchBackendUrl: String? = null,
+    @StorageScope(Scope.APPLICATION) var hoppscotchRefreshToken: String? = null
+) : Settings

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettingsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettingsPanel.kt
@@ -1,0 +1,156 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.UIUtil
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchAuthService
+import com.itangcent.easyapi.logging.IdeaLog
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.Settings
+import com.itangcent.easyapi.settings.settings
+import com.itangcent.easyapi.settings.update
+import com.itangcent.easyapi.settings.ui.SettingsPanel
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JPasswordField
+import javax.swing.SwingUtilities
+import kotlin.concurrent.thread
+
+/**
+ * Settings panel for the Hoppscotch channel.
+ *
+ * Hoppscotch-specific fields (token, server URL, backend URL) are read from /
+ * written to the unified [com.itangcent.easyapi.settings.state.UnifiedAppSettingsState]
+ * via [SettingBinder] — never touching state components directly.
+ */
+class HoppscotchSettingsPanel(private val project: Project) : SettingsPanel<Settings> {
+    private val serverUrlField = JBTextField().apply {
+        text = "https://hoppscotch.io"
+        columns = 40
+        toolTipText = "Hoppscotch server URL (use custom URL for self-hosted instances)"
+    }
+    private val backendUrlField = JBTextField().apply {
+        columns = 40
+        toolTipText = "Backend API URL for self-hosted instances (e.g., http://localhost:3170/v1). Leave empty for cloud (hoppscotch.io)."
+    }
+    private val loginButton = JButton("Login to Hoppscotch (Beta)").apply {
+        toolTipText = "Open browser to login to Hoppscotch and capture access token (Beta feature)"
+    }
+    private val tokenStatusLabel = JLabel("Not logged in").apply {
+        foreground = UIUtil.getInactiveTextColor()
+    }
+    private val logoutButton = JButton("Logout").apply {
+        toolTipText = "Clear stored Hoppscotch access token"
+        isEnabled = false
+    }
+    private val manualTokenField = JBPasswordField().apply {
+        columns = 40
+        toolTipText = "Manually enter Hoppscotch access token (fallback when browser login is not available)"
+    }
+
+    init {
+        loginButton.addActionListener { performLogin() }
+        logoutButton.addActionListener { performLogout() }
+    }
+
+    private fun performLogin() {
+        loginButton.isEnabled = false
+        loginButton.text = "Logging in..."
+        val parentWindow = SwingUtilities.getWindowAncestor(loginButton)
+        thread {
+            try {
+                val authService = HoppscotchAuthService.getInstance(project)
+                val success = kotlinx.coroutines.runBlocking { authService.login(parentWindow) }
+                SwingUtilities.invokeLater {
+                    if (success) {
+                        updateTokenStatus()
+                        Messages.showInfoMessage(project, "Successfully logged in to Hoppscotch!", "Login Success")
+                    } else {
+                        Messages.showWarningDialog(project, "Login was cancelled or failed.", "Login Failed")
+                    }
+                    loginButton.isEnabled = true
+                    loginButton.text = "Login to Hoppscotch (Beta)"
+                }
+            } catch (e: Exception) {
+                SwingUtilities.invokeLater {
+                    Messages.showErrorDialog(project, "Login failed: ${e.message}", "Login Error")
+                    loginButton.isEnabled = true
+                    loginButton.text = "Login to Hoppscotch (Beta)"
+                }
+            }
+        }
+    }
+
+    private fun performLogout() {
+        val authService = HoppscotchAuthService.getInstance(project)
+        authService.logout()
+        updateTokenStatus()
+        Messages.showInfoMessage(project, "Logged out of Hoppscotch.", "Logout")
+    }
+
+    private fun updateTokenStatus() {
+        val token = project.settings<HoppscotchSettings>().hoppscotchToken
+        if (token.isNullOrBlank()) {
+            tokenStatusLabel.text = "Not logged in"
+            tokenStatusLabel.foreground = UIUtil.getInactiveTextColor()
+            logoutButton.isEnabled = false
+        } else {
+            tokenStatusLabel.text = "Logged in (token: ${token.take(8)}...)"
+            tokenStatusLabel.foreground = java.awt.Color(java.awt.Color.green.darker().rgb)
+            logoutButton.isEnabled = true
+        }
+    }
+
+    override val component: JComponent = FormBuilder.createFormBuilder()
+        .addLabeledComponent("Server URL:", serverUrlField)
+        .addLabeledComponent("Backend URL (self-hosted only):", backendUrlField)
+        .addComponent(createLoginPanel())
+        .addLabeledComponent("Manual Token (fallback):", manualTokenField)
+        .addComponentFillVertically(JPanel(), 0)
+        .panel
+
+    private fun createLoginPanel(): JPanel {
+        return JPanel(BorderLayout(8, 0)).apply {
+            add(JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
+                add(loginButton)
+                add(logoutButton)
+            }, BorderLayout.WEST)
+            add(tokenStatusLabel, BorderLayout.CENTER)
+        }
+    }
+
+    override fun resetFrom(settings: Settings?) {
+        val s = project.settings<HoppscotchSettings>()
+        serverUrlField.text = s.hoppscotchServerUrl ?: "https://hoppscotch.io"
+        backendUrlField.text = s.hoppscotchBackendUrl ?: ""
+        manualTokenField.text = s.hoppscotchToken ?: ""
+        updateTokenStatus()
+    }
+
+    override fun applyTo(settings: Settings) {
+        val manualToken = String(manualTokenField.password).takeIf { it.isNotBlank() }
+        SettingBinder.getInstance(project).update(HoppscotchSettings::class) {
+            hoppscotchServerUrl = serverUrlField.text.takeIf { it.isNotBlank() }
+            hoppscotchBackendUrl = backendUrlField.text.takeIf { it.isNotBlank() }
+            if (manualToken != null && hoppscotchToken.isNullOrBlank()) {
+                hoppscotchToken = manualToken
+            }
+        }
+    }
+
+    override fun isModified(settings: Settings?): Boolean {
+        val s = project.settings<HoppscotchSettings>()
+        return serverUrlField.text != (s.hoppscotchServerUrl ?: "https://hoppscotch.io") ||
+                backendUrlField.text != (s.hoppscotchBackendUrl ?: "") ||
+                (String(manualTokenField.password).takeIf { it.isNotBlank() } != s.hoppscotchToken && s.hoppscotchToken.isNullOrBlank())
+    }
+
+    companion object : IdeaLog
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/model/HoppscotchModels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/model/HoppscotchModels.kt
@@ -1,0 +1,200 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch.model
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+
+/**
+ * Represents a Hoppscotch collection (schema v12).
+ *
+ * Collections can be nested: top-level collections contain folders (sub-collections)
+ * and requests. Each collection may define pre-request scripts, test scripts,
+ * collection variables, auth, and headers.
+ *
+ * @property v schema version (always 12 for collections, as Int per Hoppscotch spec)
+ * @property name display name of the collection
+ * @property folders nested sub-collections (used as folder grouping)
+ * @property requests REST requests at this level
+ * @property auth authentication configuration for this collection
+ * @property headers headers applied to all requests in this collection
+ * @property variables collection-level variables
+ * @property description optional description
+ * @property preRequestScript pre-request script (HoppScript / JavaScript)
+ * @property testScript test script (HoppScript / JavaScript)
+ */
+data class HoppCollection(
+    val v: Int = 12,
+    val name: String,
+    val _ref_id: String = generateUniqueRefId("coll"),
+    val folders: List<HoppCollection> = emptyList(),
+    val requests: List<HoppRESTRequest> = emptyList(),
+    val auth: HoppAuth = HoppAuth(),
+    val headers: List<HoppKeyValue> = emptyList(),
+    val variables: List<HoppCollectionVariable> = emptyList(),
+    val description: String? = null,
+    val preRequestScript: String = "",
+    val testScript: String = ""
+)
+
+/**
+ * Represents a Hoppscotch REST request (schema v17).
+ *
+ * @property v schema version (always "17" for requests, as String per Hoppscotch spec)
+ * @property name display name of the request
+ * @property method HTTP method (GET, POST, PUT, DELETE, etc.)
+ * @property endpoint full URL (may include Hoppscotch variables like `{{host}}`)
+ * @property params query and path parameters
+ * @property headers request headers
+ * @property auth request-level authentication override
+ * @property body request body (JSON, form-data, etc.)
+ * @property preRequestScript pre-request script for this request
+ * @property testScript test script for this request
+ * @property requestVariables request-scoped variables
+ * @property responses saved response examples
+ * @property description optional description
+ */
+data class HoppRESTRequest(
+    val v: String = "17",
+    val name: String,
+    val method: String,
+    val endpoint: String,
+    val _ref_id: String = generateUniqueRefId("req"),
+    val params: List<HoppKeyValue> = emptyList(),
+    val headers: List<HoppKeyValue> = emptyList(),
+    val auth: HoppAuth = HoppAuth(),
+    val body: HoppRequestBody = HoppRequestBody(),
+    val preRequestScript: String = "",
+    val testScript: String = "",
+    val requestVariables: List<HoppRequestVariable> = emptyList(),
+    val responses: Map<String, Any?> = emptyMap(),
+    val description: String? = null
+)
+
+/**
+ * A key-value pair used for parameters, headers, and other name-value entries.
+ *
+ * @property key the parameter/header name
+ * @property value the parameter/header value
+ * @property active whether this entry is enabled
+ * @property description optional description
+ */
+data class HoppKeyValue(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true,
+    val description: String? = null
+)
+
+/**
+ * Authentication configuration for a Hoppscotch request or collection.
+ *
+ * @property authType authentication type (e.g., "inherit", "bearer", "basic", "oauth2", "api-key", "none")
+ * @property authActive whether authentication is enabled
+ */
+data class HoppAuth(
+    val authType: String = "inherit",
+    val authActive: Boolean = true
+)
+
+/**
+ * Request body configuration.
+ *
+ * The [contentType] determines how [body] is interpreted:
+ * - `"application/json"` → [body] is a JSON string
+ * - `"application/x-www-form-urlencoded"` → [body] is a Map of key-value pairs
+ * - `"multipart/form-data"` → [body] is a List of [HoppFormDataEntry]
+ * - `null` → no body
+ *
+ * Null fields are serialized via `serializeNulls()` in [hoppscotchGson] to match
+ * Hoppscotch's expected schema.
+ *
+ * @property contentType the Content-Type header value, or null for no body
+ * @property body the body content (type depends on contentType)
+ */
+data class HoppRequestBody(
+    val contentType: String? = null,
+    val body: Any? = null
+)
+
+/**
+ * A collection-level variable in Hoppscotch.
+ *
+ * Collection variables are accessible to all requests within the collection
+ * via the `<<key>>` syntax.
+ *
+ * @property key variable name
+ * @property initialValue default value (used when first creating the variable)
+ * @property currentValue active value (used during request execution)
+ * @property secret whether this variable contains sensitive data
+ */
+data class HoppCollectionVariable(
+    val key: String,
+    val initialValue: String = "",
+    val currentValue: String = "",
+    val secret: Boolean = false
+)
+
+/**
+ * A request-scoped variable in Hoppscotch.
+ *
+ * @property key variable name
+ * @property value variable value
+ * @property active whether this variable is enabled
+ */
+data class HoppRequestVariable(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true
+)
+
+/**
+ * A form-data entry for multipart/form-data request bodies.
+ *
+ * Matches Hoppscotch's FormDataKeyValue Zod schema:
+ * - `key` and `active` are always present
+ * - `contentType` is optional
+ * - `isFile` determines whether `value` is a file reference or a plain string
+ * - When `isFile` is false, `value` is a string
+ *
+ * @property key field name
+ * @property value field value (string when isFile is false)
+ * @property active whether this entry is enabled
+ * @property isFile whether this entry represents a file upload
+ * @property contentType optional content type for this entry
+ */
+data class HoppFormDataEntry(
+    val key: String,
+    val value: String = "",
+    val active: Boolean = true,
+    val isFile: Boolean = false,
+    val contentType: String? = null
+)
+
+/**
+ * Creates a Gson instance configured for Hoppscotch JSON serialization.
+ *
+ * Key configuration:
+ * - `serializeNulls()` — ensures null fields in [HoppRequestBody] are included
+ *   (required by Hoppscotch's schema)
+ * - Optional pretty printing for file export readability
+ *
+ * @param prettyPrint whether to enable pretty-printed JSON output
+ * @return a configured Gson instance
+ */
+fun hoppscotchGson(prettyPrint: Boolean = true): Gson {
+    val builder = GsonBuilder()
+    if (prettyPrint) {
+        builder.setPrettyPrinting()
+    }
+    builder.serializeNulls()
+    return builder.create()
+}
+
+fun generateUniqueRefId(prefix: String = ""): String {
+    val timestamp = System.currentTimeMillis().toString(36)
+    val uuid = java.util.UUID.randomUUID().toString()
+    return if (prefix.isNotEmpty()) {
+        "${prefix}_${timestamp}_${uuid}"
+    } else {
+        "${timestamp}_${uuid}"
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,7 @@
         <channel implementation="com.itangcent.easyapi.exporter.channel.yapi.YapiChannel"/>
         <channel implementation="com.itangcent.easyapi.exporter.channel.curl.CurlChannel"/>
         <channel implementation="com.itangcent.easyapi.exporter.channel.httpclient.HttpClientChannel"/>
+        <channel implementation="com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.ide.fieldformat.JsonFieldFormatChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.ide.fieldformat.Json5FieldFormatChannel"/>
         <fieldFormatChannel implementation="com.itangcent.easyapi.ide.fieldformat.PropertiesFieldFormatChannel"/>

--- a/src/main/resources/docs/knowledge-base/rule-guide.md
+++ b/src/main/resources/docs/knowledge-base/rule-guide.md
@@ -193,6 +193,19 @@ Every key below is sourced from [RuleKeys.kt](../../src/main/kotlin/com/itangcen
 | `yapi.save.before` | event | throw-in-error | Hook fired before each YApi save |
 | `yapi.save.after` | event | throw-in-error | Hook fired after each YApi save |
 
+### Hoppscotch rules
+
+| Key | Type | Mode | Description |
+|-----|------|------|-------------|
+| `hopp.prerequest` | string | merge | Pre-request script (Hoppscotch) |
+| `hopp.class.prerequest` | string | merge | Class-level pre-request script (alias: `class.hopp.prerequest`) |
+| `hopp.collection.prerequest` | event | — | Collection-level pre-request script (alias: `collection.hopp.prerequest`) |
+| `hopp.test` | string | merge | Post-response test script |
+| `hopp.class.test` | string | merge | Class-level test script (alias: `class.hopp.test`) |
+| `hopp.collection.test` | event | — | Collection-level test script (alias: `collection.hopp.test`) |
+| `hopp.host` | string | replace | Host override for Hoppscotch export |
+| `hopp.format.after` | event | throw-in-error | Hook fired after Hoppscotch collection formatting |
+
 ### Enum / constant rules
 
 | Key | Type | Mode | Description |

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/CachedHoppscotchApiClientIntegrationTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/CachedHoppscotchApiClientIntegrationTest.kt
@@ -1,0 +1,278 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.cache.AppCacheRepository
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Tests for CachedHoppscotchApiClient — cache hit/miss/clear logic
+ * and delegation to underlying client.
+ */
+class CachedHoppscotchApiClientIntegrationTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+    private lateinit var cachedClient: CachedHoppscotchApiClient
+    private lateinit var cacheRepo: AppCacheRepository
+
+    override fun setUp() {
+        super.setUp()
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        cachedClient = client.asCached()
+        cacheRepo = AppCacheRepository.getInstance()
+        // Clean up any existing cache
+        cachedClient.clearTeamsCache()
+        cachedClient.clearCollectionsCache()
+        cachedClient.clearCollectionsCache("team1")
+    }
+
+    override fun tearDown() {
+        cachedClient.clearTeamsCache()
+        cachedClient.clearCollectionsCache()
+        cachedClient.clearCollectionsCache("team1")
+        super.tearDown()
+    }
+
+    // ==================== listTeams cache tests ====================
+
+    fun testListTeamsReturnsTeamsFromApiOnCacheMiss() = runBlocking {
+        val teamsData = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData)
+
+        val teams = cachedClient.listTeams()
+        assertEquals(1, teams.size)
+        assertEquals("team1", teams[0].id)
+        assertEquals("Team A", teams[0].name)
+    }
+
+    fun testListTeamsReturnsCachedTeamsOnCacheHit() = runBlocking {
+        // First call populates cache
+        val teamsData = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData)
+        cachedClient.listTeams()
+
+        // Second call should use cache
+        val teams = cachedClient.listTeams()
+        assertEquals(1, teams.size)
+        assertEquals("team1", teams[0].id)
+    }
+
+    fun testListTeamsBypassesCacheWhenUseCacheIsFalse() = runBlocking {
+        // First call populates cache
+        val teamsData1 = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData1)
+        cachedClient.listTeams()
+
+        // Second call with useCache=false should hit API again
+        val teamsData2 = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team2", "name" to "Team B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData2)
+        val teams = cachedClient.listTeams(useCache = false)
+        assertEquals(1, teams.size)
+        assertEquals("team2", teams[0].id)
+    }
+
+    fun testClearTeamsCache() = runBlocking {
+        // Populate cache
+        val teamsData = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData)
+        cachedClient.listTeams()
+
+        // Clear cache
+        cachedClient.clearTeamsCache()
+
+        // Next call should hit API again
+        val teamsData2 = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team2", "name" to "Team B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData2)
+        val teams = cachedClient.listTeams()
+        assertEquals(1, teams.size)
+        assertEquals("team2", teams[0].id)
+    }
+
+    // ==================== listCollections cache tests ====================
+
+    fun testListCollectionsReturnsCollectionsFromApiOnCacheMiss() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+
+        val collections = cachedClient.listCollections()
+        assertEquals(1, collections.size)
+        assertEquals("col1", collections[0].id)
+    }
+
+    fun testListCollectionsReturnsCachedCollectionsOnCacheHit() = runBlocking {
+        // First call populates cache
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        cachedClient.listCollections()
+
+        // Second call should use cache
+        val collections = cachedClient.listCollections()
+        assertEquals(1, collections.size)
+        assertEquals("col1", collections[0].id)
+    }
+
+    fun testListCollectionsWithTeamIdUsesTeamSpecificCache() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Team Collection")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+
+        val collections = cachedClient.listCollections(teamId = "team1")
+        assertEquals(1, collections.size)
+        assertEquals("col1", collections[0].id)
+    }
+
+    fun testListCollectionsBypassesCacheWhenUseCacheIsFalse() = runBlocking {
+        // First call populates cache
+        val collectionsData1 = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData1)
+        cachedClient.listCollections()
+
+        // Second call with useCache=false should hit API again
+        val collectionsData2 = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col2", "title" to "Collection B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData2)
+        val collections = cachedClient.listCollections(useCache = false)
+        assertEquals(1, collections.size)
+        assertEquals("col2", collections[0].id)
+    }
+
+    fun testClearCollectionsCache() = runBlocking {
+        // Populate cache
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        cachedClient.listCollections()
+
+        // Clear cache
+        cachedClient.clearCollectionsCache()
+
+        // Next call should hit API again
+        val collectionsData2 = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col2", "title" to "Collection B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData2)
+        val collections = cachedClient.listCollections()
+        assertEquals(1, collections.size)
+        assertEquals("col2", collections[0].id)
+    }
+
+    // ==================== Delegation tests ====================
+
+    fun testTestConnectionDelegatesToUnderlyingClient() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        assertTrue(cachedClient.testConnection())
+    }
+
+    fun testUploadCollectionDelegatesToUnderlyingClient() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(name = "Test")
+        val result = cachedClient.uploadCollection(collection)
+        assertTrue(result.success)
+    }
+
+    fun testDeleteCollectionDelegatesToUnderlyingClient() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(cachedClient.deleteCollection("col-1"))
+    }
+
+    // ==================== asCached extension ====================
+
+    fun testAsCachedExtensionCreatesCachedHoppscotchApiClient() {
+        val cached = HoppscotchApiClient("t", "u", httpClient = mockHttpClient).asCached()
+        assertNotNull(cached)
+        assertTrue(cached is CachedHoppscotchApiClient)
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientComprehensiveTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientComprehensiveTest.kt
@@ -1,0 +1,793 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for HoppscotchApiClient companion methods (URL resolution, cloud detection)
+ * and API methods (testConnection, listTeams, listCollections, uploadCollection,
+ * updateCollection, deleteCollection, translateToPersonalCollectionFormat, HTTP error handling).
+ */
+class HoppscotchApiClientComprehensiveTest {
+
+    // ==================== Companion method tests ====================
+
+    @Test
+    fun `resolveApiBaseUrl returns api hoppscotch io for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl returns api hoppscotch io for cloud with trailing slash`() {
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io/")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl returns same URL for self-hosted`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl returns backendUrl when provided for self-hosted`() {
+        assertEquals(
+            "http://localhost:3170",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com", "http://localhost:3170")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl ignores blank backendUrl`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com", "")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl ignores blank backendUrl with whitespace`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com", "   ")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl ignores backendUrl for cloud instance`() {
+        // Cloud always uses api.hoppscotch.io regardless of backendUrl
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io", "http://localhost:3170")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl trims trailing slash from self-hosted`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com/")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl trims trailing slash from backendUrl`() {
+        assertEquals(
+            "http://localhost:3170",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com", "http://localhost:3170/")
+        )
+    }
+
+    // ==================== resolveApiV1BaseUrl tests ====================
+
+    @Test
+    fun `resolveApiV1BaseUrl returns api hoppscotch io v1 for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl returns backendUrl as-is when provided`() {
+        // Backend URL already includes /v1
+        assertEquals(
+            "http://localhost:3170/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://custom.example.com", "http://localhost:3170/v1")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl appends v1 for self-hosted without backendUrl`() {
+        assertEquals(
+            "https://custom.example.com/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl ignores blank backendUrl`() {
+        assertEquals(
+            "https://custom.example.com/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://custom.example.com", "")
+        )
+    }
+
+    // ==================== resolveGraphQLUrl tests ====================
+
+    @Test
+    fun `resolveGraphQLUrl returns api hoppscotch io graphql for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveGraphQLUrl appends graphql for self-hosted`() {
+        assertEquals(
+            "https://custom.example.com/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `resolveGraphQLUrl uses backendUrl when provided`() {
+        assertEquals(
+            "http://localhost:3170/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://custom.example.com", "http://localhost:3170")
+        )
+    }
+
+    // ==================== isCloudServer tests ====================
+
+    @Test
+    fun `isCloudServer returns true for hoppscotch io`() {
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudServer returns true for hoppscotch io with trailing slash`() {
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io/"))
+    }
+
+    @Test
+    fun `isCloudServer returns false for custom server`() {
+        assertFalse(HoppscotchApiClient.isCloudServer("https://custom.example.com"))
+    }
+
+    @Test
+    fun `isCloudServer returns false for subdomain of hoppscotch io`() {
+        // The companion only checks exact host match, not subdomains
+        assertFalse(HoppscotchApiClient.isCloudServer("https://api.hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudServer returns true for hoppscotch io with port`() {
+        // Port 443 is default for HTTPS, host is still hoppscotch.io
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io:443"))
+    }
+
+    // ==================== API method tests with mock HttpClient ====================
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token-123",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+    }
+
+    // --- testConnection ---
+
+    @Test
+    fun `testConnection returns true for valid response`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        assertTrue(client.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false for error response`() = runBlocking {
+        val errors = """{"errors":[{"message":"Unauthorized"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errors)
+        assertFalse(client.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertFalse(blankTokenClient.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false on exception`() = runBlocking {
+        mockHttpClient.nextException = RuntimeException("Connection refused")
+        assertFalse(client.testConnection())
+    }
+
+    // --- listTeams ---
+
+    @Test
+    fun `listTeams returns teams from valid response`() = runBlocking {
+        val teamsData = JsonObject().apply {
+            add("myTeams", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "team1", "name" to "Team A"),
+                mapOf("id" to "team2", "name" to "Team B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(teamsData)
+        val teams = client.listTeams()
+        assertEquals(2, teams.size)
+        assertEquals("team1", teams[0].id)
+        assertEquals("Team A", teams[0].name)
+    }
+
+    @Test
+    fun `listTeams returns empty for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertTrue(blankTokenClient.listTeams().isEmpty())
+    }
+
+    @Test
+    fun `listTeams returns empty on exception`() = runBlocking {
+        mockHttpClient.nextException = RuntimeException("Network error")
+        assertTrue(client.listTeams().isEmpty())
+    }
+
+    @Test
+    fun `listTeams returns empty when data is null`() = runBlocking {
+        val wrapper = JsonObject().apply {
+            addProperty("data", "null")
+        }
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = """{"data":null}""")
+        assertTrue(client.listTeams().isEmpty())
+    }
+
+    @Test
+    fun `listTeams returns empty when myTeams is null`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = """{"data":{"myTeams":null}}""")
+        assertTrue(client.listTeams().isEmpty())
+    }
+
+    // --- listCollections ---
+
+    @Test
+    fun `listCollections returns collections from valid response`() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(listOf(
+                mapOf("id" to "col1", "title" to "Collection A"),
+                mapOf("id" to "col2", "title" to "Collection B")
+            )))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        val collections = client.listCollections()
+        assertEquals(2, collections.size)
+        assertEquals("col1", collections[0].id)
+        assertEquals("Collection A", collections[0].name)
+    }
+
+    @Test
+    fun `listCollections with teamId includes teamID in query`() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(emptyList<Map<String, String>>()))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        client.listCollections(teamId = "team1")
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("teamID"))
+    }
+
+    @Test
+    fun `listCollections without teamId does not include teamID in query`() = runBlocking {
+        val collectionsData = JsonObject().apply {
+            add("rootCollectionsOfTeam", GsonUtils.GSON.toJsonTree(emptyList<Map<String, String>>()))
+        }
+        mockHttpClient.nextResponse = graphqlResponse(collectionsData)
+        client.listCollections()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertFalse(lastRequest!!.body!!.contains("teamID"))
+    }
+
+    @Test
+    fun `listCollections returns empty for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertTrue(blankTokenClient.listCollections().isEmpty())
+    }
+
+    @Test
+    fun `listCollections returns empty on exception`() = runBlocking {
+        mockHttpClient.nextException = RuntimeException("Network error")
+        assertTrue(client.listCollections().isEmpty())
+    }
+
+    // --- uploadCollection ---
+
+    @Test
+    fun `uploadCollection returns success for valid personal response`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "new-col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+        val collection = HoppCollection(
+            name = "Test Collection",
+            requests = listOf(HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api"))
+        )
+        val result = client.uploadCollection(collection)
+        assertTrue(result.success)
+        assertEquals("new-col-1", result.collectionId)
+    }
+
+    @Test
+    fun `uploadCollection with teamId uses importCollectionsFromJSON`() = runBlocking {
+        val importData = JsonObject().apply {
+            addProperty("importCollectionsFromJSON", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+        val collection = HoppCollection(name = "Team Collection")
+        val result = client.uploadCollection(collection, teamId = "team1")
+        assertTrue(result.success)
+        assertNull(result.collectionId)
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("importCollectionsFromJSON"))
+        assertTrue(lastRequest.body!!.contains("teamID"))
+    }
+
+    @Test
+    fun `uploadCollection with teamId returns failure when import fails`() = runBlocking {
+        val importData = JsonObject().apply {
+            addProperty("importCollectionsFromJSON", false)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+        val collection = HoppCollection(name = "Team Collection")
+        val result = client.uploadCollection(collection, teamId = "team1")
+        assertFalse(result.success)
+        assertEquals("Upload failed", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure for GraphQL errors`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Collection name already exists"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+        val collection = HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("Collection name already exists", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure for GraphQL errors with no message`() = runBlocking {
+        val errorBody = """{"errors":[{}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+        val collection = HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("Unknown GraphQL error", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        val collection = HoppCollection(name = "Test")
+        val result = blankTokenClient.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("No access token configured", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure for null response`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 500, body = "Internal Server Error")
+        val collection = HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("Empty response from server", result.message)
+    }
+
+    @Test
+    fun `uploadCollection returns failure on exception`() = runBlocking {
+        mockHttpClient.nextException = RuntimeException("Connection refused")
+        val collection = HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertEquals("Connection refused", result.message)
+    }
+
+    // --- updateCollection ---
+
+    @Test
+    fun `updateCollection creates new then deletes old`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "new-col-2")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(importData))
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(deleteData))
+
+        val collection = HoppCollection(name = "Updated")
+        val result = client.updateCollection("old-col-1", collection)
+        assertTrue(result.success)
+        assertEquals("new-col-2", result.collectionId)
+        assertTrue(result.message!!.contains("updated successfully"))
+    }
+
+    @Test
+    fun `updateCollection returns failure for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        val collection = HoppCollection(name = "Test")
+        val result = blankTokenClient.updateCollection("old-col-1", collection)
+        assertFalse(result.success)
+        assertEquals("No access token configured", result.message)
+    }
+
+    @Test
+    fun `updateCollection returns upload result when upload fails`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Upload failed"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+        val collection = HoppCollection(name = "Failed")
+        val result = client.updateCollection("old-col-1", collection)
+        assertFalse(result.success)
+    }
+
+    @Test
+    fun `updateCollection does not delete when upload has no collectionId`() = runBlocking {
+        // Upload succeeds but no collectionId returned (shouldn't happen normally, but test the branch)
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "new-col-2")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(importData))
+        // Second call for delete
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(deleteData))
+
+        val collection = HoppCollection(name = "Test")
+        val result = client.updateCollection("old-col-1", collection)
+        // Should succeed since uploadResult.collectionId is not null
+        assertTrue(result.success)
+    }
+
+    // --- deleteCollection ---
+
+    @Test
+    fun `deleteCollection returns true for valid response`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(client.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `deleteCollection with teamId uses deleteCollection mutation`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(client.deleteCollection("col-1", teamId = "team1"))
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertTrue(lastRequest!!.body!!.contains("deleteCollection"))
+        assertTrue(lastRequest.body!!.contains("collectionID"))
+    }
+
+    @Test
+    fun `deleteCollection returns false for blank token`() = runBlocking {
+        val blankTokenClient = HoppscotchApiClient(
+            token = "",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        assertFalse(blankTokenClient.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `deleteCollection returns false on exception`() = runBlocking {
+        mockHttpClient.nextException = RuntimeException("Connection refused")
+        assertFalse(client.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `deleteCollection returns false for GraphQL errors`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Not found"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+        assertFalse(client.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `deleteCollection returns false for null response`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 500, body = "Internal Server Error")
+        assertFalse(client.deleteCollection("col-1"))
+    }
+
+    // --- HTTP error handling ---
+
+    @Test
+    fun `401 response returns false from testConnection`() = runBlocking {
+        // testConnection catches HoppscotchAuthException and returns false
+        mockHttpClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        assertFalse(client.testConnection())
+    }
+
+    @Test
+    fun `401 response returns empty list from listTeams`() = runBlocking {
+        // listTeams catches HoppscotchAuthException and returns empty list
+        mockHttpClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        assertTrue(client.listTeams().isEmpty())
+    }
+
+    @Test
+    fun `405 response returns null gracefully`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 405, body = "Method Not Allowed")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `non-200 response returns empty gracefully`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 500, body = "Internal Server Error")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `malformed JSON response returns empty gracefully`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = "not valid json")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    // --- Request headers ---
+
+    @Test
+    fun `request includes Bearer token in Authorization header`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        client.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        val authHeader = lastRequest!!.headers.find { it.first == "Authorization" }
+        assertNotNull(authHeader)
+        assertEquals("Bearer test-token-123", authHeader!!.second)
+    }
+
+    @Test
+    fun `request includes Content-Type json header`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        client.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        val contentTypeHeader = lastRequest!!.headers.find { it.first == "Content-Type" }
+        assertNotNull(contentTypeHeader)
+        assertEquals("application/json", contentTypeHeader!!.second)
+    }
+
+    // --- URL resolution in API calls ---
+
+    @Test
+    fun `custom server URL uses api graphql path`() = runBlocking {
+        val customClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://custom.hoppscotch.example",
+            httpClient = mockHttpClient
+        )
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        customClient.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertEquals("https://custom.hoppscotch.example/graphql", lastRequest!!.url)
+    }
+
+    @Test
+    fun `cloud server URL resolves to api hoppscotch io`() = runBlocking {
+        val cloudClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.io",
+            httpClient = mockHttpClient
+        )
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        cloudClient.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertEquals("https://api.hoppscotch.io/graphql", lastRequest!!.url)
+    }
+
+    @Test
+    fun `backendUrl overrides graphql path`() = runBlocking {
+        val customClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://custom.hoppscotch.example",
+            backendUrl = "http://localhost:3170",
+            httpClient = mockHttpClient
+        )
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        customClient.testConnection()
+        val lastRequest = mockHttpClient.lastRequest
+        assertNotNull(lastRequest)
+        assertEquals("http://localhost:3170/graphql", lastRequest!!.url)
+    }
+
+    // --- translateToPersonalCollectionFormat (tested via uploadCollection) ---
+
+    @Test
+    fun `uploadCollection transforms collection to personal format`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val nestedFolder = HoppCollection(
+            name = "SubFolder",
+            requests = listOf(HoppRESTRequest(name = "Sub GET", method = "GET", endpoint = "/sub")),
+            auth = HoppAuth(authType = "bearer"),
+            headers = listOf(HoppKeyValue(key = "X-Custom", value = "test"))
+        )
+        val collection = HoppCollection(
+            name = "Test Collection",
+            folders = listOf(nestedFolder),
+            requests = listOf(HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api")),
+            auth = HoppAuth(authType = "none"),
+            headers = listOf(HoppKeyValue(key = "Authorization", value = "Bearer token")),
+            variables = listOf(HoppCollectionVariable(key = "baseUrl", initialValue = "https://api.example.com")),
+            description = "Test description",
+            preRequestScript = "console.log('pre')",
+            testScript = "console.log('test')"
+        )
+        val result = client.uploadCollection(collection)
+        assertTrue(result.success)
+
+        // Verify the request body contains the transformed format
+        val lastBody = mockHttpClient.lastRequest?.body
+        assertNotNull(lastBody)
+        // The body should contain "data" sub-object with auth/headers/variables/description/scripts
+        assertTrue(lastBody!!.contains("data"))
+    }
+
+    // --- Data classes ---
+
+    @Test
+    fun `HoppTeam data class`() {
+        val team = HoppTeam(id = "t1", name = "Team 1")
+        assertEquals("t1", team.id)
+        assertEquals("Team 1", team.name)
+        val copy = team.copy(name = "Team 2")
+        assertEquals("t1", copy.id)
+        assertEquals("Team 2", copy.name)
+    }
+
+    @Test
+    fun `HoppCollectionInfo data class`() {
+        val info = HoppCollectionInfo(id = "c1", name = "Col 1")
+        assertEquals("c1", info.id)
+        assertEquals("Col 1", info.name)
+    }
+
+    @Test
+    fun `HoppUploadResult data class`() {
+        val result = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        assertTrue(result.success)
+        assertEquals("OK", result.message)
+        assertEquals("col-1", result.collectionId)
+        val copy = result.copy(message = "Updated")
+        assertEquals("Updated", copy.message)
+        assertEquals("col-1", copy.collectionId)
+    }
+
+    @Test
+    fun `HoppscotchAuthException is an Exception with message`() {
+        val exception = HoppscotchAuthException("Token expired")
+        assertTrue(exception is Exception)
+        assertEquals("Token expired", exception.message)
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+        var nextException: Throwable? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            nextException?.let { throw it }
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientTest.kt
@@ -1,0 +1,359 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for HoppscotchApiClient companion methods and API operations with mock HttpClient.
+ */
+class HoppscotchApiClientTest {
+
+    private lateinit var mockClient: MockHttpClient
+    private lateinit var apiClient: HoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockClient = MockHttpClient()
+        apiClient = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.io",
+            httpClient = mockClient
+        )
+    }
+
+    // ==================== URL Resolution (companion methods) ====================
+
+    @Test
+    fun `resolveApiBaseUrl for cloud returns api subdomain`() {
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl for cloud with trailing slash`() {
+        assertEquals(
+            "https://api.hoppscotch.io",
+            HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io/")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl for self-hosted with backend URL`() {
+        assertEquals(
+            "http://localhost:3170/v1",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com", "http://localhost:3170/v1")
+        )
+    }
+
+    @Test
+    fun `resolveApiBaseUrl for self-hosted without backend URL`() {
+        assertEquals(
+            "https://custom.example.com",
+            HoppscotchApiClient.resolveApiBaseUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl for self-hosted with backend URL`() {
+        assertEquals(
+            "http://localhost:3170/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://custom.example.com", "http://localhost:3170/v1")
+        )
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl for self-hosted without backend URL`() {
+        assertEquals(
+            "https://custom.example.com/v1",
+            HoppscotchApiClient.resolveApiV1BaseUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `resolveGraphQLUrl for cloud`() {
+        assertEquals(
+            "https://api.hoppscotch.io/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://hoppscotch.io")
+        )
+    }
+
+    @Test
+    fun `resolveGraphQLUrl for self-hosted with backend URL`() {
+        assertEquals(
+            "http://localhost:3170/v1/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://custom.example.com", "http://localhost:3170/v1")
+        )
+    }
+
+    @Test
+    fun `resolveGraphQLUrl for self-hosted without backend URL`() {
+        assertEquals(
+            "https://custom.example.com/graphql",
+            HoppscotchApiClient.resolveGraphQLUrl("https://custom.example.com")
+        )
+    }
+
+    @Test
+    fun `isCloudServer for hoppscotch io`() {
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudServer for hoppscotch io with trailing slash`() {
+        assertTrue(HoppscotchApiClient.isCloudServer("https://hoppscotch.io/"))
+    }
+
+    @Test
+    fun `isCloudServer for self-hosted`() {
+        assertFalse(HoppscotchApiClient.isCloudServer("https://custom.example.com"))
+    }
+
+    // ==================== testConnection ====================
+
+    @Test
+    fun `testConnection returns true on success`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"data":{"me":{"uid":"user-1","displayName":"Test User"}}}"""
+        )
+        assertTrue(apiClient.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false on GraphQL error`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"errors":[{"message":"Unauthorized"}]}"""
+        )
+        assertFalse(apiClient.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false on HTTP error`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 500, body = "Internal Server Error")
+        assertFalse(apiClient.testConnection())
+    }
+
+    @Test
+    fun `testConnection returns false on exception`() = runBlocking {
+        mockClient.shouldThrow = true
+        assertFalse(apiClient.testConnection())
+    }
+
+    @Test
+    fun `testConnection with blank token returns false`() = runBlocking {
+        val client = HoppscotchApiClient(token = "", httpClient = mockClient)
+        assertFalse(client.testConnection())
+    }
+
+    // ==================== listTeams ====================
+
+    @Test
+    fun `listTeams returns teams on success`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"data":{"myTeams":[{"id":"team-1","name":"Team Alpha"},{"id":"team-2","name":"Team Beta"}]}}"""
+        )
+        val teams = apiClient.listTeams()
+        assertEquals(2, teams.size)
+        assertEquals("team-1", teams[0].id)
+        assertEquals("Team Alpha", teams[0].name)
+    }
+
+    @Test
+    fun `listTeams returns empty on error`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 500, body = "Error")
+        val teams = apiClient.listTeams()
+        assertTrue(teams.isEmpty())
+    }
+
+    @Test
+    fun `listTeams with blank token returns empty`() = runBlocking {
+        val client = HoppscotchApiClient(token = "", httpClient = mockClient)
+        val teams = client.listTeams()
+        assertTrue(teams.isEmpty())
+    }
+
+    // ==================== listCollections ====================
+
+    @Test
+    fun `listCollections returns collections on success`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"data":{"rootCollectionsOfTeam":[{"id":"col-1","title":"Collection 1"},{"id":"col-2","title":"Collection 2"}]}}"""
+        )
+        val collections = apiClient.listCollections()
+        assertEquals(2, collections.size)
+        assertEquals("col-1", collections[0].id)
+        assertEquals("Collection 1", collections[0].name)
+    }
+
+    @Test
+    fun `listCollections with teamId includes teamID in query`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"data":{"rootCollectionsOfTeam":[{"id":"col-1","title":"Test"}]}}"""
+        )
+        val collections = apiClient.listCollections(teamId = "team-123")
+        assertEquals(1, collections.size)
+        // Verify the request body contains teamID
+        val requestBody = mockClient.lastRequest?.body ?: ""
+        assertTrue(requestBody.contains("teamID"))
+    }
+
+    @Test
+    fun `listCollections returns empty on error`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 500, body = "Error")
+        val collections = apiClient.listCollections()
+        assertTrue(collections.isEmpty())
+    }
+
+    @Test
+    fun `listCollections with blank token returns empty`() = runBlocking {
+        val client = HoppscotchApiClient(token = "", httpClient = mockClient)
+        val collections = client.listCollections()
+        assertTrue(collections.isEmpty())
+    }
+
+    // ==================== uploadCollection ====================
+
+    @Test
+    fun `uploadCollection with blank token returns failure`() = runBlocking {
+        val client = HoppscotchApiClient(token = "", httpClient = mockClient)
+        val collection = com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection(name = "Test")
+        val result = client.uploadCollection(collection)
+        assertFalse(result.success)
+        assertTrue(result.message?.contains("No access token") == true)
+    }
+
+    @Test
+    fun `uploadCollection handles GraphQL errors`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"errors":[{"message":"Invalid JSON format"}]}"""
+        )
+        val collection = com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection(name = "Test")
+        val result = apiClient.uploadCollection(collection)
+        assertFalse(result.success)
+        assertTrue(result.message?.contains("Invalid JSON format") == true)
+    }
+
+    @Test
+    fun `uploadCollection handles exception`() = runBlocking {
+        mockClient.shouldThrow = true
+        val collection = com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection(name = "Test")
+        val result = apiClient.uploadCollection(collection)
+        assertFalse(result.success)
+    }
+
+    // ==================== deleteCollection ====================
+
+    @Test
+    fun `deleteCollection returns true on success`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(
+            code = 200,
+            body = """{"data":{"deleteUserCollection":true}}"""
+        )
+        assertTrue(apiClient.deleteCollection("col-123"))
+    }
+
+    @Test
+    fun `deleteCollection returns false on error`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 500, body = "Error")
+        assertFalse(apiClient.deleteCollection("col-123"))
+    }
+
+    @Test
+    fun `deleteCollection with blank token returns false`() = runBlocking {
+        val client = HoppscotchApiClient(token = "", httpClient = mockClient)
+        assertFalse(client.deleteCollection("col-123"))
+    }
+
+    // ==================== 401 Auth Exception ====================
+
+    @Test
+    fun `testConnection returns false on 401`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        assertFalse(apiClient.testConnection())
+    }
+
+    @Test
+    fun `listCollections returns empty on 401`() = runBlocking {
+        mockClient.nextResponse = HttpResponse(code = 401, body = "Unauthorized")
+        val result = apiClient.listCollections("team-1")
+        assertTrue(result.isEmpty())
+    }
+
+    // ==================== Data classes ====================
+
+    @Test
+    fun `HoppTeam data class`() {
+        val team = HoppTeam(id = "team-1", name = "Test Team")
+        assertEquals("team-1", team.id)
+        assertEquals("Test Team", team.name)
+    }
+
+    @Test
+    fun `HoppCollectionInfo data class`() {
+        val info = HoppCollectionInfo(id = "col-1", name = "Test Collection")
+        assertEquals("col-1", info.id)
+        assertEquals("Test Collection", info.name)
+    }
+
+    @Test
+    fun `HoppUploadResult data class`() {
+        val result = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        assertTrue(result.success)
+        assertEquals("OK", result.message)
+        assertEquals("col-1", result.collectionId)
+    }
+
+    @Test
+    fun `HoppUploadResult copy`() {
+        val result = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        val copy = result.copy(success = false)
+        assertFalse(copy.success)
+        assertEquals("OK", copy.message)
+    }
+
+    @Test
+    fun `HoppscotchAuthException is an Exception`() {
+        val ex = HoppscotchAuthException("Token expired")
+        assertTrue(ex is Exception)
+        assertEquals("Token expired", ex.message)
+    }
+
+    /**
+     * Simple mock HttpClient that returns a pre-configured response.
+     */
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "")
+        var lastRequest: HttpRequest? = null
+        var shouldThrow: Boolean = false
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            if (shouldThrow) {
+                throw RuntimeException("Test error")
+            }
+            return nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientTranslateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchApiClientTranslateTest.kt
@@ -1,0 +1,268 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for HoppscotchApiClient.translateToPersonalCollectionFormat and
+ * additional companion method edge cases.
+ */
+class HoppscotchApiClientTranslateTest {
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+    }
+
+    // ==================== translateToPersonalCollectionFormat via reflection ====================
+
+    @Test
+    fun `translateToPersonalCollectionFormat moves auth headers variables to data sub-object`() {
+        val method = HoppscotchApiClient::class.java.getDeclaredMethod(
+            "translateToPersonalCollectionFormat", HoppCollection::class.java
+        )
+        method.isAccessible = true
+
+        val collection = HoppCollection(
+            name = "Test Collection",
+            auth = HoppAuth(authType = "bearer"),
+            headers = listOf(HoppKeyValue(key = "X-Custom", value = "test")),
+            variables = listOf(HoppCollectionVariable(key = "baseUrl", initialValue = "https://api.example.com")),
+            description = "A test collection",
+            preRequestScript = "console.log('pre')",
+            testScript = "console.log('test')",
+            requests = listOf(
+                HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api")
+            ),
+            folders = listOf(
+                HoppCollection(name = "Sub Folder")
+            )
+        )
+
+        val result = method.invoke(client, collection) as JsonObject
+
+        // Top-level fields
+        assertEquals(12, result.get("v").asInt)
+        assertEquals("Test Collection", result.get("name").asString)
+        assertNotNull(result.get("_ref_id"))
+        assertTrue(result.get("folders").isJsonArray)
+        assertTrue(result.get("requests").isJsonArray)
+
+        // Data sub-object
+        val data = result.getAsJsonObject("data")
+        assertNotNull(data)
+        assertNotNull(data.get("auth"))
+        assertNotNull(data.get("headers"))
+        assertNotNull(data.get("variables"))
+        assertEquals("A test collection", data.get("description").asString)
+        assertEquals("console.log('pre')", data.get("preRequestScript").asString)
+        assertEquals("console.log('test')", data.get("testScript").asString)
+    }
+
+    @Test
+    fun `translateToPersonalCollectionFormat handles empty collection`() {
+        val method = HoppscotchApiClient::class.java.getDeclaredMethod(
+            "translateToPersonalCollectionFormat", HoppCollection::class.java
+        )
+        method.isAccessible = true
+
+        val collection = HoppCollection(name = "Empty")
+        val result = method.invoke(client, collection) as JsonObject
+
+        assertEquals("Empty", result.get("name").asString)
+        val data = result.getAsJsonObject("data")
+        assertNotNull(data)
+        assertEquals("", data.get("description").asString)
+        assertEquals("", data.get("preRequestScript").asString)
+        assertEquals("", data.get("testScript").asString)
+    }
+
+    @Test
+    fun `translateToPersonalCollectionFormat recursively transforms folders`() {
+        val method = HoppscotchApiClient::class.java.getDeclaredMethod(
+            "translateToPersonalCollectionFormat", HoppCollection::class.java
+        )
+        method.isAccessible = true
+
+        val nestedFolder = HoppCollection(
+            name = "Nested",
+            requests = listOf(HoppRESTRequest(name = "POST /inner", method = "POST", endpoint = "/inner"))
+        )
+        val collection = HoppCollection(
+            name = "Root",
+            folders = listOf(nestedFolder)
+        )
+
+        val result = method.invoke(client, collection) as JsonObject
+        val folders = result.getAsJsonArray("folders")
+        assertEquals(1, folders.size())
+
+        val nestedResult = folders[0].asJsonObject
+        assertEquals("Nested", nestedResult.get("name").asString)
+        // Nested folder should also have data sub-object
+        assertNotNull(nestedResult.getAsJsonObject("data"))
+    }
+
+    // ==================== resolveApiBaseUrl edge cases ====================
+
+    @Test
+    fun `resolveApiBaseUrl handles URL with port`() {
+        val result = HoppscotchApiClient.resolveApiBaseUrl("https://hoppscotch.io:443")
+        assertEquals("https://api.hoppscotch.io", result)
+    }
+
+    @Test
+    fun `resolveApiBaseUrl handles HTTP scheme for self-hosted`() {
+        val result = HoppscotchApiClient.resolveApiBaseUrl("http://localhost:3000")
+        assertEquals("http://localhost:3000", result)
+    }
+
+    @Test
+    fun `resolveApiBaseUrl handles HTTP with backend URL`() {
+        val result = HoppscotchApiClient.resolveApiBaseUrl("http://localhost:3000", "http://localhost:3170")
+        assertEquals("http://localhost:3170", result)
+    }
+
+    // ==================== resolveApiV1BaseUrl edge cases ====================
+
+    @Test
+    fun `resolveApiV1BaseUrl for cloud with trailing slash`() {
+        val result = HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io/")
+        assertEquals("https://api.hoppscotch.io/v1", result)
+    }
+
+    @Test
+    fun `resolveApiV1BaseUrl for self-hosted HTTP`() {
+        val result = HoppscotchApiClient.resolveApiV1BaseUrl("http://localhost:3000")
+        assertEquals("http://localhost:3000/v1", result)
+    }
+
+    // ==================== resolveGraphQLUrl edge cases ====================
+
+    @Test
+    fun `resolveGraphQLUrl for self-hosted with backend URL`() {
+        val result = HoppscotchApiClient.resolveGraphQLUrl("http://localhost:3000", "http://localhost:3170")
+        assertEquals("http://localhost:3170/graphql", result)
+    }
+
+    // ==================== isCloudServer edge cases ====================
+
+    @Test
+    fun `isCloudServer returns false for localhost`() {
+        assertFalse(HoppscotchApiClient.isCloudServer("http://localhost:3000"))
+    }
+
+    @Test
+    fun `isCloudServer returns false for IP address`() {
+        assertFalse(HoppscotchApiClient.isCloudServer("http://192.168.1.1:3000"))
+    }
+
+    // ==================== 405 Method Not Allowed handling ====================
+
+    @Test
+    fun `405 response makes listTeams return empty list`() = runBlocking {
+        mockHttpClient.nextResponse = HttpResponse(code = 405, body = "Method Not Allowed")
+        val result = client.listTeams()
+        assertTrue(result.isEmpty())
+    }
+
+    // ==================== HoppTeam data class tests ====================
+
+    @Test
+    fun `HoppTeam data class operations`() {
+        val team = HoppTeam(id = "team-1", name = "My Team")
+        assertEquals("team-1", team.id)
+        assertEquals("My Team", team.name)
+
+        val copy = team.copy(name = "Updated Team")
+        assertEquals("team-1", copy.id)
+        assertEquals("Updated Team", copy.name)
+
+        val team2 = HoppTeam(id = "team-1", name = "My Team")
+        assertEquals(team, team2)
+        assertEquals(team.hashCode(), team2.hashCode())
+    }
+
+    // ==================== HoppCollectionInfo data class tests ====================
+
+    @Test
+    fun `HoppCollectionInfo data class operations`() {
+        val info = HoppCollectionInfo(id = "col-1", name = "My Collection")
+        assertEquals("col-1", info.id)
+        assertEquals("My Collection", info.name)
+
+        val copy = info.copy(name = "Renamed")
+        assertEquals("col-1", copy.id)
+        assertEquals("Renamed", copy.name)
+    }
+
+    // ==================== HoppUploadResult data class tests ====================
+
+    @Test
+    fun `HoppUploadResult success with collectionId`() {
+        val result = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        assertTrue(result.success)
+        assertEquals("OK", result.message)
+        assertEquals("col-1", result.collectionId)
+    }
+
+    @Test
+    fun `HoppUploadResult failure`() {
+        val result = HoppUploadResult(success = false, message = "Upload failed")
+        assertFalse(result.success)
+        assertEquals("Upload failed", result.message)
+        assertNull(result.collectionId)
+    }
+
+    @Test
+    fun `HoppUploadResult default values`() {
+        val result = HoppUploadResult(success = true)
+        assertTrue(result.success)
+        assertNull(result.message)
+        assertNull(result.collectionId)
+    }
+
+    @Test
+    fun `HoppUploadResult copy`() {
+        val result = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        val copy = result.copy(collectionId = "col-2")
+        assertEquals("col-2", copy.collectionId)
+        assertEquals("OK", copy.message)
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var nextException: Exception? = null
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            nextException?.let { throw it }
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServiceLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServiceLogicTest.kt
@@ -1,0 +1,80 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettings
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchAuthServiceLogicTest {
+
+    private val defaultServerUrl = "https://hoppscotch.io"
+
+    @Test
+    fun `getServerUrl returns custom URL when set`() {
+        val state = HoppscotchSettings(hoppscotchServerUrl = "https://custom.hoppscotch.io")
+        val result = state.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://custom.hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when null`() {
+        val state = HoppscotchSettings(hoppscotchServerUrl = null)
+        val result = state.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when blank`() {
+        val state = HoppscotchSettings(hoppscotchServerUrl = "")
+        val result = state.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `getServerUrl returns default URL when whitespace`() {
+        val state = HoppscotchSettings(hoppscotchServerUrl = "   ")
+        val result = state.hoppscotchServerUrl?.takeIf { it.isNotBlank() } ?: defaultServerUrl
+        assertEquals("https://hoppscotch.io", result)
+    }
+
+    @Test
+    fun `isJcefAvailable gracefully handles JCEF unavailability`() {
+        val result = try {
+            val jcefAppClass = Class.forName("com.intellij.ui.jcef.JBCefApp")
+            val isSupportedMethod = jcefAppClass.getMethod("isSupported")
+            isSupportedMethod.invoke(null) as Boolean
+        } catch (e: Throwable) {
+            false
+        }
+        assertNotNull("JCEF check should not throw uncaught exceptions", result)
+    }
+
+    @Test
+    fun `custom server URL constructs correct GraphQL endpoint`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(customUrl)
+        val graphqlUrl = "$apiBaseUrl/api/graphql"
+        assertEquals("https://custom.hoppscotch.example/api/graphql", graphqlUrl)
+    }
+
+    @Test
+    fun `default server URL constructs correct GraphQL endpoint`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(defaultServerUrl)
+        val graphqlUrl = "$apiBaseUrl/graphql"
+        assertEquals("https://api.hoppscotch.io/graphql", graphqlUrl)
+    }
+
+    @Test
+    fun `custom server URL constructs correct auth login URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val loginUrl = "$customUrl/auth/login"
+        assertEquals("https://custom.hoppscotch.example/auth/login", loginUrl)
+    }
+
+    @Test
+    fun `custom server URL constructs correct token refresh URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiBaseUrl(customUrl)
+        val refreshUrl = "$apiBaseUrl/api/auth/token/refresh"
+        assertEquals("https://custom.hoppscotch.example/api/auth/token/refresh", refreshUrl)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServicePrivateMethodsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServicePrivateMethodsTest.kt
@@ -1,0 +1,292 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.itangcent.easyapi.http.HttpResponse
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Tests for HoppscotchAuthService private methods via reflection.
+ *
+ * Covers the private helper methods that are not exercised by other tests:
+ * - [HoppscotchAuthService.extractTokenFromCookieHeader]
+ * - [HoppscotchAuthService.extractTokenFromResponseBody]
+ * - [HoppscotchAuthService.getJsonString]
+ * - [HoppscotchAuthService.parseJson]
+ *
+ * These methods are pure (no Project / HttpClient dependencies), so they can
+ * be safely invoked via reflection on an instance constructed with a mock Project.
+ */
+class HoppscotchAuthServicePrivateMethodsTest {
+
+    private val authService = HoppscotchAuthService(mock())
+
+    // ==================== extractTokenFromCookieHeader ====================
+
+    private fun invokeExtractTokenFromCookieHeader(
+        response: HttpResponse,
+        tokenName: String
+    ): String? {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractTokenFromCookieHeader", HttpResponse::class.java, String::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(authService, response, tokenName) as String?
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader extracts token from Set-Cookie header`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf("Set-Cookie" to listOf("access_token=abc123; Path=/; HttpOnly")),
+            body = null
+        )
+        assertEquals("abc123", invokeExtractTokenFromCookieHeader(response, "access_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader extracts token from lowercase set-cookie header`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf("set-cookie" to listOf("refresh_token=xyz789; Path=/; HttpOnly")),
+            body = null
+        )
+        assertEquals("xyz789", invokeExtractTokenFromCookieHeader(response, "refresh_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader returns null when no cookie header present`() {
+        val response = HttpResponse(code = 200, headers = emptyMap(), body = null)
+        assertNull(invokeExtractTokenFromCookieHeader(response, "access_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader returns null when token name does not match`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf("Set-Cookie" to listOf("other_token=abc123; Path=/; HttpOnly")),
+            body = null
+        )
+        assertNull(invokeExtractTokenFromCookieHeader(response, "access_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader finds correct token among multiple cookies`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf(
+                "Set-Cookie" to listOf(
+                    "session_id= sess123; Path=/; HttpOnly",
+                    "access_token=my-access-token; Path=/; HttpOnly",
+                    "refresh_token=my-refresh-token; Path=/; HttpOnly"
+                )
+            ),
+            body = null
+        )
+        assertEquals("my-access-token", invokeExtractTokenFromCookieHeader(response, "access_token"))
+        assertEquals("my-refresh-token", invokeExtractTokenFromCookieHeader(response, "refresh_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader extracts token without attributes`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf("Set-Cookie" to listOf("access_token=bareToken")),
+            body = null
+        )
+        assertEquals("bareToken", invokeExtractTokenFromCookieHeader(response, "access_token"))
+    }
+
+    @Test
+    fun `extractTokenFromCookieHeader returns empty string when token value is empty`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = mapOf("Set-Cookie" to listOf("access_token=; Path=/; HttpOnly")),
+            body = null
+        )
+        assertEquals("", invokeExtractTokenFromCookieHeader(response, "access_token"))
+    }
+
+    // ==================== extractTokenFromResponseBody ====================
+
+    private fun invokeExtractTokenFromResponseBody(response: HttpResponse): String? {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractTokenFromResponseBody", HttpResponse::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(authService, response) as String?
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody extracts access_token from JSON body`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = emptyMap(),
+            body = """{"access_token":"token-from-body","expires_in":3600}"""
+        )
+        assertEquals("token-from-body", invokeExtractTokenFromResponseBody(response))
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody returns null when body is null`() {
+        val response = HttpResponse(code = 200, headers = emptyMap(), body = null)
+        assertNull(invokeExtractTokenFromResponseBody(response))
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody returns null when body is blank`() {
+        val response = HttpResponse(code = 200, headers = emptyMap(), body = "   ")
+        assertNull(invokeExtractTokenFromResponseBody(response))
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody returns null when body is not valid JSON`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = emptyMap(),
+            body = "this is not json"
+        )
+        assertNull(invokeExtractTokenFromResponseBody(response))
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody returns null when JSON has no access_token field`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = emptyMap(),
+            body = """{"other_field":"value"}"""
+        )
+        assertNull(invokeExtractTokenFromResponseBody(response))
+    }
+
+    @Test
+    fun `extractTokenFromResponseBody returns null when access_token is null in JSON`() {
+        val response = HttpResponse(
+            code = 200,
+            headers = emptyMap(),
+            body = """{"access_token":null}"""
+        )
+        assertNull(invokeExtractTokenFromResponseBody(response))
+    }
+
+    // ==================== getJsonString ====================
+
+    private fun invokeGetJsonString(json: JsonObject?, field: String): String? {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "getJsonString", JsonObject::class.java, String::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(authService, json, field) as String?
+    }
+
+    @Test
+    fun `getJsonString returns null when json is null`() {
+        assertNull(invokeGetJsonString(null, "message"))
+    }
+
+    @Test
+    fun `getJsonString returns null when field is not present`() {
+        val json = JsonObject()
+        assertNull(invokeGetJsonString(json, "message"))
+    }
+
+    @Test
+    fun `getJsonString returns string when field is a primitive string`() {
+        val json = JsonObject()
+        json.addProperty("message", "INVALID_EMAIL")
+        assertEquals("INVALID_EMAIL", invokeGetJsonString(json, "message"))
+    }
+
+    @Test
+    fun `getJsonString returns inner message when field is a nested object with message primitive`() {
+        val json = JsonParser.parseString("""{"message":{"message":"AUTH_PROVIDER_NOT_SPECIFIED","statusCode":404}}""").asJsonObject
+        assertEquals("AUTH_PROVIDER_NOT_SPECIFIED", invokeGetJsonString(json, "message"))
+    }
+
+    @Test
+    fun `getJsonString returns string representation when field is a nested object without message`() {
+        val json = JsonParser.parseString("""{"error":{"code":500}}""").asJsonObject
+        val result = invokeGetJsonString(json, "error")
+        assertNotNull(result)
+        assertTrue(result!!.contains("\"code\":500"))
+    }
+
+    @Test
+    fun `getJsonString returns string representation when inner message is not primitive`() {
+        val json = JsonParser.parseString("""{"error":{"message":{"nested":"value"}}}""").asJsonObject
+        val result = invokeGetJsonString(json, "error")
+        assertNotNull(result)
+        // Inner message is a JsonObject (not primitive), so falls to element.toString()
+        assertTrue(result!!.contains("nested"))
+    }
+
+    @Test
+    fun `getJsonString returns string representation for non-primitive non-object field`() {
+        val json = JsonParser.parseString("""{"items":[1,2,3]}""").asJsonObject
+        val result = invokeGetJsonString(json, "items")
+        assertNotNull(result)
+        assertTrue(result!!.contains("1"))
+    }
+
+    @Test
+    fun `getJsonString returns value for numeric primitive field`() {
+        val json = JsonObject()
+        json.addProperty("code", 404)
+        assertEquals("404", invokeGetJsonString(json, "code"))
+    }
+
+    @Test
+    fun `getJsonString returns value for boolean primitive field`() {
+        val json = JsonObject()
+        json.addProperty("active", true)
+        assertEquals("true", invokeGetJsonString(json, "active"))
+    }
+
+    // ==================== parseJson ====================
+
+    private fun invokeParseJson(body: String?): JsonObject? {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "parseJson", String::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(authService, body) as JsonObject?
+    }
+
+    @Test
+    fun `parseJson returns null for null body`() {
+        assertNull(invokeParseJson(null))
+    }
+
+    @Test
+    fun `parseJson returns null for blank body`() {
+        assertNull(invokeParseJson(""))
+        assertNull(invokeParseJson("   "))
+    }
+
+    @Test
+    fun `parseJson returns JsonObject for valid JSON`() {
+        val result = invokeParseJson("""{"message":"hello","code":200}""")
+        assertNotNull(result)
+        assertEquals("hello", result?.get("message")?.asString)
+        assertEquals(200, result?.get("code")?.asInt)
+    }
+
+    @Test
+    fun `parseJson returns null for invalid JSON`() {
+        assertNull(invokeParseJson("not valid json"))
+    }
+
+    @Test
+    fun `parseJson returns null for JSON array instead of object`() {
+        assertNull(invokeParseJson("[1, 2, 3]"))
+    }
+
+    @Test
+    fun `parseJson returns empty JsonObject for empty JSON object`() {
+        val result = invokeParseJson("{}")
+        assertNotNull(result)
+        assertEquals(0, result?.size())
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServicePureLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchAuthServicePureLogicTest.kt
@@ -1,0 +1,201 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.intellij.openapi.project.Project
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Tests for HoppscotchAuthService pure logic methods.
+ *
+ * Methods like getServerUrl delegate to HoppscotchSettings (application
+ * service) and are covered by HoppscotchAuthServiceLogicTest / HoppscotchSettingsPanelLogicTest.
+ * This class tests the remaining pure logic: URL parsing via reflection, isCloudInstance,
+ * and data class behavior.
+ *
+ * Note: AuthProviderCheckResult is internal so it cannot be tested from this package.
+ */
+class HoppscotchAuthServicePureLogicTest {
+
+    private val authService = HoppscotchAuthService(mock())
+
+    // ==================== extractOobCodeFromUrl via reflection ====================
+
+    @Test
+    fun `extractOobCodeFromUrl extracts oobCode parameter`() {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractOobCodeFromUrl", String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(authService, "https://hoppscotch.io/enter?oobCode=ABC123&mode=signIn") as String?
+        assertEquals("ABC123", result)
+    }
+
+    @Test
+    fun `extractOobCodeFromUrl returns null when no oobCode`() {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractOobCodeFromUrl", String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(authService, "https://hoppscotch.io/enter?mode=signIn") as String?
+        assertNull(result)
+    }
+
+    @Test
+    fun `extractOobCodeFromUrl handles oobCode as second parameter`() {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractOobCodeFromUrl", String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(authService, "https://hoppscotch.io/enter?mode=signIn&oobCode=XYZ789") as String?
+        assertEquals("XYZ789", result)
+    }
+
+    // ==================== extractTokenFromUrl via reflection ====================
+
+    @Test
+    fun `extractTokenFromUrl extracts token parameter`() {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractTokenFromUrl", String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(authService, "https://example.com/enter?token=MYTOKEN123&email=test@test.com") as String?
+        assertEquals("MYTOKEN123", result)
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null when no token`() {
+        val method = HoppscotchAuthService::class.java.getDeclaredMethod(
+            "extractTokenFromUrl", String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(authService, "https://example.com/enter?email=test@test.com") as String?
+        assertNull(result)
+    }
+
+    // ==================== isCloudInstance ====================
+
+    @Test
+    fun `isCloudInstance returns true for hoppscotch io`() {
+        assertTrue(authService.isCloudInstance("https://hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudInstance returns true for subdomain of hoppscotch io`() {
+        assertTrue(authService.isCloudInstance("https://app.hoppscotch.io"))
+    }
+
+    @Test
+    fun `isCloudInstance returns false for self-hosted`() {
+        assertFalse(authService.isCloudInstance("https://custom.example.com"))
+    }
+
+    @Test
+    fun `isCloudInstance returns false for localhost`() {
+        assertFalse(authService.isCloudInstance("http://localhost:3000"))
+    }
+
+    // ==================== MagicLinkSendResult tests ====================
+
+    @Test
+    fun `MagicLinkSendResult success case`() {
+        val result = MagicLinkSendResult(success = true, deviceIdentifier = "dev-1")
+        assertTrue(result.success)
+        assertEquals("dev-1", result.deviceIdentifier)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkSendResult failure case`() {
+        val result = MagicLinkSendResult(success = false, errorMessage = "Failed")
+        assertFalse(result.success)
+        assertNull(result.deviceIdentifier)
+        assertEquals("Failed", result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkSendResult copy`() {
+        val result = MagicLinkSendResult(success = true, deviceIdentifier = "dev-1")
+        val copy = result.copy(errorMessage = "New error")
+        assertTrue(copy.success)
+        assertEquals("dev-1", copy.deviceIdentifier)
+        assertEquals("New error", copy.errorMessage)
+    }
+
+    // ==================== MagicLinkVerifyResult tests ====================
+
+    @Test
+    fun `MagicLinkVerifyResult success case`() {
+        val result = MagicLinkVerifyResult(
+            success = true,
+            accessToken = "access-123",
+            refreshToken = "refresh-456"
+        )
+        assertTrue(result.success)
+        assertEquals("access-123", result.accessToken)
+        assertEquals("refresh-456", result.refreshToken)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkVerifyResult failure case`() {
+        val result = MagicLinkVerifyResult(success = false, errorMessage = "Expired")
+        assertFalse(result.success)
+        assertNull(result.accessToken)
+        assertEquals("Expired", result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkVerifyResult copy`() {
+        val result = MagicLinkVerifyResult(success = true, accessToken = "at", refreshToken = "rt")
+        val copy = result.copy(accessToken = "new-at")
+        assertEquals("new-at", copy.accessToken)
+        assertEquals("rt", copy.refreshToken)
+    }
+
+    // ==================== FirebaseConfig tests ====================
+
+    @Test
+    fun `FirebaseConfig with all fields`() {
+        val config = FirebaseConfig(
+            apiKey = "key-123",
+            projectId = "project-1",
+            authDomain = "example.firebaseapp.com"
+        )
+        assertEquals("key-123", config.apiKey)
+        assertEquals("project-1", config.projectId)
+        assertEquals("example.firebaseapp.com", config.authDomain)
+    }
+
+    @Test
+    fun `FirebaseConfig with null authDomain`() {
+        val config = FirebaseConfig(apiKey = "key-123", projectId = "project-1", authDomain = null)
+        assertNull(config.authDomain)
+    }
+
+    @Test
+    fun `FirebaseConfig copy works`() {
+        val config = FirebaseConfig(apiKey = "key-123", projectId = "project-1", authDomain = "example.com")
+        val copy = config.copy(apiKey = "new-key")
+        assertEquals("new-key", copy.apiKey)
+        assertEquals("project-1", copy.projectId)
+        assertEquals("example.com", copy.authDomain)
+    }
+
+    @Test
+    fun `FirebaseConfig equals and hashCode`() {
+        val config1 = FirebaseConfig(apiKey = "key", projectId = "proj", authDomain = "domain")
+        val config2 = FirebaseConfig(apiKey = "key", projectId = "proj", authDomain = "domain")
+        assertEquals(config1, config2)
+        assertEquals(config1.hashCode(), config2.hashCode())
+    }
+
+    // ==================== HoppscotchAuthException tests ====================
+
+    @Test
+    fun `HoppscotchAuthException is an Exception with message`() {
+        val exception = HoppscotchAuthException("Token expired")
+        assertTrue(exception is Exception)
+        assertEquals("Token expired", exception.message)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelLogicTest.kt
@@ -1,0 +1,445 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchExportMetadata
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import java.io.File
+
+/**
+ * Tests for HoppscotchChannel business logic:
+ * - Channel properties
+ * - countRequests (via reflection)
+ * - formatGraphQLError (via reflection)
+ * - resolveTargetFile (via reflection)
+ * - handleResult with file export
+ * - export without token
+ * - HoppscotchExportMetadata.formatDisplay
+ */
+class HoppscotchChannelLogicTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var channel: HoppscotchChannel
+
+    override fun setUp() {
+        super.setUp()
+        channel = HoppscotchChannel()
+    }
+
+    // ── Channel property tests ───────────────────────────────────────────────
+
+    fun testChannelId() {
+        assertEquals("hoppscotch", channel.id)
+    }
+
+    fun testChannelDisplayName() {
+        assertEquals("Hoppscotch (Beta)", channel.displayName)
+    }
+
+    fun testChannelDoesNotSupportGrpc() {
+        assertFalse(channel.supportsGrpc)
+    }
+
+    fun testChannelExposesAsAction() {
+        assertTrue(channel.exposeAsAction)
+    }
+
+    fun testChannelActionText() {
+        assertEquals("Export to Hoppscotch (Beta)", channel.actionText)
+    }
+
+    // ── countRequests tests ──────────────────────────────────────────────────
+
+    fun testCountRequestsEmptyCollection() {
+        val collection = HoppCollection(name = "Empty")
+        assertEquals(0, countRequests(collection))
+    }
+
+    fun testCountRequestsFlatRequests() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1"),
+                HoppRESTRequest(name = "R2", method = "POST", endpoint = "/r2")
+            )
+        )
+        assertEquals(2, countRequests(collection))
+    }
+
+    fun testCountRequestsNestedFolders() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1")
+            ),
+            folders = listOf(
+                HoppCollection(
+                    name = "Sub",
+                    requests = listOf(
+                        HoppRESTRequest(name = "R2", method = "POST", endpoint = "/r2")
+                    )
+                )
+            )
+        )
+        assertEquals(2, countRequests(collection))
+    }
+
+    fun testCountRequestsDeeplyNested() {
+        val collection = HoppCollection(
+            name = "Root",
+            folders = listOf(
+                HoppCollection(
+                    name = "Level1",
+                    folders = listOf(
+                        HoppCollection(
+                            name = "Level2",
+                            requests = listOf(
+                                HoppRESTRequest(name = "Deep", method = "GET", endpoint = "/deep")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        assertEquals(1, countRequests(collection))
+    }
+
+    fun testCountRequestsMixedStructure() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1"),
+                HoppRESTRequest(name = "R2", method = "POST", endpoint = "/r2")
+            ),
+            folders = listOf(
+                HoppCollection(
+                    name = "Folder1",
+                    requests = listOf(
+                        HoppRESTRequest(name = "R3", method = "PUT", endpoint = "/r3")
+                    ),
+                    folders = listOf(
+                        HoppCollection(
+                            name = "Folder2",
+                            requests = listOf(
+                                HoppRESTRequest(name = "R4", method = "DELETE", endpoint = "/r4")
+                            )
+                        )
+                    )
+                ),
+                HoppCollection(
+                    name = "Folder3",
+                    requests = listOf(
+                        HoppRESTRequest(name = "R5", method = "PATCH", endpoint = "/r5")
+                    )
+                )
+            )
+        )
+        assertEquals(5, countRequests(collection))
+    }
+
+    fun testCountRequestsEmptyFolders() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1")
+            ),
+            folders = listOf(
+                HoppCollection(name = "EmptyFolder1"),
+                HoppCollection(name = "EmptyFolder2")
+            )
+        )
+        assertEquals(1, countRequests(collection))
+    }
+
+    // ── formatGraphQLError tests ─────────────────────────────────────────────
+
+    fun testFormatGraphQLErrorNullMessage() {
+        assertEquals("Upload failed with an unknown error", formatGraphQLError(null))
+    }
+
+    fun testFormatGraphQLErrorBlankMessage() {
+        assertEquals("Upload failed with an unknown error", formatGraphQLError(""))
+    }
+
+    fun testFormatGraphQLErrorWhitespaceMessage() {
+        assertEquals("Upload failed with an unknown error", formatGraphQLError("   "))
+    }
+
+    fun testFormatGraphQLErrorUnauthenticated() {
+        val result = formatGraphQLError("UNAUTHENTICATED: Token expired")
+        assertTrue("Should mention authentication failure", result.contains("Authentication failed"))
+    }
+
+    fun testFormatGraphQLErrorUnauthenticatedCaseInsensitive() {
+        val result = formatGraphQLError("unauthenticated: bad token")
+        assertTrue("Should be case-insensitive", result.contains("Authentication failed"))
+    }
+
+    fun testFormatGraphQLErrorForbidden() {
+        val result = formatGraphQLError("FORBIDDEN: Access denied")
+        assertTrue("Should mention permission denied", result.contains("Permission denied"))
+    }
+
+    fun testFormatGraphQLErrorNotFound() {
+        val result = formatGraphQLError("NOT_FOUND: Collection not found")
+        assertTrue("Should mention not found", result.contains("not found"))
+    }
+
+    fun testFormatGraphQLErrorAlreadyExists() {
+        val result = formatGraphQLError("Collection already exists in workspace")
+        assertTrue("Should mention already exists", result.contains("already exists"))
+    }
+
+    fun testFormatGraphQLErrorRateLimit() {
+        val result = formatGraphQLError("Rate limit exceeded, try again later")
+        assertTrue("Should mention rate limit", result.contains("Rate limit"))
+    }
+
+    fun testFormatGraphQLErrorGenericMessage() {
+        val result = formatGraphQLError("Some unknown error occurred")
+        assertEquals("Upload failed: Some unknown error occurred", result)
+    }
+
+    // ── resolveTargetFile tests ──────────────────────────────────────────────
+
+    fun testResolveTargetFileWithOutputDir() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val fileConfig = ChannelConfig.FileConfig(
+                outputDir = tempDir.absolutePath,
+                fileName = "my_collection"
+            )
+            val file = resolveTargetFile(fileConfig, "hoppscotch_collection.json")
+            assertNotNull(file)
+            assertEquals("my_collection.json", file!!.name)
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testResolveTargetFileWithOutputDirNoFileName() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val fileConfig = ChannelConfig.FileConfig(
+                outputDir = tempDir.absolutePath
+            )
+            val file = resolveTargetFile(fileConfig, "hoppscotch_collection.json")
+            assertNotNull(file)
+            assertEquals("hoppscotch_collection.json", file!!.name)
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testResolveTargetFileCreatesDirectory() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val newDir = File(tempDir, "subdir/nested")
+            assertFalse("Dir should not exist yet", newDir.exists())
+            val fileConfig = ChannelConfig.FileConfig(
+                outputDir = newDir.absolutePath,
+                fileName = "output"
+            )
+            val file = resolveTargetFile(fileConfig, "hoppscotch_collection.json")
+            assertNotNull(file)
+            assertTrue("Directory should be created", newDir.exists())
+            assertEquals("output.json", file!!.name)
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testResolveTargetFileWithNullFileConfig() = runBlocking {
+        // When fileConfig is null, falls back to file chooser which throws in headless test
+        try {
+            val file = resolveTargetFile(null, "hoppscotch_collection.json")
+            // If it doesn't throw, it should return null
+            assertNull("Should return null when no fileConfig and no file chooser", file)
+        } catch (e: Exception) {
+            // Expected: file chooser throws in headless test
+            // - ArrayIndexOutOfBoundsException: when file chooser dialog has no items
+            // - HeadlessException: when running on Linux CI without a display
+            val cause = e.cause ?: e
+            assertTrue(
+                "Expected file chooser error, got: ${cause.javaClass.simpleName}",
+                cause is ArrayIndexOutOfBoundsException || cause is java.awt.HeadlessException
+            )
+        }
+    }
+
+    // ── handleResult tests ───────────────────────────────────────────────────
+
+    fun testHandleResultWithNonHoppscotchMetadataReturnsFalse() = runBlocking {
+        val result = ExportResult.Success(count = 5, target = "Test", metadata = null)
+        val handled = channel.handleResult(project, result, ChannelConfig.Empty)
+        assertFalse("Should return false for non-Hoppscotch metadata", handled)
+    }
+
+    fun testHandleResultWithCollectionDataWritesFile() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val collectionData = HoppCollection(
+                name = "Test",
+                requests = listOf(
+                    HoppRESTRequest(name = "GET /users", method = "GET", endpoint = "/users")
+                )
+            )
+            val metadata = HoppscotchExportMetadata(
+                collectionName = "Test",
+                collectionData = collectionData
+            )
+            val result = ExportResult.Success(count = 1, target = "Hoppscotch Collection", metadata = metadata)
+            val config = ChannelConfig.FileConfig(
+                outputDir = tempDir.absolutePath,
+                fileName = "test_collection"
+            )
+
+            // Messages.showInfoMessage throws in headless test — catch it
+            try {
+                channel.handleResult(project, result, config)
+            } catch (_: RuntimeException) {
+                // Expected in headless test environment — file is written before the dialog
+            }
+
+            val outputFile = File(tempDir, "test_collection.json")
+            assertTrue("Output file should exist", outputFile.exists())
+            val content = outputFile.readText()
+            assertTrue("Output should contain collection name", content.contains("Test"))
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testHandleResultWithCollectionDataDefaultFileName() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val collectionData = HoppCollection(name = "Test")
+            val metadata = HoppscotchExportMetadata(
+                collectionName = "Test",
+                collectionData = collectionData
+            )
+            val result = ExportResult.Success(count = 0, target = "Hoppscotch Collection", metadata = metadata)
+            val config = ChannelConfig.FileConfig(
+                outputDir = tempDir.absolutePath
+            )
+
+            try {
+                channel.handleResult(project, result, config)
+            } catch (_: RuntimeException) {
+                // Expected in headless test environment
+            }
+
+            val outputFile = File(tempDir, "hoppscotch_collection.json")
+            assertTrue("Default filename should be used", outputFile.exists())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    fun testHandleResultWithCollectionDataCreatesDirectory() = runBlocking {
+        val tempDir = createTempDir("hoppscotch-test")
+        try {
+            val newDir = File(tempDir, "output")
+            val collectionData = HoppCollection(name = "Test")
+            val metadata = HoppscotchExportMetadata(
+                collectionName = "Test",
+                collectionData = collectionData
+            )
+            val result = ExportResult.Success(count = 0, target = "Hoppscotch Collection", metadata = metadata)
+            val config = ChannelConfig.FileConfig(
+                outputDir = newDir.absolutePath,
+                fileName = "result"
+            )
+
+            try {
+                channel.handleResult(project, result, config)
+            } catch (_: RuntimeException) {
+                // Expected
+            }
+
+            assertTrue("Directory should be created", newDir.exists())
+            val outputFile = File(newDir, "result.json")
+            assertTrue("Output file should exist", outputFile.exists())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    // ── HoppscotchExportMetadata formatDisplay tests ─────────────────────────
+
+    fun testMetadataFormatDisplayWithCollectionDataReturnsNull() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "Test",
+            collectionData = HoppCollection(name = "Test")
+        )
+        assertNull("Should return null when collectionData is present", metadata.formatDisplay())
+    }
+
+    fun testMetadataFormatDisplayWithoutCollectionDataShowsName() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "My Collection"
+        )
+        assertEquals("My Collection", metadata.formatDisplay())
+    }
+
+    fun testMetadataFormatDisplayWithWorkspaceAndCollection() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "My Collection",
+            workspaceName = "My Team"
+        )
+        assertEquals("My Team/My Collection", metadata.formatDisplay())
+    }
+
+    fun testMetadataFormatDisplayWithOnlyCollectionId() {
+        val metadata = HoppscotchExportMetadata(
+            collectionId = "abc-123"
+        )
+        assertEquals("abc-123", metadata.formatDisplay())
+    }
+
+    fun testMetadataFormatDisplayWithWorkspaceAndCollectionId() {
+        val metadata = HoppscotchExportMetadata(
+            workspaceName = "Team",
+            collectionId = "abc-123"
+        )
+        assertEquals("Team/abc-123", metadata.formatDisplay())
+    }
+
+    // ── Reflection helpers ───────────────────────────────────────────────────
+
+    private fun countRequests(collection: HoppCollection): Int {
+        val method = HoppscotchChannel::class.java.getDeclaredMethod("countRequests", HoppCollection::class.java)
+        method.isAccessible = true
+        return method.invoke(channel, collection) as Int
+    }
+
+    private fun formatGraphQLError(message: String?): String {
+        val method = HoppscotchChannel::class.java.getDeclaredMethod("formatGraphQLError", String::class.java)
+        method.isAccessible = true
+        return method.invoke(channel, message) as String
+    }
+
+    private suspend fun resolveTargetFile(
+        fileConfig: ChannelConfig.FileConfig?,
+        defaultFileName: String
+    ): File? {
+        val method = HoppscotchChannel::class.java.getDeclaredMethod(
+            "resolveTargetFile",
+            com.intellij.openapi.project.Project::class.java,
+            ChannelConfig.FileConfig::class.java,
+            String::class.java,
+            kotlin.coroutines.Continuation::class.java
+        )
+        method.isAccessible = true
+        return kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+            val result = method.invoke(channel, project, fileConfig, defaultFileName, cont)
+            if (result !== kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED) {
+                @Suppress("UNCHECKED_CAST")
+                cont.resumeWith(Result.success(result as File?))
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchChannelTest.kt
@@ -1,0 +1,62 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.Channel
+import com.itangcent.easyapi.exporter.channel.ChannelRegistry
+import com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchExportMetadata
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.exporter.model.ExportResult
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+
+class HoppscotchChannelTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var channel: HoppscotchChannel
+
+    override fun setUp() {
+        super.setUp()
+        channel = HoppscotchChannel()
+    }
+
+    fun testChannelProperties() {
+        assertEquals("hoppscotch", channel.id)
+        assertEquals("Hoppscotch (Beta)", channel.displayName)
+        assertFalse(channel.supportsGrpc)
+        assertTrue(channel.exposeAsAction)
+        assertEquals("Export to Hoppscotch (Beta)", channel.actionText)
+    }
+
+    fun testChannelRegistered() {
+        val registry = ChannelRegistry.getInstance(project)
+        val channels = registry.getAvailableChannels(emptyList())
+        val hoppscotchChannel = channels.find { it.id == "hoppscotch" }
+        assertNotNull("Hoppscotch channel should be registered", hoppscotchChannel)
+        assertEquals("Hoppscotch (Beta)", hoppscotchChannel!!.displayName)
+    }
+
+    fun testCreateOptionsPanelReturnsNonNull() {
+        val panel = channel.createOptionsPanel(project)
+        assertNotNull("Options panel should not be null", panel)
+    }
+
+    fun testCountRequests() {
+        val collection = HoppCollection(
+            name = "Root",
+            requests = listOf(
+                HoppRESTRequest(name = "R1", method = "GET", endpoint = "/r1"),
+                HoppRESTRequest(name = "R2", method = "POST", endpoint = "/r2")
+            ),
+            folders = listOf(
+                HoppCollection(
+                    name = "Sub",
+                    requests = listOf(
+                        HoppRESTRequest(name = "R3", method = "PUT", endpoint = "/r3")
+                    )
+                )
+            )
+        )
+        val method = HoppscotchChannel::class.java.getDeclaredMethod("countRequests", HoppCollection::class.java)
+        method.isAccessible = true
+        val count = method.invoke(channel, collection) as Int
+        assertEquals(3, count)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchCloudUploadTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchCloudUploadTest.kt
@@ -1,0 +1,192 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.ChannelConfig
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppRESTRequest
+import com.itangcent.easyapi.http.HttpClient
+import com.itangcent.easyapi.http.HttpRequest
+import com.itangcent.easyapi.http.HttpResponse
+import com.itangcent.easyapi.util.json.GsonUtils
+import com.google.gson.JsonObject
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class HoppscotchCloudUploadTest {
+
+    private lateinit var mockHttpClient: MockHttpClient
+    private lateinit var client: HoppscotchApiClient
+    private lateinit var cachedClient: CachedHoppscotchApiClient
+
+    @Before
+    fun setUp() {
+        mockHttpClient = MockHttpClient()
+        client = HoppscotchApiClient(
+            token = "test-token",
+            serverUrl = "https://hoppscotch.test",
+            httpClient = mockHttpClient
+        )
+        cachedClient = client.asCached()
+    }
+
+    @Test
+    fun `asCached extension creates CachedHoppscotchApiClient`() {
+        val cached = HoppscotchApiClient("t", "u", httpClient = mockHttpClient).asCached()
+        assertNotNull(cached)
+        assertTrue(cached is CachedHoppscotchApiClient)
+    }
+
+    @Test
+    fun `full upload flow - create new collection`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-new-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(
+            name = "My API",
+            requests = listOf(
+                HoppRESTRequest(name = "GET /users", method = "GET", endpoint = "/users"),
+                HoppRESTRequest(name = "POST /users", method = "POST", endpoint = "/users")
+            )
+        )
+        val result = cachedClient.uploadCollection(collection)
+        assertTrue(result.success)
+        assertEquals("col-new-1", result.collectionId)
+    }
+
+    @Test
+    fun `full upload flow - update existing collection`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-new-2")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(importData))
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.responseQueue.add(graphqlResponse(deleteData))
+
+        val collection = HoppCollection(name = "My API v2")
+        val result = cachedClient.updateCollection("col-old-1", collection)
+        assertTrue(result.success)
+        assertEquals("col-new-2", result.collectionId)
+        assertTrue(result.message!!.contains("updated successfully"))
+    }
+
+    @Test
+    fun `cached client delegates upload to underlying client`() = runBlocking {
+        val importData = JsonObject().apply {
+            add("importUserCollectionsFromJSON", JsonObject().apply {
+                addProperty("exportedCollection", "col-1")
+                addProperty("collectionType", "REST")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(name = "Test")
+        val result = cachedClient.uploadCollection(collection)
+        assertTrue(result.success)
+    }
+
+    @Test
+    fun `cached client delegates delete to underlying client`() = runBlocking {
+        val deleteData = JsonObject().apply {
+            addProperty("deleteUserCollection", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(deleteData)
+        assertTrue(cachedClient.deleteCollection("col-1"))
+    }
+
+    @Test
+    fun `cached client delegates testConnection to underlying client`() = runBlocking {
+        val data = JsonObject().apply {
+            add("me", JsonObject().apply {
+                addProperty("uid", "user1")
+                addProperty("displayName", "Test User")
+            })
+        }
+        mockHttpClient.nextResponse = graphqlResponse(data)
+        assertTrue(cachedClient.testConnection())
+    }
+
+    @Test
+    fun `HoppscotchConfig stores collection update info`() {
+        val config = HoppscotchConfig(
+            collectionId = "col-1",
+            collectionName = "My Collection",
+            isUpdate = true
+        )
+        assertEquals("col-1", config.collectionId)
+        assertEquals("My Collection", config.collectionName)
+        assertTrue(config.isUpdate)
+    }
+
+    @Test
+    fun `HoppscotchConfig defaults to create mode`() {
+        val config = HoppscotchConfig()
+        assertNull(config.collectionId)
+        assertNull(config.collectionName)
+        assertFalse(config.isUpdate)
+    }
+
+    @Test
+    fun `upload with teamId uses importCollectionsFromJSON`() = runBlocking {
+        val importData = JsonObject().apply {
+            addProperty("importCollectionsFromJSON", true)
+        }
+        mockHttpClient.nextResponse = graphqlResponse(importData)
+
+        val collection = HoppCollection(name = "Team Collection")
+        val result = cachedClient.uploadCollection(collection, teamId = "team-1")
+        assertTrue(result.success)
+
+        val lastBody = mockHttpClient.lastRequest?.body
+        assertNotNull(lastBody)
+        assertTrue(lastBody!!.contains("importCollectionsFromJSON"))
+        assertTrue(lastBody.contains("teamID"))
+    }
+
+    @Test
+    fun `upload failure does not delete old collection during update`() = runBlocking {
+        val errorBody = """{"errors":[{"message":"Server error"}]}"""
+        mockHttpClient.nextResponse = HttpResponse(code = 200, body = errorBody)
+
+        val collection = HoppCollection(name = "Failed Upload")
+        val result = client.updateCollection("old-col-1", collection)
+        assertFalse(result.success)
+    }
+
+    @Test
+    fun `HoppUploadResult copy preserves fields`() {
+        val original = HoppUploadResult(success = true, message = "OK", collectionId = "col-1")
+        val copied = original.copy(message = "Updated successfully (new ID: col-1)")
+        assertTrue(copied.success)
+        assertEquals("Updated successfully (new ID: col-1)", copied.message)
+        assertEquals("col-1", copied.collectionId)
+    }
+
+    private fun graphqlResponse(data: JsonObject): HttpResponse {
+        val wrapper = JsonObject().apply { add("data", data) }
+        return HttpResponse(code = 200, body = GsonUtils.GSON.toJson(wrapper))
+    }
+
+    class MockHttpClient : HttpClient {
+        var nextResponse: HttpResponse = HttpResponse(code = 200, body = "{}")
+        var responseQueue: ArrayDeque<HttpResponse> = ArrayDeque()
+        var lastRequest: HttpRequest? = null
+
+        override suspend fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return if (responseQueue.isNotEmpty()) responseQueue.removeFirst() else nextResponse
+        }
+
+        override fun close() {}
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchExportMetadataTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchExportMetadataTest.kt
@@ -1,0 +1,58 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppCollection
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchExportMetadataTest {
+
+    @Test
+    fun testFormatDisplayWithWorkspaceAndCollectionNames() {
+        val metadata = HoppscotchExportMetadata(
+            workspaceName = "My Workspace",
+            collectionName = "My Collection"
+        )
+        assertEquals("My Workspace/My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithWorkspaceNameOnly() {
+        val metadata = HoppscotchExportMetadata(workspaceName = "My Workspace")
+        assertEquals("My Workspace", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithCollectionNameOnly() {
+        val metadata = HoppscotchExportMetadata(collectionName = "My Collection")
+        assertEquals("My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithCollectionIdFallback() {
+        val metadata = HoppscotchExportMetadata(collectionId = "col-456")
+        assertEquals("col-456", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayWithNullData() {
+        val metadata = HoppscotchExportMetadata()
+        assertEquals("", metadata.formatDisplay())
+    }
+
+    @Test
+    fun testFormatDisplayReturnsNullWhenCollectionDataPresent() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "Test",
+            collectionData = HoppCollection(name = "Test")
+        )
+        assertNull(metadata.formatDisplay())
+    }
+
+    @Test
+    fun testCopy() {
+        val metadata = HoppscotchExportMetadata(workspaceName = "Test")
+        val copy = metadata.copy(collectionName = "New Collection")
+        assertEquals("Test", copy.workspaceName)
+        assertEquals("New Collection", copy.collectionName)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterLogicTest.kt
@@ -1,0 +1,516 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
+import com.itangcent.easyapi.exporter.model.*
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for HoppscotchFormatter pure logic methods.
+ * Methods that depend on Project/RuleEngine are tested via integration tests.
+ */
+class HoppscotchFormatterLogicTest {
+
+    // ==================== parsePath ====================
+
+    @Test
+    fun `parsePath splits on forward slash`() {
+        val result = HoppscotchFormatter.parsePath("/users/list")
+        assertEquals(listOf("users", "list"), result)
+    }
+
+    @Test
+    fun `parsePath trims leading and trailing slashes`() {
+        val result = HoppscotchFormatter.parsePath("/users/list/")
+        assertEquals(listOf("users", "list"), result)
+    }
+
+    @Test
+    fun `parsePath handles single segment`() {
+        val result = HoppscotchFormatter.parsePath("/users")
+        assertEquals(listOf("users"), result)
+    }
+
+    @Test
+    fun `parsePath handles empty string`() {
+        val result = HoppscotchFormatter.parsePath("")
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun `parsePath handles root path`() {
+        val result = HoppscotchFormatter.parsePath("/")
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun `parsePath handles path without leading slash`() {
+        val result = HoppscotchFormatter.parsePath("users/list")
+        assertEquals(listOf("users", "list"), result)
+    }
+
+    @Test
+    fun `parsePath handles deep nesting`() {
+        val result = HoppscotchFormatter.parsePath("/api/v1/users/{id}/posts")
+        assertEquals(listOf("api", "v1", "users", "{id}", "posts"), result)
+    }
+
+    // ==================== HoppscotchFormatOptions ====================
+
+    @Test
+    fun `HoppscotchFormatOptions defaults`() {
+        val opts = HoppscotchFormatOptions()
+        assertEquals("https://<<host>>", opts.defaultHost)
+        assertTrue(opts.appendTimestamp)
+    }
+
+    @Test
+    fun `HoppscotchFormatOptions custom values`() {
+        val opts = HoppscotchFormatOptions(defaultHost = "https://api.example.com", appendTimestamp = false)
+        assertEquals("https://api.example.com", opts.defaultHost)
+        assertFalse(opts.appendTimestamp)
+    }
+
+    // ==================== HoppCollection ====================
+
+    @Test
+    fun `HoppCollection defaults`() {
+        val coll = HoppCollection(name = "Test")
+        assertEquals(12, coll.v)
+        assertEquals("Test", coll.name)
+        assertTrue(coll.folders.isEmpty())
+        assertTrue(coll.requests.isEmpty())
+        assertEquals("", coll.preRequestScript)
+        assertEquals("", coll.testScript)
+    }
+
+    @Test
+    fun `HoppCollection with folders and requests`() {
+        val request = HoppRESTRequest(
+            name = "Get Users",
+            method = "GET",
+            endpoint = "https://api.example.com/users"
+        )
+        val folder = HoppCollection(name = "Users", requests = listOf(request))
+        val coll = HoppCollection(name = "API", folders = listOf(folder))
+        assertEquals(1, coll.folders.size)
+        assertEquals("Users", coll.folders[0].name)
+        assertEquals(1, coll.folders[0].requests.size)
+    }
+
+    @Test
+    fun `HoppCollection with scripts`() {
+        val coll = HoppCollection(
+            name = "API",
+            preRequestScript = "console.log('before')",
+            testScript = "console.log('after')"
+        )
+        assertEquals("console.log('before')", coll.preRequestScript)
+        assertEquals("console.log('after')", coll.testScript)
+    }
+
+    // ==================== HoppRESTRequest ====================
+
+    @Test
+    fun `HoppRESTRequest defaults`() {
+        val req = HoppRESTRequest(name = "Test", method = "GET", endpoint = "/test")
+        assertEquals("17", req.v)
+        assertEquals("GET", req.method)
+        assertTrue(req.params.isEmpty())
+        assertTrue(req.headers.isEmpty())
+        assertEquals("", req.preRequestScript)
+        assertEquals("", req.testScript)
+    }
+
+    @Test
+    fun `HoppRESTRequest with all fields`() {
+        val req = HoppRESTRequest(
+            name = "Create User",
+            method = "POST",
+            endpoint = "https://api.example.com/users",
+            params = listOf(HoppKeyValue(key = "page", value = "1")),
+            headers = listOf(HoppKeyValue(key = "Content-Type", value = "application/json")),
+            body = HoppRequestBody(contentType = "application/json", body = """{"name":"Alice"}"""),
+            preRequestScript = "pm.environment.set('token', 'abc')",
+            testScript = "pm.response.to.have.status(200)",
+            description = "Creates a new user"
+        )
+        assertEquals("POST", req.method)
+        assertEquals(1, req.params.size)
+        assertEquals(1, req.headers.size)
+        assertNotNull(req.body)
+        assertEquals("Creates a new user", req.description)
+    }
+
+    // ==================== HoppKeyValue ====================
+
+    @Test
+    fun `HoppKeyValue defaults`() {
+        val kv = HoppKeyValue(key = "test")
+        assertEquals("test", kv.key)
+        assertEquals("", kv.value)
+        assertTrue(kv.active)
+        assertNull(kv.description)
+    }
+
+    @Test
+    fun `HoppKeyValue with all fields`() {
+        val kv = HoppKeyValue(key = "Authorization", value = "Bearer token", active = false, description = "Auth header")
+        assertEquals("Authorization", kv.key)
+        assertEquals("Bearer token", kv.value)
+        assertFalse(kv.active)
+        assertEquals("Auth header", kv.description)
+    }
+
+    // ==================== HoppAuth ====================
+
+    @Test
+    fun `HoppAuth defaults to inherit`() {
+        val auth = HoppAuth()
+        assertEquals("inherit", auth.authType)
+        assertTrue(auth.authActive)
+    }
+
+    @Test
+    fun `HoppAuth bearer`() {
+        val auth = HoppAuth(authType = "bearer", authActive = true)
+        assertEquals("bearer", auth.authType)
+    }
+
+    // ==================== HoppRequestBody ====================
+
+    @Test
+    fun `HoppRequestBody defaults to no body`() {
+        val body = HoppRequestBody()
+        assertNull(body.contentType)
+        assertNull(body.body)
+    }
+
+    @Test
+    fun `HoppRequestBody JSON body`() {
+        val body = HoppRequestBody(contentType = "application/json", body = """{"key":"value"}""")
+        assertEquals("application/json", body.contentType)
+        assertEquals("""{"key":"value"}""", body.body)
+    }
+
+    @Test
+    fun `HoppRequestBody form-urlencoded body`() {
+        val body = HoppRequestBody(contentType = "application/x-www-form-urlencoded", body = "key=value")
+        assertEquals("application/x-www-form-urlencoded", body.contentType)
+    }
+
+    @Test
+    fun `HoppRequestBody multipart body`() {
+        val formData = listOf(
+            HoppFormDataEntry(key = "file", value = "test.txt", isFile = true),
+            HoppFormDataEntry(key = "name", value = "Alice", isFile = false)
+        )
+        val body = HoppRequestBody(contentType = "multipart/form-data", body = formData)
+        assertEquals("multipart/form-data", body.contentType)
+        assertNotNull(body.body)
+    }
+
+    // ==================== HoppFormDataEntry ====================
+
+    @Test
+    fun `HoppFormDataEntry defaults`() {
+        val entry = HoppFormDataEntry(key = "field")
+        assertEquals("field", entry.key)
+        assertEquals("", entry.value)
+        assertTrue(entry.active)
+        assertFalse(entry.isFile)
+        assertNull(entry.contentType)
+    }
+
+    @Test
+    fun `HoppFormDataEntry file entry`() {
+        val entry = HoppFormDataEntry(key = "upload", value = "document.pdf", isFile = true, contentType = "application/pdf")
+        assertTrue(entry.isFile)
+        assertEquals("application/pdf", entry.contentType)
+    }
+
+    // ==================== HoppCollectionVariable ====================
+
+    @Test
+    fun `HoppCollectionVariable defaults`() {
+        val v = HoppCollectionVariable(key = "host")
+        assertEquals("host", v.key)
+        assertEquals("", v.initialValue)
+        assertEquals("", v.currentValue)
+        assertFalse(v.secret)
+    }
+
+    @Test
+    fun `HoppCollectionVariable with values`() {
+        val v = HoppCollectionVariable(key = "token", initialValue = "abc", currentValue = "xyz", secret = true)
+        assertEquals("abc", v.initialValue)
+        assertEquals("xyz", v.currentValue)
+        assertTrue(v.secret)
+    }
+
+    // ==================== HoppRequestVariable ====================
+
+    @Test
+    fun `HoppRequestVariable defaults`() {
+        val v = HoppRequestVariable(key = "id")
+        assertEquals("id", v.key)
+        assertEquals("", v.value)
+        assertTrue(v.active)
+    }
+
+    // ==================== hoppscotchGson ====================
+
+    @Test
+    fun `hoppscotchGson serializes nulls`() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val body = HoppRequestBody()
+        val json = gson.toJson(body)
+        assertTrue(json.contains("contentType"))
+        assertTrue(json.contains("body"))
+    }
+
+    @Test
+    fun `hoppscotchGson pretty print`() {
+        val gson = hoppscotchGson(prettyPrint = true)
+        val coll = HoppCollection(name = "Test")
+        val json = gson.toJson(coll)
+        assertTrue(json.contains("\n"))
+    }
+
+    @Test
+    fun `hoppscotchGson compact print`() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val coll = HoppCollection(name = "Test")
+        val json = gson.toJson(coll)
+        assertFalse(json.contains("\n"))
+    }
+
+    @Test
+    fun `hoppscotchGson serializes collection correctly`() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val coll = HoppCollection(
+            name = "Test API",
+            folders = listOf(HoppCollection(name = "Users")),
+            requests = listOf(
+                HoppRESTRequest(
+                    name = "Get Users",
+                    method = "GET",
+                    endpoint = "https://api.example.com/users"
+                )
+            )
+        )
+        val json = gson.toJson(coll)
+        assertTrue(json.contains("\"name\":"))
+        assertTrue(json.contains("\"Test API\""))
+        assertTrue(json.contains("\"method\":"))
+    }
+
+    // ==================== generateUniqueRefId ====================
+
+    @Test
+    fun `generateUniqueRefId with prefix`() {
+        val id = generateUniqueRefId("coll")
+        assertTrue(id.startsWith("coll_"))
+    }
+
+    @Test
+    fun `generateUniqueRefId without prefix`() {
+        val id = generateUniqueRefId()
+        assertFalse(id.startsWith("_"))
+        assertTrue(id.contains("_"))
+    }
+
+    @Test
+    fun `generateUniqueRefId generates unique ids`() {
+        val id1 = generateUniqueRefId("req")
+        val id2 = generateUniqueRefId("req")
+        assertNotEquals(id1, id2)
+    }
+
+    // ==================== ParameterBinding ====================
+
+    @Test
+    fun `ParameterBinding types`() {
+        assertTrue(ParameterBinding.Query is ParameterBinding.Query)
+        assertTrue(ParameterBinding.Path is ParameterBinding.Path)
+        assertTrue(ParameterBinding.Header is ParameterBinding.Header)
+        assertTrue(ParameterBinding.Cookie is ParameterBinding.Cookie)
+        assertTrue(ParameterBinding.Body is ParameterBinding.Body)
+        assertTrue(ParameterBinding.Form is ParameterBinding.Form)
+        assertTrue(ParameterBinding.Ignored is ParameterBinding.Ignored)
+    }
+
+    // ==================== HttpMethod ====================
+
+    @Test
+    fun `HttpMethod fromSpring`() {
+        assertEquals(HttpMethod.GET, HttpMethod.fromSpring("GET"))
+        assertEquals(HttpMethod.POST, HttpMethod.fromSpring("POST"))
+        assertEquals(HttpMethod.PUT, HttpMethod.fromSpring("PUT"))
+        assertEquals(HttpMethod.DELETE, HttpMethod.fromSpring("DELETE"))
+        assertEquals(HttpMethod.PATCH, HttpMethod.fromSpring("PATCH"))
+        assertEquals(HttpMethod.HEAD, HttpMethod.fromSpring("HEAD"))
+        assertEquals(HttpMethod.OPTIONS, HttpMethod.fromSpring("OPTIONS"))
+        assertNull(HttpMethod.fromSpring("UNKNOWN"))
+    }
+
+    @Test
+    fun `HttpMethod fromSpring case insensitive`() {
+        assertEquals(HttpMethod.GET, HttpMethod.fromSpring("get"))
+        assertEquals(HttpMethod.POST, HttpMethod.fromSpring("post"))
+    }
+
+    // ==================== ParameterType ====================
+
+    @Test
+    fun `ParameterType fromTypeName null returns TEXT`() {
+        assertEquals(ParameterType.TEXT, ParameterType.fromTypeName(null))
+    }
+
+    @Test
+    fun `ParameterType fromTypeName blank returns TEXT`() {
+        assertEquals(ParameterType.TEXT, ParameterType.fromTypeName(""))
+        assertEquals(ParameterType.TEXT, ParameterType.fromTypeName("  "))
+    }
+
+    @Test
+    fun `ParameterType fromTypeName file returns FILE`() {
+        assertEquals(ParameterType.FILE, ParameterType.fromTypeName("MultipartFile"))
+    }
+
+    @Test
+    fun `ParameterType rawType`() {
+        assertEquals("text", ParameterType.TEXT.rawType())
+        assertEquals("file", ParameterType.FILE.rawType())
+    }
+
+    // ==================== ApiEndpoint helpers ====================
+
+    @Test
+    fun `ApiEndpoint isHttp`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        assertTrue(endpoint.isHttp)
+        assertFalse(endpoint.isGrpc)
+    }
+
+    @Test
+    fun `ApiEndpoint httpMetadata`() {
+        val httpMeta = HttpMetadata(path = "/test", method = HttpMethod.GET)
+        val endpoint = ApiEndpoint(metadata = httpMeta)
+        assertNotNull(endpoint.httpMetadata)
+        assertEquals("/test", endpoint.httpMetadata?.path)
+    }
+
+    @Test
+    fun `ApiEndpoint path for HTTP`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/api/users", method = HttpMethod.GET))
+        assertEquals("/api/users", endpoint.path)
+    }
+
+    @Test
+    fun `ApiEndpoint setParam adds query param`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        endpoint.setParam("page", "1", true, "Page number")
+        assertEquals(1, endpoint.httpMetadata?.parameters?.size)
+        assertEquals("page", endpoint.httpMetadata?.parameters?.first()?.name)
+        assertEquals(ParameterBinding.Query, endpoint.httpMetadata?.parameters?.first()?.binding)
+    }
+
+    @Test
+    fun `ApiEndpoint setFormParam adds form param`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.POST))
+        endpoint.setFormParam("username", "alice", true, "Username")
+        assertEquals(1, endpoint.httpMetadata?.parameters?.size)
+        assertEquals(ParameterBinding.Form, endpoint.httpMetadata?.parameters?.first()?.binding)
+    }
+
+    @Test
+    fun `ApiEndpoint setPathParam adds path param`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/users/{id}", method = HttpMethod.GET))
+        endpoint.setPathParam("id", "1", "User ID")
+        assertEquals(1, endpoint.httpMetadata?.parameters?.size)
+        assertEquals(ParameterBinding.Path, endpoint.httpMetadata?.parameters?.first()?.binding)
+        assertTrue(endpoint.httpMetadata?.parameters?.first()?.required == true)
+    }
+
+    @Test
+    fun `ApiEndpoint setHeader adds header`() {
+        val endpoint = ApiEndpoint(metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        endpoint.setHeader("Authorization", "Bearer token", true, "Auth token")
+        assertEquals(1, endpoint.httpMetadata?.headers?.size)
+        assertEquals("Authorization", endpoint.httpMetadata?.headers?.first()?.name)
+    }
+
+    @Test
+    fun `ApiEndpoint appendDesc appends description`() {
+        val endpoint = ApiEndpoint(name = "Test", description = "Original", metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        endpoint.appendDesc(" - extra")
+        assertEquals("Original - extra", endpoint.description)
+    }
+
+    @Test
+    fun `ApiEndpoint appendDesc with null description`() {
+        val endpoint = ApiEndpoint(name = "Test", description = null, metadata = HttpMetadata(path = "/test", method = HttpMethod.GET))
+        endpoint.appendDesc("new desc")
+        assertEquals("new desc", endpoint.description)
+    }
+
+    // ==================== HttpMetadata ====================
+
+    @Test
+    fun `HttpMetadata defaults`() {
+        val meta = HttpMetadata(path = "/test", method = HttpMethod.GET)
+        assertTrue(meta.parameters.isEmpty())
+        assertTrue(meta.headers.isEmpty())
+        assertNull(meta.contentType)
+        assertNull(meta.body)
+        assertEquals("HTTP", meta.protocol)
+    }
+
+    @Test
+    fun `HttpMetadata with all fields`() {
+        val meta = HttpMetadata(
+            path = "/api/users",
+            method = HttpMethod.POST,
+            parameters = mutableListOf(
+                ApiParameter(name = "name", binding = ParameterBinding.Form, example = "Alice")
+            ),
+            headers = mutableListOf(
+                ApiHeader(name = "Content-Type", value = "application/json")
+            ),
+            contentType = "application/json",
+            body = null
+        )
+        assertEquals(HttpMethod.POST, meta.method)
+        assertEquals(1, meta.parameters.size)
+        assertEquals(1, meta.headers.size)
+        assertEquals("application/json", meta.contentType)
+    }
+
+    // ==================== ApiParameter ====================
+
+    @Test
+    fun `ApiParameter defaults`() {
+        val param = ApiParameter(name = "test")
+        assertEquals("test", param.name)
+        assertEquals(ParameterType.TEXT, param.type)
+        assertFalse(param.required)
+        assertNull(param.binding)
+        assertNull(param.defaultValue)
+        assertNull(param.description)
+        assertNull(param.example)
+        assertNull(param.enumValues)
+    }
+
+    // ==================== ApiHeader ====================
+
+    @Test
+    fun `ApiHeader defaults`() {
+        val header = ApiHeader(name = "X-Custom")
+        assertEquals("X-Custom", header.name)
+        assertNull(header.value)
+        assertNull(header.description)
+        assertNull(header.example)
+        assertFalse(header.required)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterPrivateMethodsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterPrivateMethodsTest.kt
@@ -1,0 +1,573 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppFormDataEntry
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppKeyValue
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppRequestBody
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.ApiParameter
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.ParameterBinding
+import com.itangcent.easyapi.psi.model.ObjectModel
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Tests for HoppscotchFormatter private methods via reflection.
+ *
+ * Covers the private helper methods that are not exercised by other tests:
+ * - [HoppscotchFormatter.buildBody] (all 5 branches)
+ * - [HoppscotchFormatter.buildParams]
+ * - [HoppscotchFormatter.buildHeaders]
+ * - [HoppscotchFormatter.buildEndpointUrl]
+ * - [HoppscotchFormatter.convertToHoppscotchVarSyntax]
+ *
+ * The [HoppscotchFormatter.ruleEngine] field is `lazy`, so constructing the
+ * formatter with a mock Project is safe as long as we only call private
+ * methods that don't access `ruleEngine` — which all the tested methods are.
+ */
+class HoppscotchFormatterPrivateMethodsTest {
+
+    private val formatter = HoppscotchFormatter(mock())
+
+    // ==================== convertToHoppscotchVarSyntax ====================
+
+    private fun invokeConvertToHoppscotchVarSyntax(value: String): String {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "convertToHoppscotchVarSyntax", String::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(formatter, value) as String
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax replaces mustache with angle brackets`() {
+        assertEquals("https://<<host>>/api", invokeConvertToHoppscotchVarSyntax("https://{{host}}/api"))
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax trims whitespace`() {
+        assertEquals("https://host/api", invokeConvertToHoppscotchVarSyntax("  https://host/api  "))
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax removes backticks`() {
+        assertEquals("https://host/api", invokeConvertToHoppscotchVarSyntax("`https://host/api`"))
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax handles plain URL`() {
+        assertEquals("https://host/api", invokeConvertToHoppscotchVarSyntax("https://host/api"))
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax handles multiple variables`() {
+        assertEquals(
+            "https://<<host>>/<<resource>>/<<id>>",
+            invokeConvertToHoppscotchVarSyntax("https://{{host}}/{{resource}}/{{id}}")
+        )
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax handles empty string`() {
+        assertEquals("", invokeConvertToHoppscotchVarSyntax(""))
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax handles backticks with variables`() {
+        assertEquals("https://<<host>>/api", invokeConvertToHoppscotchVarSyntax("`https://{{host}}/api`"))
+    }
+
+    // ==================== buildEndpointUrl ====================
+
+    private fun invokeBuildEndpointUrl(meta: HttpMetadata, host: String): String {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "buildEndpointUrl", HttpMetadata::class.java, String::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(formatter, meta, host) as String
+    }
+
+    @Test
+    fun `buildEndpointUrl combines host and path`() {
+        val meta = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+        assertEquals("https://example.com/api/users", invokeBuildEndpointUrl(meta, "https://example.com"))
+    }
+
+    @Test
+    fun `buildEndpointUrl adds leading slash if missing`() {
+        val meta = HttpMetadata(path = "api/users", method = HttpMethod.GET)
+        assertEquals("https://example.com/api/users", invokeBuildEndpointUrl(meta, "https://example.com"))
+    }
+
+    @Test
+    fun `buildEndpointUrl removes trailing slash from host`() {
+        val meta = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+        assertEquals("https://example.com/api/users", invokeBuildEndpointUrl(meta, "https://example.com/"))
+    }
+
+    @Test
+    fun `buildEndpointUrl replaces mustache with angle brackets`() {
+        val meta = HttpMetadata(path = "/api/{{resource}}", method = HttpMethod.GET)
+        assertEquals("https://<<host>>/api/<<resource>>", invokeBuildEndpointUrl(meta, "https://{{host}}"))
+    }
+
+    @Test
+    fun `buildEndpointUrl trims leading backticks from combined URL`() {
+        // trim('`') only removes backticks from the start/end of the full combined string,
+        // not from the middle. A backtick at the end of host is in the middle after concat.
+        val meta = HttpMetadata(path = "/api/users", method = HttpMethod.GET)
+        val result = invokeBuildEndpointUrl(meta, "`https://example.com`")
+        assertEquals("https://example.com`/api/users", result)
+    }
+
+    @Test
+    fun `buildEndpointUrl trims trailing backticks from combined URL`() {
+        // When the path itself ends with a backtick, trim('`') removes it from the end
+        val meta = HttpMetadata(path = "/api/users`", method = HttpMethod.GET)
+        val result = invokeBuildEndpointUrl(meta, "https://example.com")
+        // combined = "https://example.com/api/users`" -> trim('`') -> "https://example.com/api/users"
+        assertEquals("https://example.com/api/users", result)
+    }
+
+    @Test
+    fun `buildEndpointUrl handles root path`() {
+        val meta = HttpMetadata(path = "/", method = HttpMethod.GET)
+        assertEquals("https://example.com/", invokeBuildEndpointUrl(meta, "https://example.com"))
+    }
+
+    @Test
+    fun `buildEndpointUrl handles empty path`() {
+        val meta = HttpMetadata(path = "", method = HttpMethod.GET)
+        assertEquals("https://example.com/", invokeBuildEndpointUrl(meta, "https://example.com"))
+    }
+
+    // ==================== buildParams ====================
+
+    private fun invokeBuildParams(meta: HttpMetadata): List<HoppKeyValue> {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "buildParams", HttpMetadata::class.java
+        )
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(formatter, meta) as List<HoppKeyValue>
+    }
+
+    @Test
+    fun `buildParams returns empty list for no parameters`() {
+        val meta = HttpMetadata(path = "/api", method = HttpMethod.GET)
+        assertTrue(invokeBuildParams(meta).isEmpty())
+    }
+
+    @Test
+    fun `buildParams includes query parameters`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query, example = "1")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals(1, params.size)
+        assertEquals("page", params[0].key)
+        assertEquals("1", params[0].value)
+        assertTrue(params[0].active)
+    }
+
+    @Test
+    fun `buildParams includes path parameters`() {
+        val meta = HttpMetadata(
+            path = "/api/users/{id}",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "id", binding = ParameterBinding.Path, example = "42")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals(1, params.size)
+        assertEquals("id", params[0].key)
+        assertEquals("42", params[0].value)
+    }
+
+    @Test
+    fun `buildParams excludes form parameters`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query, example = "1"),
+                ApiParameter(name = "username", binding = ParameterBinding.Form, example = "alice")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals(1, params.size)
+        assertEquals("page", params[0].key)
+    }
+
+    @Test
+    fun `buildParams excludes header and body parameters`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query, example = "1"),
+                ApiParameter(name = "X-Custom", binding = ParameterBinding.Header, example = "val"),
+                ApiParameter(name = "body", binding = ParameterBinding.Body, example = "data")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals(1, params.size)
+        assertEquals("page", params[0].key)
+    }
+
+    @Test
+    fun `buildParams uses defaultValue when example is null`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query, defaultValue = "10")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals("10", params[0].value)
+    }
+
+    @Test
+    fun `buildParams uses empty string when neither example nor defaultValue`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query)
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals("", params[0].value)
+    }
+
+    @Test
+    fun `buildParams includes description`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            parameters = mutableListOf(
+                ApiParameter(name = "page", binding = ParameterBinding.Query, example = "1", description = "Page number")
+            )
+        )
+        val params = invokeBuildParams(meta)
+        assertEquals("Page number", params[0].description)
+    }
+
+    // ==================== buildHeaders ====================
+
+    private fun invokeBuildHeaders(meta: HttpMetadata): List<HoppKeyValue> {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "buildHeaders", HttpMetadata::class.java
+        )
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(formatter, meta) as List<HoppKeyValue>
+    }
+
+    @Test
+    fun `buildHeaders returns empty list for no headers`() {
+        val meta = HttpMetadata(path = "/api", method = HttpMethod.GET)
+        assertTrue(invokeBuildHeaders(meta).isEmpty())
+    }
+
+    @Test
+    fun `buildHeaders uses value when present`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            headers = mutableListOf(
+                ApiHeader(name = "Authorization", value = "Bearer token")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals(1, headers.size)
+        assertEquals("Authorization", headers[0].key)
+        assertEquals("Bearer token", headers[0].value)
+        assertTrue(headers[0].active)
+    }
+
+    @Test
+    fun `buildHeaders uses example when value is null`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            headers = mutableListOf(
+                ApiHeader(name = "Authorization", value = null, example = "Bearer example")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals("Bearer example", headers[0].value)
+    }
+
+    @Test
+    fun `buildHeaders uses empty string when neither value nor example`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            headers = mutableListOf(
+                ApiHeader(name = "X-Custom", value = null, example = null)
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals("", headers[0].value)
+    }
+
+    @Test
+    fun `buildHeaders includes description`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            headers = mutableListOf(
+                ApiHeader(name = "Authorization", value = "Bearer token", description = "Auth header")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals("Auth header", headers[0].description)
+    }
+
+    @Test
+    fun `buildHeaders handles multiple headers`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            headers = mutableListOf(
+                ApiHeader(name = "Content-Type", value = "application/json"),
+                ApiHeader(name = "Accept", value = "application/json"),
+                ApiHeader(name = "Authorization", value = "Bearer token")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals(3, headers.size)
+    }
+
+    // ==================== buildBody ====================
+
+    private fun invokeBuildBody(meta: HttpMetadata): HoppRequestBody {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "buildBody", HttpMetadata::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(formatter, meta) as HoppRequestBody
+    }
+
+    @Test
+    fun `buildBody returns JSON body when content type is json`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/json",
+            body = ObjectModel.Single("string")
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("application/json", body.contentType)
+        assertNotNull(body.body)
+        assertTrue(body.body is String)
+    }
+
+    @Test
+    fun `buildBody returns empty JSON object when content type is json but no body`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/json",
+            body = null
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("application/json", body.contentType)
+        assertEquals("{}", body.body)
+    }
+
+    @Test
+    fun `buildBody handles uppercase JSON content type`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "APPLICATION/JSON",
+            body = ObjectModel.Single("string")
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("application/json", body.contentType)
+        assertNotNull(body.body)
+    }
+
+    @Test
+    fun `buildBody returns form-urlencoded body`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/x-www-form-urlencoded",
+            parameters = mutableListOf(
+                ApiParameter(name = "username", binding = ParameterBinding.Form, example = "alice"),
+                ApiParameter(name = "password", binding = ParameterBinding.Form, example = "secret")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("application/x-www-form-urlencoded", body.contentType)
+        val bodyStr = body.body as String
+        assertTrue(bodyStr.contains("username=alice"))
+        assertTrue(bodyStr.contains("password=secret"))
+        assertTrue(bodyStr.contains("&"))
+    }
+
+    @Test
+    fun `buildBody form-urlencoded uses defaultValue when example is null`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/x-www-form-urlencoded",
+            parameters = mutableListOf(
+                ApiParameter(name = "name", binding = ParameterBinding.Form, defaultValue = "default-val")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        val bodyStr = body.body as String
+        assertTrue(bodyStr.contains("name=default-val"))
+    }
+
+    @Test
+    fun `buildBody form-urlencoded URL-encodes values`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/x-www-form-urlencoded",
+            parameters = mutableListOf(
+                ApiParameter(name = "query", binding = ParameterBinding.Form, example = "hello world&more")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        val bodyStr = body.body as String
+        // Space and & should be URL-encoded
+        assertTrue(bodyStr.contains("query=hello+world%26more"))
+    }
+
+    @Test
+    fun `buildBody returns multipart body for multipart content type`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "multipart/form-data",
+            parameters = mutableListOf(
+                ApiParameter(name = "file", binding = ParameterBinding.Form, example = "test.txt"),
+                ApiParameter(name = "name", binding = ParameterBinding.Form, example = "Alice")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("multipart/form-data", body.contentType)
+        assertNotNull(body.body)
+        @Suppress("UNCHECKED_CAST")
+        val entries = body.body as List<HoppFormDataEntry>
+        assertEquals(2, entries.size)
+        assertEquals("file", entries[0].key)
+        assertEquals("test.txt", entries[0].value)
+        assertTrue(entries[0].active)
+        assertFalse(entries[0].isFile)
+    }
+
+    @Test
+    fun `buildBody returns multipart body for form-data content type`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "application/form-data",
+            parameters = mutableListOf(
+                ApiParameter(name = "name", binding = ParameterBinding.Form, example = "Alice")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("multipart/form-data", body.contentType)
+        assertNotNull(body.body)
+    }
+
+    @Test
+    fun `buildBody multipart uses defaultValue when example is null`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "multipart/form-data",
+            parameters = mutableListOf(
+                ApiParameter(name = "name", binding = ParameterBinding.Form, defaultValue = "default-name")
+            )
+        )
+        val body = invokeBuildBody(meta)
+        @Suppress("UNCHECKED_CAST")
+        val entries = body.body as List<HoppFormDataEntry>
+        assertEquals("default-name", entries[0].value)
+    }
+
+    @Test
+    fun `buildBody multipart uses empty string when no example or defaultValue`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "multipart/form-data",
+            parameters = mutableListOf(
+                ApiParameter(name = "name", binding = ParameterBinding.Form)
+            )
+        )
+        val body = invokeBuildBody(meta)
+        @Suppress("UNCHECKED_CAST")
+        val entries = body.body as List<HoppFormDataEntry>
+        assertEquals("", entries[0].value)
+    }
+
+    @Test
+    fun `buildBody returns JSON body when no content type but body is present`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = null,
+            body = ObjectModel.Single("string")
+        )
+        val body = invokeBuildBody(meta)
+        assertEquals("application/json", body.contentType)
+        assertNotNull(body.body)
+    }
+
+    @Test
+    fun `buildBody returns empty body when no content type and no body`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            contentType = null,
+            body = null
+        )
+        val body = invokeBuildBody(meta)
+        assertNull(body.contentType)
+        assertNull(body.body)
+    }
+
+    @Test
+    fun `buildBody returns empty body for unknown content type without body`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.GET,
+            contentType = "text/plain",
+            body = null
+        )
+        val body = invokeBuildBody(meta)
+        assertNull(body.contentType)
+        assertNull(body.body)
+    }
+
+    @Test
+    fun `buildBody returns JSON body for unknown content type with body`() {
+        val meta = HttpMetadata(
+            path = "/api",
+            method = HttpMethod.POST,
+            contentType = "text/plain",
+            body = ObjectModel.Single("string")
+        )
+        val body = invokeBuildBody(meta)
+        // Falls through to the `if (meta.body != null)` branch
+        assertEquals("application/json", body.contentType)
+        assertNotNull(body.body)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterPureLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatterPureLogicTest.kt
@@ -1,0 +1,358 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
+import com.itangcent.easyapi.exporter.model.*
+import com.itangcent.easyapi.psi.model.ObjectModel
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Tests for HoppscotchFormatter pure logic methods and format() behavior.
+ *
+ * Uses reflection to test private methods (buildBody, buildParams, buildHeaders,
+ * buildEndpointUrl, convertToHoppscotchVarSyntax, formatTimestamp) and
+ * tests companion methods directly.
+ */
+class HoppscotchFormatterPureLogicTest {
+
+    // ==================== Companion method tests ====================
+
+    @Test
+    fun `parsePath splits simple path`() {
+        assertEquals(listOf("api", "users"), HoppscotchFormatter.parsePath("/api/users"))
+    }
+
+    @Test
+    fun `parsePath splits path with trailing slash`() {
+        assertEquals(listOf("api", "users"), HoppscotchFormatter.parsePath("/api/users/"))
+    }
+
+    @Test
+    fun `parsePath splits path without leading slash`() {
+        assertEquals(listOf("api", "users"), HoppscotchFormatter.parsePath("api/users"))
+    }
+
+    @Test
+    fun `parsePath splits empty path`() {
+        assertEquals(emptyList<String>(), HoppscotchFormatter.parsePath(""))
+    }
+
+    @Test
+    fun `parsePath splits root path`() {
+        assertEquals(emptyList<String>(), HoppscotchFormatter.parsePath("/"))
+    }
+
+    @Test
+    fun `parsePath splits deeply nested path`() {
+        assertEquals(listOf("api", "v1", "users", "{id}"), HoppscotchFormatter.parsePath("/api/v1/users/{id}"))
+    }
+
+    // ==================== formatTimestamp via reflection ====================
+
+    @Test
+    fun `formatTimestamp produces expected format`() {
+        // formatTimestamp is a private companion method
+        val companionClass = HoppscotchFormatter.Companion::class.java
+        val method = companionClass.getDeclaredMethod("formatTimestamp", Long::class.javaPrimitiveType ?: Long::class.java)
+        method.isAccessible = true
+        val result = method.invoke(HoppscotchFormatter, 1705312245000L) as String
+        assertTrue("Expected 14-digit timestamp but got: $result", result.matches(Regex("\\d{14}")))
+    }
+
+    @Test
+    fun `formatTimestamp for epoch zero`() {
+        val companionClass = HoppscotchFormatter.Companion::class.java
+        val method = companionClass.getDeclaredMethod("formatTimestamp", Long::class.javaPrimitiveType ?: Long::class.java)
+        method.isAccessible = true
+        val result = method.invoke(HoppscotchFormatter, 0L) as String
+        assertTrue("Expected 14-digit timestamp but got: $result", result.matches(Regex("\\d{14}")))
+    }
+
+    // ==================== convertToHoppscotchVarSyntax logic test ====================
+    // convertToHoppscotchVarSyntax is a private instance method requiring Project.
+    // We test the equivalent logic directly since it's simple string manipulation.
+
+    @Test
+    fun `convertToHoppscotchVarSyntax logic - replaces mustache with angle brackets`() {
+        val input = "https://{{host}}/api"
+        val result = input.trim().trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://<<host>>/api", result)
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax logic - trims whitespace`() {
+        val input = "  https://host/api  "
+        val result = input.trim().trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://host/api", result)
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax logic - removes backticks`() {
+        val input = "`https://host/api`"
+        val result = input.trim().trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://host/api", result)
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax logic - handles plain URL`() {
+        val input = "https://host/api"
+        val result = input.trim().trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://host/api", result)
+    }
+
+    @Test
+    fun `convertToHoppscotchVarSyntax logic - multiple variables`() {
+        val input = "https://{{host}}/{{resource}}/{{id}}"
+        val result = input.trim().trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://<<host>>/<<resource>>/<<id>>", result)
+    }
+
+    // ==================== buildEndpointUrl logic test ====================
+    // buildEndpointUrl is a private instance method requiring Project.
+    // We test the equivalent logic directly.
+
+    @Test
+    fun `buildEndpointUrl logic - combines host and path`() {
+        val host = "https://example.com"
+        val path = "/api/users"
+        val normalizedPath = path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        val result = (host.trimEnd('/') + normalizedPath).trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://example.com/api/users", result)
+    }
+
+    @Test
+    fun `buildEndpointUrl logic - adds leading slash if missing`() {
+        val host = "https://example.com"
+        val path = "api/users"
+        val normalizedPath = path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        val result = (host.trimEnd('/') + normalizedPath).trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://example.com/api/users", result)
+    }
+
+    @Test
+    fun `buildEndpointUrl logic - removes trailing slash from host`() {
+        val host = "https://example.com/"
+        val path = "/api/users"
+        val normalizedPath = path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        val result = (host.trimEnd('/') + normalizedPath).trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://example.com/api/users", result)
+    }
+
+    @Test
+    fun `buildEndpointUrl logic - replaces mustache with angle brackets`() {
+        val host = "https://{{host}}"
+        val path = "/api/{{resource}}"
+        val normalizedPath = path.trim().let { if (it.startsWith("/")) it else "/$it" }
+        val result = (host.trimEnd('/') + normalizedPath).trim('`').replace("{{", "<<").replace("}}", ">>")
+        assertEquals("https://<<host>>/api/<<resource>>", result)
+    }
+
+    // ==================== HoppscotchFormatOptions tests ====================
+
+    @Test
+    fun `HoppscotchFormatOptions default values`() {
+        val options = HoppscotchFormatOptions()
+        assertEquals("https://<<host>>", options.defaultHost)
+        assertTrue(options.appendTimestamp)
+    }
+
+    @Test
+    fun `HoppscotchFormatOptions custom values`() {
+        val options = HoppscotchFormatOptions(defaultHost = "https://api.example.com", appendTimestamp = false)
+        assertEquals("https://api.example.com", options.defaultHost)
+        assertFalse(options.appendTimestamp)
+    }
+
+    @Test
+    fun `HoppscotchFormatOptions copy`() {
+        val options = HoppscotchFormatOptions()
+        val copy = options.copy(appendTimestamp = false)
+        assertFalse(copy.appendTimestamp)
+        assertEquals(options.defaultHost, copy.defaultHost)
+    }
+
+    // ==================== HoppscotchExportMetadata tests ====================
+
+    @Test
+    fun `HoppscotchExportMetadata formatDisplay returns null for file export`() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "Test",
+            collectionData = HoppCollection(name = "Test")
+        )
+        assertNull(metadata.formatDisplay())
+    }
+
+    @Test
+    fun `HoppscotchExportMetadata formatDisplay returns workspace slash collection for cloud`() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "My Collection",
+            workspaceName = "My Workspace"
+        )
+        assertEquals("My Workspace/My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun `HoppscotchExportMetadata formatDisplay uses collectionId when collectionName is null`() {
+        val metadata = HoppscotchExportMetadata(
+            collectionId = "col-123",
+            workspaceName = "My Workspace"
+        )
+        assertEquals("My Workspace/col-123", metadata.formatDisplay())
+    }
+
+    @Test
+    fun `HoppscotchExportMetadata formatDisplay with null workspace`() {
+        val metadata = HoppscotchExportMetadata(
+            collectionName = "My Collection"
+        )
+        assertEquals("My Collection", metadata.formatDisplay())
+    }
+
+    @Test
+    fun `HoppscotchExportMetadata formatDisplay with all nulls except collectionData`() {
+        val metadata = HoppscotchExportMetadata(
+            collectionData = HoppCollection(name = "Test")
+        )
+        assertNull(metadata.formatDisplay())
+    }
+
+    // ==================== HoppscotchRuleKeys tests ====================
+
+    @Test
+    fun `HoppscotchRuleKeys maps to correct RuleKeys`() {
+        assertNotNull(HoppscotchRuleKeys.HOPP_PREREQUEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_CLASS_PREREQUEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_COLLECTION_PREREQUEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_TEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_CLASS_TEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_COLLECTION_TEST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_HOST)
+        assertNotNull(HoppscotchRuleKeys.HOPP_FORMAT_AFTER)
+    }
+
+    // ==================== HttpMethod fromSpring tests ====================
+
+    @Test
+    fun `HttpMethod fromSpring maps correctly`() {
+        assertEquals(HttpMethod.GET, HttpMethod.fromSpring("GET"))
+        assertEquals(HttpMethod.POST, HttpMethod.fromSpring("POST"))
+        assertEquals(HttpMethod.PUT, HttpMethod.fromSpring("PUT"))
+        assertEquals(HttpMethod.DELETE, HttpMethod.fromSpring("DELETE"))
+        assertEquals(HttpMethod.PATCH, HttpMethod.fromSpring("PATCH"))
+        assertEquals(HttpMethod.HEAD, HttpMethod.fromSpring("HEAD"))
+        assertEquals(HttpMethod.OPTIONS, HttpMethod.fromSpring("OPTIONS"))
+        assertNull(HttpMethod.fromSpring("UNKNOWN"))
+    }
+
+    @Test
+    fun `HttpMethod fromSpring is case insensitive`() {
+        assertEquals(HttpMethod.GET, HttpMethod.fromSpring("get"))
+        assertEquals(HttpMethod.POST, HttpMethod.fromSpring("post"))
+    }
+
+    // ==================== ParameterBinding tests ====================
+
+    @Test
+    fun `ParameterBinding instances are singletons`() {
+        assertSame(ParameterBinding.Query, ParameterBinding.Query)
+        assertSame(ParameterBinding.Path, ParameterBinding.Path)
+        assertSame(ParameterBinding.Header, ParameterBinding.Header)
+        assertSame(ParameterBinding.Cookie, ParameterBinding.Cookie)
+        assertSame(ParameterBinding.Body, ParameterBinding.Body)
+        assertSame(ParameterBinding.Form, ParameterBinding.Form)
+        assertSame(ParameterBinding.Ignored, ParameterBinding.Ignored)
+    }
+
+    // ==================== ApiParameter tests ====================
+
+    @Test
+    fun `ApiParameter default values`() {
+        val param = ApiParameter(name = "id")
+        assertEquals("id", param.name)
+        assertEquals(ParameterType.TEXT, param.type)
+        assertFalse(param.required)
+        assertNull(param.binding)
+        assertNull(param.defaultValue)
+        assertNull(param.description)
+        assertNull(param.example)
+        assertNull(param.enumValues)
+    }
+
+    @Test
+    fun `ApiParameter with all fields`() {
+        val param = ApiParameter(
+            name = "userId",
+            type = ParameterType.TEXT,
+            required = true,
+            binding = ParameterBinding.Query,
+            defaultValue = "1",
+            description = "User ID",
+            example = "42",
+            enumValues = listOf("1", "2", "3")
+        )
+        assertEquals("userId", param.name)
+        assertTrue(param.required)
+        assertEquals(ParameterBinding.Query, param.binding)
+        assertEquals("1", param.defaultValue)
+        assertEquals("42", param.example)
+        assertEquals(listOf("1", "2", "3"), param.enumValues)
+    }
+
+    // ==================== ApiHeader tests ====================
+
+    @Test
+    fun `ApiHeader default values`() {
+        val header = ApiHeader(name = "X-Custom")
+        assertEquals("X-Custom", header.name)
+        assertNull(header.value)
+        assertNull(header.description)
+        assertNull(header.example)
+        assertFalse(header.required)
+    }
+
+    @Test
+    fun `ApiHeader with all fields`() {
+        val header = ApiHeader(
+            name = "Authorization",
+            value = "Bearer token",
+            description = "Auth header",
+            example = "Bearer xyz",
+            required = true
+        )
+        assertEquals("Authorization", header.name)
+        assertEquals("Bearer token", header.value)
+        assertEquals("Auth header", header.description)
+        assertEquals("Bearer xyz", header.example)
+        assertTrue(header.required)
+    }
+
+    // ==================== HttpMetadata tests ====================
+
+    @Test
+    fun `HttpMetadata default values`() {
+        val meta = HttpMetadata(method = HttpMethod.GET, path = "/api")
+        assertEquals(HttpMethod.GET, meta.method)
+        assertEquals("/api", meta.path)
+        assertTrue(meta.parameters.isEmpty())
+        assertTrue(meta.headers.isEmpty())
+        assertNull(meta.contentType)
+        assertNull(meta.bodyAttr)
+        assertNull(meta.alternativePaths)
+        assertNull(meta.body)
+        assertNull(meta.responseBody)
+    }
+
+    @Test
+    fun `HttpMetadata with parameters and headers`() {
+        val meta = HttpMetadata(
+            method = HttpMethod.POST,
+            path = "/api/users",
+            contentType = "application/json",
+            body = ObjectModel.Single("string")
+        )
+        assertEquals(HttpMethod.POST, meta.method)
+        assertEquals("/api/users", meta.path)
+        assertEquals("application/json", meta.contentType)
+        assertNotNull(meta.body)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchMagicLinkLoginDialogTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchMagicLinkLoginDialogTest.kt
@@ -1,0 +1,206 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class HoppscotchMagicLinkLoginDialogTest {
+
+    // --- Email validation tests ---
+
+    @Test
+    fun `isValidEmail accepts standard email`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with subdomain`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user@mail.example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with plus sign`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("user+tag@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail accepts email with dots in local part`() {
+        assertTrue(HoppscotchMagicLinkLoginDialog.isValidEmail("first.last@example.com"))
+    }
+
+    @Test
+    fun `isValidEmail rejects empty string`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail(""))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without at sign`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("userexample.com"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without domain`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user@"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string without TLD`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user@example"))
+    }
+
+    @Test
+    fun `isValidEmail rejects string with spaces`() {
+        assertFalse(HoppscotchMagicLinkLoginDialog.isValidEmail("user @example.com"))
+    }
+
+    // --- Token extraction from URL tests ---
+
+    @Test
+    fun `extractTokenFromUrl extracts token from standard magic link URL`() {
+        val url = "https://hoppscotch.io/enter?token=abc123def456"
+        assertEquals("abc123def456", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl extracts token from self-hosted URL`() {
+        val url = "https://custom.example.com/enter?token=xyz789"
+        assertEquals("xyz789", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl extracts token from URL with multiple query params`() {
+        val url = "https://hoppscotch.io/enter?foo=bar&token=abc123&baz=qux"
+        assertEquals("abc123", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL without token param`() {
+        val url = "https://hoppscotch.io/enter?foo=bar"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL without query string`() {
+        val url = "https://hoppscotch.io/enter"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for empty string`() {
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(""))
+    }
+
+    @Test
+    fun `extractTokenFromUrl falls back to regex for partial URL strings`() {
+        // The regex should find token= even in a partial URL string
+        val url = "enter?token=abc123"
+        assertEquals("abc123", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for string without query marker`() {
+        // No ? or & before token=, so it shouldn't match
+        val url = "not a url but token=abc123 is here"
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl returns null for URL with empty token value`() {
+        val url = "https://hoppscotch.io/enter?token="
+        assertNull(HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    @Test
+    fun `extractTokenFromUrl handles token with special characters`() {
+        val url = "https://hoppscotch.io/enter?token=abc-123_xyz.ABC"
+        assertEquals("abc-123_xyz.ABC", HoppscotchMagicLinkLoginDialog.extractTokenFromUrl(url))
+    }
+
+    // --- Magic link API URL construction tests ---
+
+    @Test
+    fun `cloud instance constructs correct signin URL`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("https://api.hoppscotch.io/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    @Test
+    fun `cloud instance constructs correct verify URL`() {
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl("https://hoppscotch.io")
+        val verifyUrl = "$apiBaseUrl/auth/verify"
+        assertEquals("https://api.hoppscotch.io/v1/auth/verify", verifyUrl)
+    }
+
+    @Test
+    fun `self-hosted instance constructs correct signin URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(customUrl)
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("https://custom.hoppscotch.example/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    @Test
+    fun `self-hosted with backend URL constructs correct signin URL`() {
+        val customUrl = "https://custom.hoppscotch.example"
+        val backendUrl = "http://localhost:3170/v1"
+        val apiBaseUrl = HoppscotchApiClient.resolveApiV1BaseUrl(customUrl, backendUrl)
+        val signinUrl = "$apiBaseUrl/auth/signin?origin=app"
+        assertEquals("http://localhost:3170/v1/auth/signin?origin=app", signinUrl)
+    }
+
+    // --- MagicLinkSendResult tests ---
+
+    @Test
+    fun `MagicLinkSendResult success case`() {
+        val result = MagicLinkSendResult(success = true, deviceIdentifier = "abc123")
+        assertTrue(result.success)
+        assertEquals("abc123", result.deviceIdentifier)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkSendResult failure case`() {
+        val result = MagicLinkSendResult(success = false, errorMessage = "Network error")
+        assertFalse(result.success)
+        assertNull(result.deviceIdentifier)
+        assertEquals("Network error", result.errorMessage)
+    }
+
+    // --- MagicLinkVerifyResult tests ---
+
+    @Test
+    fun `MagicLinkVerifyResult success case`() {
+        val result = MagicLinkVerifyResult(
+            success = true,
+            accessToken = "access123",
+            refreshToken = "refresh456"
+        )
+        assertTrue(result.success)
+        assertEquals("access123", result.accessToken)
+        assertEquals("refresh456", result.refreshToken)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun `MagicLinkVerifyResult failure with expired link`() {
+        val result = MagicLinkVerifyResult(
+            success = false,
+            errorMessage = "This magic link has expired. Please request a new one."
+        )
+        assertFalse(result.success)
+        assertNull(result.accessToken)
+        assertNull(result.refreshToken)
+        assertEquals("This magic link has expired. Please request a new one.", result.errorMessage)
+    }
+
+    // --- HoppscotchLoginMethodDialog.Method tests ---
+
+    @Test
+    fun `Method enum has all three values`() {
+        val methods = HoppscotchLoginMethodDialog.Method.values()
+        assertEquals(3, methods.size)
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.MAGIC_LINK))
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.BROWSER))
+        assertTrue(methods.contains(HoppscotchLoginMethodDialog.Method.MANUAL_TOKEN))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettingsPanelCoverageTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchSettingsPanelCoverageTest.kt
@@ -1,0 +1,297 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.settings.SettingBinder
+import com.itangcent.easyapi.settings.state.UnifiedAppSettingsState
+import com.itangcent.easyapi.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import javax.swing.JButton
+import javax.swing.JLabel
+import javax.swing.JPasswordField
+import javax.swing.JTextField
+
+/**
+ * Coverage-focused tests for [HoppscotchSettingsPanel].
+ *
+ * Fills gaps left by [com.itangcent.easyapi.settings.ui.HoppscotchSettingsPanelPlatformTest]:
+ * - `applyTo` manual token branch (set when null, skip when already set, skip when blank)
+ * - `applyTo` blank serverUrl/backendUrl → null conversion
+ * - `isModified` for serverUrl, backendUrl, and manualToken fields
+ * - `updateTokenStatus` "Logged in" / "Not logged in" branches (tokenStatusLabel + logoutButton)
+ * - `resetFrom` with null serverUrl/backendUrl → default fallback
+ * - Round-trip with all custom fields
+ * - Multiple resetFrom calls
+ *
+ * Uses the IntelliJ Platform test framework ([EasyApiLightCodeInsightFixtureTestCase])
+ * because [HoppscotchSettingsPanel] requires a [com.intellij.openapi.project.Project].
+ */
+class HoppscotchSettingsPanelCoverageTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var panel: HoppscotchSettingsPanel
+
+    private val moduleKey = "com.itangcent.easyapi.exporter.channel.hoppscotch.HoppscotchSettings"
+
+    override fun setUp() {
+        super.setUp()
+        panel = HoppscotchSettingsPanel(project)
+        // Reset Hoppscotch settings to defaults so tests are independent.
+        setSettings {
+            hoppscotchToken = null
+            hoppscotchServerUrl = "https://hoppscotch.io"
+            hoppscotchBackendUrl = null
+        }
+    }
+
+    // ---- Helpers ----
+
+    private fun setSettings(updater: HoppscotchSettings.() -> Unit) {
+        SettingBinder.getInstance(project).update(HoppscotchSettings::class, updater)
+    }
+
+    private fun getHoppscotchField(property: String): String? {
+        return UnifiedAppSettingsState.getInstance().getValue(moduleKey, property)
+    }
+
+    private fun serverUrlField(): JTextField = getPrivateField("serverUrlField")
+    private fun backendUrlField(): JTextField = getPrivateField("backendUrlField")
+    private fun manualTokenField(): JPasswordField = getPrivateField("manualTokenField")
+    private fun tokenStatusLabel(): JLabel = getPrivateField("tokenStatusLabel")
+    private fun logoutButton(): JButton = getPrivateField("logoutButton")
+
+    private fun <T> getPrivateField(name: String): T {
+        val field = HoppscotchSettingsPanel::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(panel) as T
+    }
+
+    // ---- applyTo: manual token branch (lines 142-144) ----
+
+    fun testApplyTo_manualToken_setsWhenSettingsTokenIsNull() {
+        // Settings token is null (from setUp)
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = "my-manual-token"
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertEquals("my-manual-token", getHoppscotchField("hoppscotchToken"))
+    }
+
+    fun testApplyTo_manualToken_doesNotOverrideExistingToken() {
+        setSettings { hoppscotchToken = "existing-token" }
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = "manual-token-attempt"
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertEquals("existing-token", getHoppscotchField("hoppscotchToken"))
+    }
+
+    fun testApplyTo_blankManualToken_doesNotSet() {
+        // Settings token is null (from setUp)
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = "   " // blank
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertNull(getHoppscotchField("hoppscotchToken"))
+    }
+
+    // ---- applyTo: blank URL → null conversion ----
+
+    fun testApplyTo_blankServerUrl_setsNull() {
+        setSettings { hoppscotchServerUrl = "https://custom.example.com" }
+        panel.resetFrom(HoppscotchSettings())
+        serverUrlField().text = ""
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertNull(getHoppscotchField("hoppscotchServerUrl"))
+    }
+
+    fun testApplyTo_blankBackendUrl_setsNull() {
+        setSettings { hoppscotchBackendUrl = "http://localhost:3170/v1" }
+        panel.resetFrom(HoppscotchSettings())
+        backendUrlField().text = ""
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertNull(getHoppscotchField("hoppscotchBackendUrl"))
+    }
+
+    // ---- isModified: serverUrl / backendUrl changes ----
+
+    fun testIsModified_serverUrlChanged_returnsTrue() {
+        setSettings { hoppscotchServerUrl = "https://original.example.com" }
+        panel.resetFrom(HoppscotchSettings())
+
+        // Change the UI field
+        serverUrlField().text = "https://changed.example.com"
+
+        assertTrue(panel.isModified(HoppscotchSettings()))
+    }
+
+    fun testIsModified_backendUrlChanged_returnsTrue() {
+        setSettings { hoppscotchBackendUrl = "http://original:3170/v1" }
+        panel.resetFrom(HoppscotchSettings())
+
+        backendUrlField().text = "http://changed:8080/v1"
+
+        assertTrue(panel.isModified(HoppscotchSettings()))
+    }
+
+    // ---- isModified: manual token branch (line 152) ----
+
+    fun testIsModified_manualTokenEnteredAndSettingsTokenBlank_returnsTrue() {
+        // Settings token is null (from setUp)
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = "new-manual-token"
+
+        assertTrue(panel.isModified(HoppscotchSettings()))
+    }
+
+    fun testIsModified_manualTokenEnteredAndSettingsTokenSet_returnsFalse() {
+        setSettings { hoppscotchToken = "existing-token" }
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = "different-token"
+
+        assertFalse(panel.isModified(HoppscotchSettings()))
+    }
+
+    fun testIsModified_blankManualTokenAndSettingsTokenNull_returnsFalse() {
+        // Settings token is null (from setUp)
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = ""
+
+        assertFalse(panel.isModified(HoppscotchSettings()))
+    }
+
+    // ---- updateTokenStatus: "Logged in" branch (lines 104-108) ----
+
+    fun testResetFrom_withToken_showsLoggedInStatus() {
+        setSettings { hoppscotchToken = "abcd1234efgh5678" }
+        panel.resetFrom(HoppscotchSettings())
+
+        val statusText = tokenStatusLabel().text
+        assertTrue("Status should indicate logged in, was: $statusText", statusText.startsWith("Logged in"))
+        assertTrue("Logout button should be enabled when token is set", logoutButton().isEnabled)
+    }
+
+    fun testResetFrom_withNullToken_showsNotLoggedInStatus() {
+        // Settings token is null (from setUp)
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("Not logged in", tokenStatusLabel().text)
+        assertFalse("Logout button should be disabled when token is null", logoutButton().isEnabled)
+    }
+
+    fun testResetFrom_withBlankToken_showsNotLoggedInStatus() {
+        setSettings { hoppscotchToken = "   " }
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("Not logged in", tokenStatusLabel().text)
+        assertFalse(logoutButton().isEnabled)
+    }
+
+    fun testResetWithToken_statusContainsTokenPrefix() {
+        setSettings { hoppscotchToken = "tokenXYZ12345678" }
+        panel.resetFrom(HoppscotchSettings())
+
+        // The status label should show the first 8 chars of the token
+        val statusText = tokenStatusLabel().text
+        assertTrue("Status should contain token prefix, was: $statusText", statusText.contains("tokenXYZ"))
+    }
+
+    // ---- resetFrom: null serverUrl/backendUrl → default fallback (lines 131-133) ----
+
+    fun testResetFrom_nullServerUrl_usesDefault() {
+        setSettings { hoppscotchServerUrl = null }
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("https://hoppscotch.io", serverUrlField().text)
+    }
+
+    fun testResetFrom_nullBackendUrl_usesEmptyString() {
+        setSettings { hoppscotchBackendUrl = null }
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("", backendUrlField().text)
+    }
+
+    fun testResetFrom_nullToken_usesEmptyString() {
+        setSettings { hoppscotchToken = null }
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("", manualTokenField().text)
+    }
+
+    // ---- Round-trip with all custom fields ----
+
+    fun testRoundTrip_allCustomFields() {
+        setSettings {
+            hoppscotchServerUrl = "https://custom.example.com"
+            hoppscotchBackendUrl = "http://localhost:3170/v1"
+            hoppscotchToken = "round-trip-token"
+        }
+        panel.resetFrom(HoppscotchSettings())
+        assertFalse("Panel should not be modified after reset", panel.isModified(HoppscotchSettings()))
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertEquals("https://custom.example.com", getHoppscotchField("hoppscotchServerUrl"))
+        assertEquals("http://localhost:3170/v1", getHoppscotchField("hoppscotchBackendUrl"))
+        assertEquals("round-trip-token", getHoppscotchField("hoppscotchToken"))
+    }
+
+    // ---- Multiple resetFrom calls ----
+
+    fun testMultipleResetFrom_lastOneWins() {
+        setSettings {
+            hoppscotchServerUrl = "https://first.example.com"
+            hoppscotchBackendUrl = "http://first:3170/v1"
+        }
+        panel.resetFrom(HoppscotchSettings())
+
+        setSettings {
+            hoppscotchServerUrl = "https://second.example.com"
+            hoppscotchBackendUrl = "http://second:8080/v1"
+        }
+        panel.resetFrom(HoppscotchSettings())
+
+        assertEquals("https://second.example.com", serverUrlField().text)
+        assertEquals("http://second:8080/v1", backendUrlField().text)
+        assertFalse(panel.isModified(HoppscotchSettings()))
+    }
+
+    // ---- applyTo then isModified consistency ----
+
+    fun testApplyTo_thenIsModified_false() {
+        setSettings {
+            hoppscotchServerUrl = "https://pre-apply.example.com"
+            hoppscotchBackendUrl = "http://pre:3170/v1"
+        }
+        panel.resetFrom(HoppscotchSettings())
+
+        // Change UI fields
+        serverUrlField().text = "https://post-apply.example.com"
+        backendUrlField().text = "http://post:8080/v1"
+        assertTrue(panel.isModified(HoppscotchSettings()))
+
+        // Apply changes
+        panel.applyTo(HoppscotchSettings())
+
+        // After applyTo, settings should match UI → not modified
+        assertFalse(panel.isModified(HoppscotchSettings()))
+    }
+
+    // ---- applyTo does not clear existing token when manual token is blank ----
+
+    fun testApplyTo_blankManualToken_doesNotClearExistingToken() {
+        setSettings { hoppscotchToken = "preserve-me" }
+        panel.resetFrom(HoppscotchSettings())
+        manualTokenField().text = ""
+
+        panel.applyTo(HoppscotchSettings())
+
+        assertEquals("preserve-me", getHoppscotchField("hoppscotchToken"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/model/HoppscotchModelsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/model/HoppscotchModelsTest.kt
@@ -1,0 +1,365 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch.model
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Comprehensive tests for Hoppscotch model data classes and utility functions.
+ */
+class HoppscotchModelsTest {
+
+    // ==================== HoppCollection tests ====================
+
+    @Test
+    fun `HoppCollection default values`() {
+        val collection = HoppCollection(name = "Test")
+        assertEquals(12, collection.v)
+        assertEquals("Test", collection.name)
+        assertTrue(collection._ref_id.startsWith("coll_"))
+        assertTrue(collection.folders.isEmpty())
+        assertTrue(collection.requests.isEmpty())
+        assertEquals(HoppAuth(), collection.auth)
+        assertTrue(collection.headers.isEmpty())
+        assertTrue(collection.variables.isEmpty())
+        assertNull(collection.description)
+        assertEquals("", collection.preRequestScript)
+        assertEquals("", collection.testScript)
+    }
+
+    @Test
+    fun `HoppCollection with all fields`() {
+        val collection = HoppCollection(
+            name = "Full Collection",
+            folders = listOf(HoppCollection(name = "Sub")),
+            requests = listOf(HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api")),
+            auth = HoppAuth(authType = "bearer"),
+            headers = listOf(HoppKeyValue(key = "Auth", value = "token")),
+            variables = listOf(HoppCollectionVariable(key = "host", initialValue = "https://api.example.com")),
+            description = "Test description",
+            preRequestScript = "console.log('pre')",
+            testScript = "console.log('test')"
+        )
+        assertEquals(1, collection.folders.size)
+        assertEquals(1, collection.requests.size)
+        assertEquals("bearer", collection.auth.authType)
+        assertEquals("Test description", collection.description)
+    }
+
+    @Test
+    fun `HoppCollection copy`() {
+        val original = HoppCollection(name = "Original")
+        val copy = original.copy(name = "Copied")
+        assertEquals("Copied", copy.name)
+        assertEquals(original.v, copy.v)
+    }
+
+    @Test
+    fun `HoppCollection equals and hashCode`() {
+        val c1 = HoppCollection(name = "Test", v = 12)
+        val c2 = HoppCollection(name = "Test", v = 12)
+        // They won't be equal because _ref_id is different
+        // But if we set the same _ref_id they should be equal
+        val c3 = c1.copy()
+        assertEquals(c1, c3)
+    }
+
+    // ==================== HoppRESTRequest tests ====================
+
+    @Test
+    fun `HoppRESTRequest default values`() {
+        val request = HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api")
+        assertEquals("17", request.v)
+        assertEquals("GET /api", request.name)
+        assertEquals("GET", request.method)
+        assertEquals("/api", request.endpoint)
+        assertTrue(request._ref_id.startsWith("req_"))
+        assertTrue(request.params.isEmpty())
+        assertTrue(request.headers.isEmpty())
+        assertEquals(HoppAuth(), request.auth)
+        assertEquals(HoppRequestBody(), request.body)
+        assertEquals("", request.preRequestScript)
+        assertEquals("", request.testScript)
+        assertTrue(request.requestVariables.isEmpty())
+        assertTrue(request.responses.isEmpty())
+        assertNull(request.description)
+    }
+
+    @Test
+    fun `HoppRESTRequest with all fields`() {
+        val request = HoppRESTRequest(
+            name = "POST /api/users",
+            method = "POST",
+            endpoint = "https://api.example.com/api/users",
+            params = listOf(HoppKeyValue(key = "page", value = "1")),
+            headers = listOf(HoppKeyValue(key = "Content-Type", value = "application/json")),
+            body = HoppRequestBody(contentType = "application/json", body = "{}"),
+            preRequestScript = "pm.request.headers.add('X-Custom')",
+            testScript = "pm.response.to.have.status(200)",
+            description = "Create a new user"
+        )
+        assertEquals(1, request.params.size)
+        assertEquals(1, request.headers.size)
+        assertEquals("application/json", request.body.contentType)
+        assertEquals("Create a new user", request.description)
+    }
+
+    // ==================== HoppKeyValue tests ====================
+
+    @Test
+    fun `HoppKeyValue default values`() {
+        val kv = HoppKeyValue(key = "name")
+        assertEquals("name", kv.key)
+        assertEquals("", kv.value)
+        assertTrue(kv.active)
+        assertNull(kv.description)
+    }
+
+    @Test
+    fun `HoppKeyValue with all fields`() {
+        val kv = HoppKeyValue(key = "Authorization", value = "Bearer token", active = false, description = "Auth header")
+        assertEquals("Authorization", kv.key)
+        assertEquals("Bearer token", kv.value)
+        assertFalse(kv.active)
+        assertEquals("Auth header", kv.description)
+    }
+
+    @Test
+    fun `HoppKeyValue equals and hashCode`() {
+        val kv1 = HoppKeyValue(key = "name", value = "value")
+        val kv2 = HoppKeyValue(key = "name", value = "value")
+        assertEquals(kv1, kv2)
+        assertEquals(kv1.hashCode(), kv2.hashCode())
+    }
+
+    // ==================== HoppAuth tests ====================
+
+    @Test
+    fun `HoppAuth default values`() {
+        val auth = HoppAuth()
+        assertEquals("inherit", auth.authType)
+        assertTrue(auth.authActive)
+    }
+
+    @Test
+    fun `HoppAuth custom values`() {
+        val auth = HoppAuth(authType = "bearer", authActive = false)
+        assertEquals("bearer", auth.authType)
+        assertFalse(auth.authActive)
+    }
+
+    @Test
+    fun `HoppAuth equals and hashCode`() {
+        val a1 = HoppAuth()
+        val a2 = HoppAuth()
+        assertEquals(a1, a2)
+        assertEquals(a1.hashCode(), a2.hashCode())
+    }
+
+    // ==================== HoppRequestBody tests ====================
+
+    @Test
+    fun `HoppRequestBody default values`() {
+        val body = HoppRequestBody()
+        assertNull(body.contentType)
+        assertNull(body.body)
+    }
+
+    @Test
+    fun `HoppRequestBody with JSON body`() {
+        val body = HoppRequestBody(contentType = "application/json", body = """{"name":"John"}""")
+        assertEquals("application/json", body.contentType)
+        assertEquals("""{"name":"John"}""", body.body)
+    }
+
+    @Test
+    fun `HoppRequestBody with form data body`() {
+        val formData = listOf(HoppFormDataEntry(key = "file", value = "test.txt", isFile = true))
+        val body = HoppRequestBody(contentType = "multipart/form-data", body = formData)
+        assertEquals("multipart/form-data", body.contentType)
+        assertNotNull(body.body)
+    }
+
+    // ==================== HoppCollectionVariable tests ====================
+
+    @Test
+    fun `HoppCollectionVariable default values`() {
+        val variable = HoppCollectionVariable(key = "host")
+        assertEquals("host", variable.key)
+        assertEquals("", variable.initialValue)
+        assertEquals("", variable.currentValue)
+        assertFalse(variable.secret)
+    }
+
+    @Test
+    fun `HoppCollectionVariable with all fields`() {
+        val variable = HoppCollectionVariable(
+            key = "apiKey",
+            initialValue = "default-key",
+            currentValue = "actual-key",
+            secret = true
+        )
+        assertEquals("apiKey", variable.key)
+        assertEquals("default-key", variable.initialValue)
+        assertEquals("actual-key", variable.currentValue)
+        assertTrue(variable.secret)
+    }
+
+    // ==================== HoppRequestVariable tests ====================
+
+    @Test
+    fun `HoppRequestVariable default values`() {
+        val variable = HoppRequestVariable(key = "id")
+        assertEquals("id", variable.key)
+        assertEquals("", variable.value)
+        assertTrue(variable.active)
+    }
+
+    @Test
+    fun `HoppRequestVariable with all fields`() {
+        val variable = HoppRequestVariable(key = "id", value = "123", active = false)
+        assertEquals("id", variable.key)
+        assertEquals("123", variable.value)
+        assertFalse(variable.active)
+    }
+
+    // ==================== HoppFormDataEntry tests ====================
+
+    @Test
+    fun `HoppFormDataEntry default values`() {
+        val entry = HoppFormDataEntry(key = "name")
+        assertEquals("name", entry.key)
+        assertEquals("", entry.value)
+        assertTrue(entry.active)
+        assertFalse(entry.isFile)
+        assertNull(entry.contentType)
+    }
+
+    @Test
+    fun `HoppFormDataEntry with all fields`() {
+        val entry = HoppFormDataEntry(
+            key = "avatar",
+            value = "photo.jpg",
+            active = false,
+            isFile = true,
+            contentType = "image/jpeg"
+        )
+        assertEquals("avatar", entry.key)
+        assertEquals("photo.jpg", entry.value)
+        assertFalse(entry.active)
+        assertTrue(entry.isFile)
+        assertEquals("image/jpeg", entry.contentType)
+    }
+
+    // ==================== hoppscotchGson tests ====================
+
+    @Test
+    fun `hoppscotchGson with pretty print`() {
+        val gson = hoppscotchGson(prettyPrint = true)
+        val json = gson.toJson(HoppAuth(authType = "bearer"))
+        // Pretty print should include newlines
+        assertTrue(json.contains("\n"))
+        assertTrue(json.contains("bearer"))
+    }
+
+    @Test
+    fun `hoppscotchGson without pretty print`() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val json = gson.toJson(HoppAuth(authType = "bearer"))
+        // No pretty print, should be single line
+        assertFalse(json.contains("\n"))
+        assertTrue(json.contains("bearer"))
+    }
+
+    @Test
+    fun `hoppscotchGson serializes nulls`() {
+        val gson = hoppscotchGson()
+        val body = HoppRequestBody(contentType = null, body = null)
+        val json = gson.toJson(body)
+        // serializeNulls() should include null fields
+        assertTrue(json.contains("contentType"))
+        assertTrue(json.contains("body"))
+    }
+
+    @Test
+    fun `hoppscotchGson serializes collection correctly`() {
+        val gson = hoppscotchGson()
+        val collection = HoppCollection(
+            name = "Test",
+            requests = listOf(
+                HoppRESTRequest(name = "GET /api", method = "GET", endpoint = "/api")
+            )
+        )
+        val json = gson.toJson(collection)
+        assertTrue(json.contains("Test"))
+        assertTrue(json.contains("GET /api"))
+        assertTrue(json.contains("12"))  // v=12
+    }
+
+    @Test
+    fun `hoppscotchGson serializes and deserializes HoppAuth`() {
+        val gson = hoppscotchGson(prettyPrint = false)
+        val auth = HoppAuth(authType = "basic", authActive = false)
+        val json = gson.toJson(auth)
+        val deserialized = gson.fromJson(json, HoppAuth::class.java)
+        assertEquals(auth, deserialized)
+    }
+
+    // ==================== generateUniqueRefId tests ====================
+
+    @Test
+    fun `generateUniqueRefId with prefix`() {
+        val id = generateUniqueRefId("coll")
+        assertTrue(id.startsWith("coll_"))
+        assertTrue(id.length > 10) // Should contain timestamp + UUID
+    }
+
+    @Test
+    fun `generateUniqueRefId without prefix`() {
+        val id = generateUniqueRefId("")
+        assertFalse(id.startsWith("_"))
+        assertTrue(id.length > 10)
+    }
+
+    @Test
+    fun `generateUniqueRefId generates unique values`() {
+        val id1 = generateUniqueRefId("req")
+        val id2 = generateUniqueRefId("req")
+        assertNotEquals(id1, id2)
+    }
+
+    @Test
+    fun `generateUniqueRefId default prefix`() {
+        val id = generateUniqueRefId()
+        // Default prefix is empty
+        assertFalse(id.startsWith("_"))
+    }
+
+    // ==================== HoppRequestBody with various body types ====================
+
+    @Test
+    fun `HoppRequestBody with urlencoded body as string`() {
+        val body = HoppRequestBody(
+            contentType = "application/x-www-form-urlencoded",
+            body = "name=John&age=30"
+        )
+        assertEquals("application/x-www-form-urlencoded", body.contentType)
+        assertEquals("name=John&age=30", body.body)
+    }
+
+    @Test
+    fun `HoppRequestBody with form data list`() {
+        val formData = listOf(
+            HoppFormDataEntry(key = "name", value = "John"),
+            HoppFormDataEntry(key = "file", value = "doc.pdf", isFile = true)
+        )
+        val body = HoppRequestBody(contentType = "multipart/form-data", body = formData)
+        assertEquals("multipart/form-data", body.contentType)
+        @Suppress("UNCHECKED_CAST")
+        val entries = body.body as List<HoppFormDataEntry>
+        assertEquals(2, entries.size)
+        assertEquals("name", entries[0].key)
+        assertTrue(entries[1].isFile)
+    }
+}


### PR DESCRIPTION
## Summary

Ports the **Hoppscotch export channel** from easy-api (tangcent/easy-api#715) to easy-yapi. The channel brick is self-contained under `exporter/channel/hoppscotch/` and depends only on shared code (`HttpClientProvider`, `SettingBinder`, `ChannelRegistry` EP) that is already byte-identical in both repos after the recent cross-repo sync.

Close #1343

## What's included

- **GraphQL API client** with caching (`HoppscotchApiClient`, `CachedHoppscotchApiClient`)
- **Multi-method authentication** (magic link, browser, manual token)
- **Hoppscotch collection formatter** (schema v12/v17)
- **Rule engine integration** (`HoppscotchRuleKeys` — `hopp.*` keys)
- **Settings panel**
- **17 test files** (all passing)

## Shared-file changes (IV-A / IV-C)

| File | Change | Bucket |
|------|--------|--------|
| `plugin.xml` | Register `HoppscotchChannel` on the `channel` EP | IV-A (EP namespace) |
| `README.md` | Add Hoppscotch (Beta) to channel table, usage step, architecture (YApi branding preserved) | IV-C (content) |
| `docs/knowledge-base/rule-guide.md` + mirror copies | Add `### Hoppscotch rules` section (`hopp.*` keys) after YApi rules | IV-C (content) |

The brick files (15 main + 17 test) are **byte-identical copies** of easy-api's `hoppscotch/` brick. The exclude list (`verify-channel-platform-exclude.txt`) already covers `hoppscotch` as IV-B, so V3 sync-health stays green.

## Verification

- [x] `./gradlew compileKotlin compileTestKotlin --rerun-tasks` → **PASS** (33s)
- [x] `./gradlew test --tests "*.channel.hoppscotch.*"` → **PASS** (all hoppscotch tests green)
- [x] `./scripts/verify-channel-platform.sh v3` → **PASS** (all shared files byte-identical)
- [x] IV-C content propagated to README + rule-guide (+ mirror copies in `skills/` and `src/main/resources/docs/`)
- [x] YApi branding preserved (no Hoppscotch-only branding leaked into easy-api; YApi section retained)