### PR TITLE
feat(ai): namespace per-app env vars across exporters and agent

### DIFF
--- a/docs/knowledge-base/rule-guide.md
+++ b/docs/knowledge-base/rule-guide.md
@@ -488,6 +488,206 @@ the same catalog when scanning your project.
 
 ---
 
+## Multi-Application Namespace
+
+> **Per-app namespacing for workspaces that host more than one service.** Real
+> workspaces frequently contain several applications / modules — an
+> `order-service` + a `payment-service` + an `admin-portal` — each with its own
+> authorization filter, login endpoint, and host. Without namespacing, two apps
+> in one workspace both write `Authorization` and the second export silently
+> overwrites the first app's token in the Postman environment; every endpoint
+> points at `{{host}}` so all apps share one host; and app A's login captures
+> into `username` / `password` collide with app B's. Namespacing disambiguates
+> every per-app env var by the application identity, baked as a literal into the
+> rule at **authoring time** (the agent has PSI + file access; the runtime does
+> not).
+
+> **Bundle integrity still holds.** A workflow bundle is a producer script +
+> consumer header (+ env var) proposed together (see [Workflow Patterns](#workflow-patterns)).
+> Namespacing does not relax this: within one bundle the producer's stored
+> env-var name and the consumer's referenced env-var name MUST be identical,
+> and both MUST carry the same namespace key. Either half alone is still broken.
+
+### Namespace-key resolution order
+
+The agent resolves the namespace key for a target app in this order, and records
+which branch it used so the user can correct a wrong guess before saving:
+
+1. **IntelliJ Module name** of the target endpoints' source classes, via
+   `ModuleHelper.resolveModuleName(psiElement)` (always available, no framework
+   dependency). The raw module name is normalized through the canonical
+   `NamespaceKeyNormalizer` (see the naming-convention table below) so
+   `OrderService` → `order-service`, `order_service` → `order-service`,
+   `admin portal` → `admin-portal`. The normalized key uses only the
+   character class `[a-z0-9-]` (lower-case ASCII letters, digits, hyphens);
+   every other character is stripped or replaced. This is the same value `runtime.module()`
+   returns at export time, so the agent's literal key and the runtime module
+   name agree whenever this branch is taken.
+
+2. **`spring.application.name`** read at **authoring time** via `read_rule_file`
+   (the ONLY file-reading tool the agent has). Call it with the app's
+   `application.yml` / `application-*.yml` / `application.properties` path —
+   this triggers a one-time `FileReadConsentGate` consent prompt the user must
+   approve. Use this branch only when the module name is absent, empty, or a
+   generic placeholder (`<unnamed>`, the project name, etc.). If the user denies
+   consent or the file is absent, fall back to branch (3).
+   **Do NOT attempt `get_psi_class_info` for this purpose** — it is
+   class-signature only (name, modifiers, annotations, field/method signatures)
+   and cannot read `application.yml` or any non-class file.
+
+3. **`ask_clarification`** (`single_choice`) when both branches above are
+   ambiguous, or when two target apps would resolve to the same key (collision).
+   Offer concrete disambiguation options (the original names + the normalized
+   candidates) before writing any rule — never let the second app silently
+   overwrite the first.
+
+> **Authoring-time vs runtime split is hard.** The namespace key is resolved by
+> the agent (PSI + file access) and baked as a literal into the rule value. The
+> runtime host rule uses `runtime.module()` (the runtime mirror of branch 1); it
+> cannot read `spring.application.name` — `ConfigReader` / `config.get(...)`
+> sees only `.easy.api.config*` plugin rule files, never the project's
+> `application.yml`. If the app name is needed at runtime, it must be a literal
+> the agent baked in at authoring time.
+
+### Per-app env-var naming convention
+
+Every per-app env var in a workflow/host bundle is namespaced by the resolved
+key. The canonical transform is `NamespaceKeyNormalizer.normalize(input)` — the
+same pure utility the agent invokes — so users can predict the result:
+
+| Slot | Placeholder | Notes |
+|------|-------------|-------|
+| Host | `{{<key>}}` | Proposed as `postman.host={{<key>}}` / `hopp.host={{<key>}}`. The Hoppscotch formatter rewrites unresolved `${...}` in header values to `<<key>>` at export time. |
+| Bearer token | `{{<key>-token}}` | Lower-case `-token` suffix by default (matches the lowercase workflow-recipe convention). Allow `-TOKEN` (UPPER) when an existing rule already uses it — reuse the existing casing via `get_existing_rules_for_key` rather than renaming. |
+| Login username | `{{<key>-username}}` | Same casing rule as the token. |
+| Login password | `{{<key>-password}}` | Same casing rule as the token. |
+
+In rule values the namespaced var is written as `${<key>-token}` (e.g.
+`Bearer ${order-service-token}`); the Postman/Hoppscotch formatters convert
+**unresolved** `${...}` in header values to the platform syntax
+(`{{order-service-token}}` / `<<order-service-token>>`) at export time.
+**Resolved** `${...}` (config-backed) and regex-capture `${1}` are left
+untouched.
+
+### Multi-app bundle-split rule
+
+When the ambient `modules:` hint shows more than one API-bearing module (N > 1),
+call `get_module_dependency_graph` and cluster the API-bearing modules into
+connected components (layered modules like `admin-api` + `admin-impl` collapse
+to one app; disjoint apps stay separate). Each connected component is one app
+group. When `list_project_endpoints` / the ambient `moduleNames` set reveals
+more than one app group, propose **one namespaced bundle per app** — one
+`propose_rule_content` call per bundle. Each bundle must still be complete on
+its own (producer script + consumer header + host + env var, all carrying the
+same namespace key) per the bundle-integrity rule above.
+
+For consumers the agent cannot confidently assign to an app group (shared /
+common modules consumed by several apps — e.g. a `common` or `dto` module both
+apps depend on), call `ask_clarification` (`single_choice`, concrete app
+options) rather than guess.
+
+Before proposing any bundle, call `get_existing_rules_for_key` for each key in
+the bundle and skip rules already present in any source (project / global /
+extension / remote) scoped to the same namespace key — the same
+anti-duplication rule from [Workflow Patterns](#workflow-patterns) applies
+per-app.
+
+### Known limitation — body-level namespacing
+
+The v1 runtime enabler converts unresolved `${...}` placeholders **only in
+header values** (the `method.additional.header` value surface, where
+`Authorization: Bearer ${<key>-token}` lives). Conversion of `${...}` in
+`method.additional.param` values and the request body is **deferred** — the
+request body has JSON-structure / JSON5-mode / `ObjectModel` serialization
+concerns that make symmetric conversion riskier and out of scope for v1.
+
+**Do NOT promise body-level namespacing** in your proposals. If a namespaced
+token is needed in a body, propose it as `${<key>-token}` and note that the user
+must wire the env var in the Environments panel until param/body conversion
+ships.
+
+### Resolution-branch recording
+
+The agent's proposal summary MUST state which resolution branch was used
+(module name / `spring.application.name` / user-clarified via
+`ask_clarification`) and the resulting namespace key, so the user can correct a
+wrong guess before saving. For example:
+
+> *Namespacing* — `order-service` resolved from **module name** (branch 1);
+> `payment-service` resolved from **spring.application.name** (branch 2, read
+> via `read_rule_file` from `application.yml`); the admin portal was
+> **user-clarified** (branch 3) after colliding with `payment-service` on the
+> normalized `admin` candidate.
+
+### Single-app still namespaced
+
+Namespacing applies **even when only one app is currently exported**. A
+single-app workspace does not imply a single-app user — the user may export a
+different app later into the same Postman environment, and bare `{{host}}` /
+`${Authorization}` would then collide. Default to the namespaced form
+(`{{<key>-token}}`, etc.) silently; only call `ask_clarification` on genuine
+collision or unresolved ambiguity, not on the single-app case.
+
+### Worked example — two apps in one workspace
+
+A workspace contains `order-service` (IntelliJ module `order-service`, Spring
+Boot app with `spring.application.name=order-service`) and `payment-service`
+(module `payment-service`, `spring.application.name=payment-service`). Each has
+its own `/login` producer and a set of secured consumers.
+
+**Detection.** `list_project_endpoints` + the ambient `moduleNames` set reveal
+two app groups. The agent resolves the key for each via branch 1 (module name) —
+both normalize cleanly (`order-service`, `payment-service`), no collision, no
+clarification needed.
+
+**Bundle 1 — `order-service`** (one `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{order-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to order-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+```
+
+**Bundle 2 — `payment-service`** (a second `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{payment-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+```
+
+**Env vars** (user creates in the Environments panel): `order-service` (host),
+`order-service-token`, `payment-service` (host), `payment-service-token`. The
+two apps never overwrite each other — each token lives in its own namespaced
+slot.
+
+**Proposal summary.** State the branch used per app: `order-service` — module
+name (branch 1); `payment-service` — module name (branch 1). No clarification
+was needed (no collision). Each bundle is complete on its own (producer +
+consumer + host + env var, all carrying the same key).
+
+> **Detection tip for the AI assistant:** before proposing any namespaced
+> bundle, run `list_project_endpoints` and read the ambient `moduleNames` set
+> to detect multi-app workspaces; resolve the key per app via the order above
+> (module name → `spring.application.name` via `read_rule_file` + consent gate
+> → `ask_clarification`); call `get_existing_rules_for_key` for each key to
+> avoid duplicate host / header rules scoped to the same namespace; record the
+> resolution branch per app in the proposal summary. **Propose one complete
+> bundle per app** — a namespaced consumer header without its matching producer
+> script (or vice versa) is still a broken chain.
+
+---
+
 ## Recipes
 
 ### 1. Rename an API endpoint

--- a/skills/easy-yapi-assistant/SKILL.md
+++ b/skills/easy-yapi-assistant/SKILL.md
@@ -220,6 +220,40 @@ change. This mirrors the built-in agent's `propose_rule_content` →
 user-confirmed "Save…" flow; the only difference is you write the file
 directly instead of staging it through a UI.
 
+### Multi-app namespacing
+
+When a workspace hosts more than one app (each IntelliJ Module /
+`spring.application.name` is a candidate app — detect by scanning the
+project's module structure and `application.yml` files), namespace every
+per-app env var by a resolved key so exports don't collide. Apply this
+**even for a single-app workspace** — a single app today doesn't mean a
+single app forever, and bare `{{host}}` / `${Authorization}` would collide
+if the user exports a different app later into the same Postman environment.
+
+- **Resolve the namespace key** in order: (1) Module name (inferred from
+  the source file's IntelliJ module / directory), normalized lower-case
+  with spaces/underscores → hyphens, characters outside `[a-z0-9-]`
+  stripped, capped at 40 chars; (2) `spring.application.name` read
+  directly from the app's `application.yml`/`application-*.yml`/
+  `application.properties` (fall through if absent); (3) ask the user a
+  short clarifying question on collision or unresolved ambiguity.
+- **Namespace every env var**: host `{{<key>}}`, bearer `{{<key>-token}}`,
+  login `{{<key>-username}}`/`{{<key>-password}}` (lower-case by default;
+  UPPER when an existing rule already uses it — reuse the existing casing
+  rather than renaming). The producer's stored name and the consumer's
+  referenced name MUST be identical (bundle integrity still holds).
+- **Split bundles per app**: propose one bundle per app, each complete on
+  its own (producer script + consumer header + host + env var, all sharing
+  the same key); for consumers you can't confidently assign to an app
+  (shared/common modules), ask the user with concrete app options.
+- **Record the resolution branch** (module name / `spring.application.name` /
+  user-clarified) and the resulting key in the proposal shown to the user,
+  so they can correct a wrong guess before saving.
+- **Fetch the full recipe** from the bundled `docs/rule-guide.md` (the
+  "Multi-Application Namespace" section) — don't reproduce it from memory.
+  Note: the v1 runtime converts unresolved `${...}` placeholders in
+  **header values** only; do not promise body-level namespacing.
+
 ## Critical Rule File Format (follow exactly — inlined from the agent preamble)
 
 Each line is `<key>[<filter>]=<value>` or `<key>=<value>` (no filter). The

--- a/skills/easy-yapi-assistant/docs/rule-guide.md
+++ b/skills/easy-yapi-assistant/docs/rule-guide.md
@@ -488,6 +488,206 @@ the same catalog when scanning your project.
 
 ---
 
+## Multi-Application Namespace
+
+> **Per-app namespacing for workspaces that host more than one service.** Real
+> workspaces frequently contain several applications / modules — an
+> `order-service` + a `payment-service` + an `admin-portal` — each with its own
+> authorization filter, login endpoint, and host. Without namespacing, two apps
+> in one workspace both write `Authorization` and the second export silently
+> overwrites the first app's token in the Postman environment; every endpoint
+> points at `{{host}}` so all apps share one host; and app A's login captures
+> into `username` / `password` collide with app B's. Namespacing disambiguates
+> every per-app env var by the application identity, baked as a literal into the
+> rule at **authoring time** (the agent has PSI + file access; the runtime does
+> not).
+
+> **Bundle integrity still holds.** A workflow bundle is a producer script +
+> consumer header (+ env var) proposed together (see [Workflow Patterns](#workflow-patterns)).
+> Namespacing does not relax this: within one bundle the producer's stored
+> env-var name and the consumer's referenced env-var name MUST be identical,
+> and both MUST carry the same namespace key. Either half alone is still broken.
+
+### Namespace-key resolution order
+
+The agent resolves the namespace key for a target app in this order, and records
+which branch it used so the user can correct a wrong guess before saving:
+
+1. **IntelliJ Module name** of the target endpoints' source classes, via
+   `ModuleHelper.resolveModuleName(psiElement)` (always available, no framework
+   dependency). The raw module name is normalized through the canonical
+   `NamespaceKeyNormalizer` (see the naming-convention table below) so
+   `OrderService` → `order-service`, `order_service` → `order-service`,
+   `admin portal` → `admin-portal`. The normalized key uses only the
+   character class `[a-z0-9-]` (lower-case ASCII letters, digits, hyphens);
+   every other character is stripped or replaced. This is the same value `runtime.module()`
+   returns at export time, so the agent's literal key and the runtime module
+   name agree whenever this branch is taken.
+
+2. **`spring.application.name`** read at **authoring time** via `read_rule_file`
+   (the ONLY file-reading tool the agent has). Call it with the app's
+   `application.yml` / `application-*.yml` / `application.properties` path —
+   this triggers a one-time `FileReadConsentGate` consent prompt the user must
+   approve. Use this branch only when the module name is absent, empty, or a
+   generic placeholder (`<unnamed>`, the project name, etc.). If the user denies
+   consent or the file is absent, fall back to branch (3).
+   **Do NOT attempt `get_psi_class_info` for this purpose** — it is
+   class-signature only (name, modifiers, annotations, field/method signatures)
+   and cannot read `application.yml` or any non-class file.
+
+3. **`ask_clarification`** (`single_choice`) when both branches above are
+   ambiguous, or when two target apps would resolve to the same key (collision).
+   Offer concrete disambiguation options (the original names + the normalized
+   candidates) before writing any rule — never let the second app silently
+   overwrite the first.
+
+> **Authoring-time vs runtime split is hard.** The namespace key is resolved by
+> the agent (PSI + file access) and baked as a literal into the rule value. The
+> runtime host rule uses `runtime.module()` (the runtime mirror of branch 1); it
+> cannot read `spring.application.name` — `ConfigReader` / `config.get(...)`
+> sees only `.easy.api.config*` plugin rule files, never the project's
+> `application.yml`. If the app name is needed at runtime, it must be a literal
+> the agent baked in at authoring time.
+
+### Per-app env-var naming convention
+
+Every per-app env var in a workflow/host bundle is namespaced by the resolved
+key. The canonical transform is `NamespaceKeyNormalizer.normalize(input)` — the
+same pure utility the agent invokes — so users can predict the result:
+
+| Slot | Placeholder | Notes |
+|------|-------------|-------|
+| Host | `{{<key>}}` | Proposed as `postman.host={{<key>}}` / `hopp.host={{<key>}}`. The Hoppscotch formatter rewrites unresolved `${...}` in header values to `<<key>>` at export time. |
+| Bearer token | `{{<key>-token}}` | Lower-case `-token` suffix by default (matches the lowercase workflow-recipe convention). Allow `-TOKEN` (UPPER) when an existing rule already uses it — reuse the existing casing via `get_existing_rules_for_key` rather than renaming. |
+| Login username | `{{<key>-username}}` | Same casing rule as the token. |
+| Login password | `{{<key>-password}}` | Same casing rule as the token. |
+
+In rule values the namespaced var is written as `${<key>-token}` (e.g.
+`Bearer ${order-service-token}`); the Postman/Hoppscotch formatters convert
+**unresolved** `${...}` in header values to the platform syntax
+(`{{order-service-token}}` / `<<order-service-token>>`) at export time.
+**Resolved** `${...}` (config-backed) and regex-capture `${1}` are left
+untouched.
+
+### Multi-app bundle-split rule
+
+When the ambient `modules:` hint shows more than one API-bearing module (N > 1),
+call `get_module_dependency_graph` and cluster the API-bearing modules into
+connected components (layered modules like `admin-api` + `admin-impl` collapse
+to one app; disjoint apps stay separate). Each connected component is one app
+group. When `list_project_endpoints` / the ambient `moduleNames` set reveals
+more than one app group, propose **one namespaced bundle per app** — one
+`propose_rule_content` call per bundle. Each bundle must still be complete on
+its own (producer script + consumer header + host + env var, all carrying the
+same namespace key) per the bundle-integrity rule above.
+
+For consumers the agent cannot confidently assign to an app group (shared /
+common modules consumed by several apps — e.g. a `common` or `dto` module both
+apps depend on), call `ask_clarification` (`single_choice`, concrete app
+options) rather than guess.
+
+Before proposing any bundle, call `get_existing_rules_for_key` for each key in
+the bundle and skip rules already present in any source (project / global /
+extension / remote) scoped to the same namespace key — the same
+anti-duplication rule from [Workflow Patterns](#workflow-patterns) applies
+per-app.
+
+### Known limitation — body-level namespacing
+
+The v1 runtime enabler converts unresolved `${...}` placeholders **only in
+header values** (the `method.additional.header` value surface, where
+`Authorization: Bearer ${<key>-token}` lives). Conversion of `${...}` in
+`method.additional.param` values and the request body is **deferred** — the
+request body has JSON-structure / JSON5-mode / `ObjectModel` serialization
+concerns that make symmetric conversion riskier and out of scope for v1.
+
+**Do NOT promise body-level namespacing** in your proposals. If a namespaced
+token is needed in a body, propose it as `${<key>-token}` and note that the user
+must wire the env var in the Environments panel until param/body conversion
+ships.
+
+### Resolution-branch recording
+
+The agent's proposal summary MUST state which resolution branch was used
+(module name / `spring.application.name` / user-clarified via
+`ask_clarification`) and the resulting namespace key, so the user can correct a
+wrong guess before saving. For example:
+
+> *Namespacing* — `order-service` resolved from **module name** (branch 1);
+> `payment-service` resolved from **spring.application.name** (branch 2, read
+> via `read_rule_file` from `application.yml`); the admin portal was
+> **user-clarified** (branch 3) after colliding with `payment-service` on the
+> normalized `admin` candidate.
+
+### Single-app still namespaced
+
+Namespacing applies **even when only one app is currently exported**. A
+single-app workspace does not imply a single-app user — the user may export a
+different app later into the same Postman environment, and bare `{{host}}` /
+`${Authorization}` would then collide. Default to the namespaced form
+(`{{<key>-token}}`, etc.) silently; only call `ask_clarification` on genuine
+collision or unresolved ambiguity, not on the single-app case.
+
+### Worked example — two apps in one workspace
+
+A workspace contains `order-service` (IntelliJ module `order-service`, Spring
+Boot app with `spring.application.name=order-service`) and `payment-service`
+(module `payment-service`, `spring.application.name=payment-service`). Each has
+its own `/login` producer and a set of secured consumers.
+
+**Detection.** `list_project_endpoints` + the ambient `moduleNames` set reveal
+two app groups. The agent resolves the key for each via branch 1 (module name) —
+both normalize cleanly (`order-service`, `payment-service`), no collision, no
+clarification needed.
+
+**Bundle 1 — `order-service`** (one `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{order-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to order-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+```
+
+**Bundle 2 — `payment-service`** (a second `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{payment-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+```
+
+**Env vars** (user creates in the Environments panel): `order-service` (host),
+`order-service-token`, `payment-service` (host), `payment-service-token`. The
+two apps never overwrite each other — each token lives in its own namespaced
+slot.
+
+**Proposal summary.** State the branch used per app: `order-service` — module
+name (branch 1); `payment-service` — module name (branch 1). No clarification
+was needed (no collision). Each bundle is complete on its own (producer +
+consumer + host + env var, all carrying the same key).
+
+> **Detection tip for the AI assistant:** before proposing any namespaced
+> bundle, run `list_project_endpoints` and read the ambient `moduleNames` set
+> to detect multi-app workspaces; resolve the key per app via the order above
+> (module name → `spring.application.name` via `read_rule_file` + consent gate
+> → `ask_clarification`); call `get_existing_rules_for_key` for each key to
+> avoid duplicate host / header rules scoped to the same namespace; record the
+> resolution branch per app in the proposal summary. **Propose one complete
+> bundle per app** — a namespaced consumer header without its matching producer
+> script (or vice versa) is still a broken chain.
+
+---
+
 ## Recipes
 
 ### 1. Rename an API endpoint

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/AgentMemory.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/AgentMemory.kt
@@ -51,5 +51,26 @@ data class Ambient(
     val projectName: String,
     val editingRuleFile: String?,
     val existingRuleFiles: List<String>,
-    val userLanguage: String? = null
+    val userLanguage: String? = null,
+    /**
+     * Names of the IntelliJ `Module`s in the workspace that contain API-bearing
+     * PSI (e.g. `@RestController` / `@Controller` classes), captured once per
+     * [AmbientPerception.capture] so the agent can detect multi-app workspaces
+     * cheaply without an `list_project_endpoints` round-trip on every turn.
+     *
+     * Privacy: carries only module **names** — never env-var keys or values
+     * from the Environments panel.
+     */
+    val moduleNames: List<String> = emptyList(),
+    /**
+     * Web frameworks detected among the project's API-bearing PSI (e.g.
+     * `SpringMVC`, `Feign`, `JAX-RS`, `gRPC`), derived from the
+     * `frameworkName` of each [com.itangcent.easyapi.exporter.core.CompositeApiClassRecognizer]
+     * implementation that recognized at least one API class. Computed once per
+     * [AmbientPerception.capture] in the same PSI scan as [moduleNames].
+     *
+     * Privacy: carries only short framework labels — never env-var keys or
+     * values from the Environments panel.
+     */
+    val frameworkHints: List<String> = emptyList()
 )

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/AmbientPerception.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/AmbientPerception.kt
@@ -1,8 +1,20 @@
 package com.itangcent.easyapi.ai.agent
 
 import com.itangcent.easyapi.config.source.RuleFileResolver
+import com.itangcent.easyapi.core.threading.readSync
+import com.itangcent.easyapi.exporter.core.ApiClassRecognizer
+import com.itangcent.easyapi.exporter.core.CompositeApiClassRecognizer
+import com.itangcent.easyapi.exporter.feign.FeignClientRecognizer
+import com.itangcent.easyapi.exporter.grpc.GrpcServiceRecognizer
+import com.itangcent.easyapi.exporter.jaxrs.JaxRsResourceRecognizer
+import com.itangcent.easyapi.exporter.springmvc.ActuatorEndpointRecognizer
+import com.itangcent.easyapi.exporter.springmvc.SpringControllerRecognizer
 import com.itangcent.easyapi.logging.IdeaLog
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import java.nio.file.Paths
 import java.util.Locale
 
@@ -45,12 +57,114 @@ object AmbientPerception : IdeaLog {
             RuleFileResolver(project).listRuleFiles()
         }.getOrDefault(emptyList())
         val userLanguage = detectUserLanguage()
+        val perception = runCatching { captureApiPerception(project) }
+            .onFailure { LOG.warn("Ambient perception capture failed", it) }
+            .getOrDefault(ApiPerception(emptyList(), emptyList()))
         // Trace what the agent "saw" at turn start.
         LOG.info("ambient capture: project=$projectName " +
             "editingRuleFile=${editingRuleFile ?: "<none>"} " +
             "existingRuleFiles=${existingRuleFiles.size} " +
-            "userLanguage=${userLanguage ?: "<none>"}")
-        return Ambient(projectName, editingRuleFile, existingRuleFiles, userLanguage)
+            "userLanguage=${userLanguage ?: "<none>"} " +
+            "moduleNames=${perception.moduleNames.size} " +
+            "frameworkHints=${perception.frameworkHints.size}")
+        LOG.info("Ambient captured ${perception.moduleNames.size} API-bearing module(s), " +
+            "${perception.frameworkHints.size} framework(s)")
+        return Ambient(
+            projectName,
+            editingRuleFile,
+            existingRuleFiles,
+            userLanguage,
+            perception.moduleNames,
+            perception.frameworkHints
+        )
+    }
+
+    /**
+     * Single PSI scan that captures both the API-bearing module names and the
+     * detected web-framework labels, computed once per [capture] so the agent
+     * can detect multi-app workspaces and active frameworks cheaply without an
+     * `list_project_endpoints` round-trip on every turn.
+     *
+     * Reuses [CompositeApiClassRecognizer.allTargetAnnotations] — the same
+     * aggregated annotation set `ApiScanner` searches on — and the indexed
+     * [AnnotatedElementsSearch] primitive, so no new PSI tool is introduced
+     * (cached fields on `Ambient`, not new tools). For each controller class
+     * found, its containing module is resolved via
+     * [ModuleUtilCore.findModuleForPsiElement]. When an annotation FQN produces
+     * ≥1 hit, its owning recognizer's [ApiClassRecognizer.frameworkName] is
+     * collected into [ApiPerception.frameworkHints] (deduped).
+     *
+     * Settings gates (Req 9.3) are respected automatically: disabled
+     * recognizers are excluded from [CompositeApiClassRecognizer.allTargetAnnotations],
+     * so their annotations are never searched and their framework labels never
+     * surface — even though [annotationFrameworkLookup] covers every recognizer.
+     *
+     * PSI read runs inside `readSync`. Best-effort: a per-annotation search
+     * failure is logged and skipped so ambient capture never blocks the agent.
+     *
+     * Privacy: collects module **names** and short framework **labels** only —
+     * never env-var keys or values from the Environments panel.
+     */
+    private fun captureApiPerception(project: Project): ApiPerception = readSync {
+        val annotationFqns = CompositeApiClassRecognizer.getInstance(project).allTargetAnnotations
+        if (annotationFqns.isEmpty()) return@readSync ApiPerception(emptyList(), emptyList())
+        val projectScope = GlobalSearchScope.projectScope(project)
+        val allScope = GlobalSearchScope.allScope(project)
+        val javaFacade = JavaPsiFacade.getInstance(project)
+        val moduleNames = LinkedHashSet<String>()
+        val frameworkHints = LinkedHashSet<String>()
+        for (annotationFqn in annotationFqns) {
+            try {
+                val annotationClass = javaFacade.findClass(annotationFqn, allScope) ?: continue
+                if (!annotationClass.isAnnotationType) continue
+                val annotated = AnnotatedElementsSearch.searchPsiClasses(annotationClass, projectScope).findAll()
+                var hasHit = false
+                for (psiClass in annotated) {
+                    if (psiClass.isAnnotationType) continue
+                    hasHit = true
+                    val module = ModuleUtilCore.findModuleForPsiElement(psiClass)
+                    if (module != null && module.name.isNotBlank()) {
+                        moduleNames.add(module.name)
+                    }
+                }
+                if (hasHit) {
+                    annotationFrameworkLookup[annotationFqn]?.let { frameworkHints.add(it) }
+                }
+            } catch (e: Exception) {
+                LOG.warn("Ambient perception capture: error searching annotation $annotationFqn", e)
+            }
+        }
+        ApiPerception(moduleNames.toList(), frameworkHints.toList())
+    }
+
+    /**
+     * Maps each framework annotation FQN to its framework label
+     * ([ApiClassRecognizer.frameworkName]), built once from every recognizer
+     * regardless of settings. The settings gate is applied upstream by
+     * [CompositeApiClassRecognizer.allTargetAnnotations] (which excludes
+     * disabled recognizers), so only FQNs present there are ever looked up.
+     *
+     * Instantiating the recognizers is cheap (they are data holders; the
+     * `suspend isApiClass` is never called here). This avoids touching
+     * `CompositeApiClassRecognizer` (whose `cachedRecognizers` is private) and
+     * keeps the annotation→framework mapping sourced from the recognizer
+     * implementations themselves rather than duplicated string literals.
+     */
+    private val annotationFrameworkLookup: Map<String, String> = run {
+        val recognizers: List<ApiClassRecognizer> = listOf(
+            SpringControllerRecognizer(),
+            FeignClientRecognizer(),
+            JaxRsResourceRecognizer(),
+            ActuatorEndpointRecognizer(),
+            GrpcServiceRecognizer()
+        )
+        val map = HashMap<String, String>()
+        for (recognizer in recognizers) {
+            for (annotationFqn in recognizer.targetAnnotations) {
+                map[annotationFqn] = recognizer.frameworkName
+            }
+        }
+        map
     }
 
     /**
@@ -79,3 +193,13 @@ object AmbientPerception : IdeaLog {
         return null
     }
 }
+
+/**
+ * Result of the single API-perception PSI scan: the API-bearing module names
+ * and the detected web-framework labels, computed together in one pass by
+ * [AmbientPerception.captureApiPerception].
+ */
+private data class ApiPerception(
+    val moduleNames: List<String>,
+    val frameworkHints: List<String>
+)

--- a/src/main/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilder.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilder.kt
@@ -44,6 +44,18 @@ object SystemPromptBuilder : IdeaLog {
         if (amb.existingRuleFiles.isNotEmpty()) {
             parts += "other rule files: ${amb.existingRuleFiles.joinToString(", ")}"
         }
+        // Surface the IntelliJ Modules that contain API-bearing PSI so the
+        // agent can detect multi-app workspaces cheaply (on-demand fetch for
+        // the full recipe via `get_plugin_doc`). Empty list → no hint.
+        if (amb.moduleNames.isNotEmpty()) {
+            parts += "modules: ${amb.moduleNames.joinToString(", ")}"
+        }
+        // Surface the detected web frameworks so the agent knows which
+        // frameworks are active without a list_project_endpoints round-trip.
+        // Derived from the same PSI scan as moduleNames. Empty list → no hint.
+        if (amb.frameworkHints.isNotEmpty()) {
+            parts += "frameworks active: ${amb.frameworkHints.joinToString(", ")}"
+        }
         // Surface the detected Markdown template locale so the agent can decide
         // whether to propose `markdown.template.language=<tag>`. `en`/null
         // mean "default (English) template" — no hint, no proposal.

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphTool.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphTool.kt
@@ -1,0 +1,166 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleOrderEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.itangcent.easyapi.core.threading.read
+import com.itangcent.easyapi.logging.IdeaLog
+
+/**
+ * Perception tool that returns the workspace module dependency graph.
+ *
+ * For every IntelliJ `Module` in the workspace, renders its
+ * `ModuleOrderEntry` dependencies on other workspace modules as a compact
+ * adjacency list (`module: [dep, dep]`). `LibraryOrderEntry` / `SdkOrderEntry`
+ * edges are excluded — only module-to-module edges are structural for app
+ * clustering. The agent clusters the returned edges into connected components
+ * to decide which modules form one app (the tool delivers edges; it does not
+ * compute the grouping).
+ *
+ * Above [NODE_CAP] nodes a summary ("N modules in K disjoint clusters: …") is
+ * returned instead of the full adjacency, so a monorepo does not blow the
+ * response budget. The output is structural only — module names + edges; it
+ * never carries env-var keys or values.
+ *
+ * Call only when the ambient `modules:` hint shows more than one API-bearing
+ * module.
+ *
+ * @requires ReadAction context (PSI/index read via [ModuleRootManager]).
+ */
+class GetModuleDependencyGraphTool : AiTool, IdeaLog {
+
+    override val name: String = "get_module_dependency_graph"
+
+    override val description: String =
+        "Return the workspace module dependency graph (module-name -> " +
+            "depends-on module-names). Call only when the ambient `modules:` " +
+            "hint shows more than one API-bearing module, to decide which " +
+            "modules form one app (connected components). Above ~24 nodes a " +
+            "summary ('N modules in K clusters') is returned instead."
+
+    override val kind: ToolKind = ToolKind.PERCEPTION
+
+    override val parametersSchema: Map<String, Any?> = emptyMap()
+
+    override suspend fun execute(args: Map<String, Any?>, ctx: ToolContext): ToolResult {
+        val adjacency = read {
+            val modules = ModuleManager.getInstance(ctx.project).modules
+            val result = LinkedHashMap<String, MutableList<String>>()
+            for (module in modules) {
+                try {
+                    val deps = ModuleRootManager.getInstance(module).orderEntries
+                        .filterIsInstance<ModuleOrderEntry>()
+                        // Req 8.1: restrict to workspace (non-external) modules —
+                        // a ModuleOrderEntry whose Module is null is an external /
+                        // unloaded reference, not a structural workspace edge.
+                        .filter { it.module != null }
+                        .mapNotNull { it.moduleName }
+                        .filter { it.isNotBlank() && it != module.name }
+                        .distinct()
+                    result[module.name] = deps.toMutableList()
+                } catch (e: Exception) {
+                    LOG.warn("module-dep-graph: error reading module ${module.name}", e)
+                }
+            }
+            result
+        }
+        LOG.info(
+            "module-dep-graph: ${adjacency.size} nodes, " +
+                "${adjacency.values.sumOf { it.size }} edges"
+        )
+        return ToolResult.Text(renderGraph(adjacency))
+    }
+
+    companion object {
+        /** Above this node count the tool returns a summary instead of the
+         *  full adjacency list. */
+        const val NODE_CAP: Int = 24
+
+        /**
+         * Pure, testable renderer for the module dependency graph.
+         *
+         * @param adjacency module name -> its `ModuleOrderEntry` dependency
+         *  module names (library/SDK entries already excluded by the caller).
+         *  Dependency targets that are absent as keys (a read failure omitted
+         *  them, or they are external) are tolerated.
+         * @param nodeCap node count above which the summary form is returned.
+         * @return the textual representation fed back to the LLM. Never throws.
+         */
+        internal fun renderGraph(
+            adjacency: Map<String, List<String>>,
+            nodeCap: Int = NODE_CAP
+        ): String {
+            if (adjacency.isEmpty()) return "(no modules)"
+            // Include dependency targets that are not themselves keys so the
+            // summary reports the true node count (a module may be depended
+            // on but have no entry of its own).
+            val allNodes = adjacency.keys.toMutableSet()
+            adjacency.values.forEach { deps ->
+                deps.forEach { if (it !in allNodes) allNodes.add(it) }
+            }
+            if (allNodes.size > nodeCap) {
+                return summarize(allNodes, adjacency)
+            }
+            return adjacency.keys.sorted().joinToString("\n") { name ->
+                val deps = adjacency[name].orEmpty().distinct().sorted()
+                "$name: [${deps.joinToString(", ")}]"
+            }
+        }
+
+        private fun summarize(
+            allNodes: Set<String>,
+            adjacency: Map<String, List<String>>
+        ): String {
+            val components = connectedComponents(allNodes, adjacency)
+            val parts = components
+                .sortedWith(
+                    compareByDescending<List<String>> { it.size }
+                        .thenBy { it.first() }
+                )
+                .joinToString(", ") { cluster ->
+                    val representative = cluster.minOrNull() ?: "?"
+                    "$representative(${cluster.size})"
+                }
+            return "${allNodes.size} modules in ${components.size} disjoint clusters: $parts"
+        }
+
+        /**
+         * Computes connected components over the *undirected* edge set
+         * (module A depends on B ⟹ A and B are in the same component).
+         */
+        private fun connectedComponents(
+            nodes: Set<String>,
+            adjacency: Map<String, List<String>>
+        ): List<List<String>> {
+            // Undirected adjacency: forward (a -> deps) + reverse (dep -> a).
+            val undirected = HashMap<String, MutableList<String>>()
+            for (node in nodes) undirected[node] = mutableListOf()
+            adjacency.forEach { (src, deps) ->
+                for (dep in deps) {
+                    undirected.getOrPut(src) { mutableListOf() }.add(dep)
+                    undirected.getOrPut(dep) { mutableListOf() }.add(src)
+                }
+            }
+            val visited = HashSet<String>()
+            val components = mutableListOf<List<String>>()
+            for (start in nodes.sorted()) {
+                if (start in visited) continue
+                val component = mutableListOf<String>()
+                val queue = ArrayDeque<String>()
+                queue.add(start)
+                visited.add(start)
+                while (queue.isNotEmpty()) {
+                    val current = queue.removeFirst()
+                    component.add(current)
+                    for (neighbor in undirected[current].orEmpty()) {
+                        if (neighbor in visited) continue
+                        visited.add(neighbor)
+                        queue.add(neighbor)
+                    }
+                }
+                components.add(component.sorted())
+            }
+            return components
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/ai/tools/RuleTools.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/ai/tools/RuleTools.kt
@@ -4,7 +4,7 @@ package com.itangcent.easyapi.ai.tools
  * The standard set of tools handed to the [ToolRegistry] for a real
  * conversation.
  *
- * 10 perception tools + 1 staging action (`propose_rule_content`).
+ * 11 perception tools + 1 staging action (`propose_rule_content`).
  * `write_rule_file` is intentionally NOT registered in v1 — the disk write
  * happens only through the user-confirmed "Save…" UI flow.
  *
@@ -26,6 +26,7 @@ fun standardRuleTools(): List<AiTool> = listOf(
     FindClassesByAnnotationTool(),
     FindClassesBySupertypeTool(),
     GetExistingRulesForKeyTool(),
+    GetModuleDependencyGraphTool(),
     AskClarificationTool(),
     ProposeRuleContentTool()
     // WriteRuleFileTool() is reserved — not registered in v1.

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/PlaceholderSyntaxConverter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/PlaceholderSyntaxConverter.kt
@@ -1,0 +1,87 @@
+package com.itangcent.easyapi.exporter.channel
+
+import com.itangcent.easyapi.config.DOLLAR_BRACE_PATTERN
+
+/**
+ * Target variable syntax for unresolved `${...}` placeholders.
+ *
+ * Each platform renders unresolved environment-variable references using a
+ * distinct delimiter pair; this enum captures the open/close tokens so the
+ * converter stays platform-agnostic.
+ *
+ * @property open The opening delimiter of the platform's variable syntax.
+ * @property close The closing delimiter of the platform's variable syntax.
+ */
+enum class PlaceholderTargetSyntax(val open: String, val close: String) {
+    POSTMAN("{{", "}}"),
+    HOPPSCOTCH("<<", ">>"),
+}
+
+/**
+ * Converts unresolved `${name}` placeholders in a header/param value to the
+ * target platform's variable syntax.
+ *
+ * Resolved placeholders (config-backed) and regex-capture `${1}` are left
+ * untouched so the converter never breaks an existing single-app export
+ * (byte-parity fast path) nor a path-parameter capture reference.
+ *
+ * Pure: no `Project` / `EnvironmentService` / `ConfigReader` dependency. The
+ * caller supplies [isResolvable] (typically
+ * `ConfigReader.getInstance(project).getFirst(name).isNullOrEmpty().not()`),
+ * mirroring the [com.itangcent.easyapi.exporter.channel.curl.EndpointVariableResolver]
+ * shape (pure object, caller-supplied lookup).
+ *
+ * Reuses the existing [DOLLAR_BRACE_PATTERN] from `com.itangcent.easyapi.config`
+ * (the same regex the config layer uses for variable resolution) — no new
+ * regex is introduced.
+ */
+object PlaceholderSyntaxConverter {
+
+    /** Matches `${1}`, `${12}`, … — a regex-capture reference, not a variable. */
+    private val REGEX_CAPTURE_PATTERN = Regex("^\\d+$")
+
+    /**
+     * Converts unresolved `${name}` placeholders in [value] to [target]'s syntax.
+     *
+     * Behavior:
+     * 1. **Fast path** — if [value] contains no `${`, it is returned unchanged
+     *    (same instance) to preserve byte-parity for placeholder-free values.
+     * 2. For each `${name}` match (via [DOLLAR_BRACE_PATTERN]):
+     *    - skip if `name` matches `^\d+$` (regex-capture reference, e.g. `${1}`);
+     *    - leave `${name}` as-is if [isResolvable] returns `true` (the config
+     *      layer will substitute it);
+     *    - otherwise replace with `target.open + name + target.close`.
+     * 3. Already-present `{{...}}` / `<<...>>` are never touched — only `${...}`
+     *    is rewritten.
+     *
+     * A malformed `${` with no closing `}` is not matched by the regex and is
+     * left as-is. This function never throws.
+     *
+     * @param value The header/param value possibly containing `${...}`.
+     * @param target The target platform variable syntax.
+     * @param isResolvable Oracle returning `true` when the config layer can
+     *   substitute `name` (i.e. it should be left as `${name}`).
+     */
+    fun convert(
+        value: String,
+        target: PlaceholderTargetSyntax,
+        isResolvable: (String) -> Boolean,
+    ): String {
+        // Fast path: no placeholder to convert — return the same instance.
+        if (!value.contains("\${")) return value
+
+        return DOLLAR_BRACE_PATTERN.replace(value) { match ->
+            val name = match.groupValues[1].trim()
+            if (REGEX_CAPTURE_PATTERN.matches(name)) {
+                // Regex-capture reference (e.g. `${1}`) — leave untouched.
+                return@replace match.value
+            }
+            if (isResolvable(name)) {
+                // Config layer will substitute this — leave as `${name}`.
+                return@replace match.value
+            }
+            // Unresolved — rewrite to the target platform syntax.
+            target.open + name + target.close
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppscotchFormatter.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.exporter.channel.PlaceholderSyntaxConverter
+import com.itangcent.easyapi.exporter.channel.PlaceholderTargetSyntax
 import com.itangcent.easyapi.exporter.channel.hoppscotch.model.*
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.HttpMetadata
@@ -171,7 +174,10 @@ class HoppscotchFormatter(
         return meta.headers.map { header ->
             HoppKeyValue(
                 key = header.name,
-                value = header.value ?: header.example ?: "",
+                value = PlaceholderSyntaxConverter.convert(
+                    header.value ?: header.example ?: "",
+                    PlaceholderTargetSyntax.HOPPSCOTCH
+                ) { name -> !ConfigReader.getInstance(project).getFirst(name).isNullOrEmpty() },
                 active = true,
                 description = header.description
             )

--- a/src/main/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanFormatter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanFormatter.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.exporter.channel.PlaceholderSyntaxConverter
+import com.itangcent.easyapi.exporter.channel.PlaceholderTargetSyntax
 import com.itangcent.easyapi.exporter.model.ApiEndpoint
 import com.itangcent.easyapi.exporter.model.HttpMetadata
 import com.itangcent.easyapi.exporter.model.ParameterBinding
@@ -257,7 +260,10 @@ class PostmanFormatter(
         val headers = meta.headers.map {
             PostmanHeader(
                 key = it.name,
-                value = it.value ?: "",
+                value = PlaceholderSyntaxConverter.convert(
+                    it.value ?: "",
+                    PlaceholderTargetSyntax.POSTMAN
+                ) { name -> !ConfigReader.getInstance(project).getFirst(name).isNullOrEmpty() },
                 type = "text",
                 description = ""
             )

--- a/src/main/resources/ai/agent-preamble.md
+++ b/src/main/resources/ai/agent-preamble.md
@@ -149,6 +149,37 @@ signing, correlation, or auto-refresh, probe for these five groups:
 table from memory — the canonical doc carries detection signals, complete
 `key[filter]=value` lines, and env-var-reuse notes.
 
+### Multi-app namespacing
+
+When multiple apps (Modules with API-bearing PSI — see the ambient `modules:`
+hint or `list_project_endpoints`) share a workspace, namespace every per-app
+env var by a resolved key so exports don't collide. The ambient
+`frameworks active:` hint shows which web frameworks are present so you can
+pre-fetch framework-specific recipes without inferring from endpoints.
+
+- **Cluster modules into apps**: when the ambient `modules:` hint shows N > 1,
+  call `get_module_dependency_graph` and cluster the API-bearing modules into
+  connected components (layered `api`+`impl` collapse to one app; disjoint
+  apps stay separate). Fall back to `ask_clarification` on shared-leaf
+  ambiguity (e.g. a `common` module both apps depend on).
+- **Resolve the namespace key** in order: (1) Module name
+  (`ModuleHelper.resolveModuleName`, normalized to a safe segment — see the
+  naming convention in the rule-guide recipe); (2)
+  `spring.application.name` via `read_rule_file` on the app's
+  `application.yml`/`application-*.yml`/`application.properties` (one-time
+  `FileReadConsentGate`; on denial/absent fall through); (3)
+  `ask_clarification` on collision. `get_psi_class_info` can't read
+  `application.yml`.
+- **Namespace every env var**: host `{{<key>}}`, bearer `{{<key>-token}}`,
+  login `{{<key>-username}}`/`{{<key>-password}}`; producer/consumer share
+  one name (bundle integrity).
+- **Split bundles per app**: one `propose_rule_content` per app; each bundle
+  complete on its own.
+- **Record the resolution branch** (module name/`spring.application.name`/
+  user-clarified) and key in the proposal summary.
+- **Fetch the full recipe** via `get_plugin_doc name="rule-guide"` (the
+  "Multi-Application Namespace" section) — don't reproduce it from memory.
+
 ### Workflow correctness rules (CRITICAL — follow exactly)
 
 1. **Bundle integrity.** Workflow rules that form a chain (login-script +

--- a/src/main/resources/docs/knowledge-base/rule-guide.md
+++ b/src/main/resources/docs/knowledge-base/rule-guide.md
@@ -488,6 +488,206 @@ the same catalog when scanning your project.
 
 ---
 
+## Multi-Application Namespace
+
+> **Per-app namespacing for workspaces that host more than one service.** Real
+> workspaces frequently contain several applications / modules — an
+> `order-service` + a `payment-service` + an `admin-portal` — each with its own
+> authorization filter, login endpoint, and host. Without namespacing, two apps
+> in one workspace both write `Authorization` and the second export silently
+> overwrites the first app's token in the Postman environment; every endpoint
+> points at `{{host}}` so all apps share one host; and app A's login captures
+> into `username` / `password` collide with app B's. Namespacing disambiguates
+> every per-app env var by the application identity, baked as a literal into the
+> rule at **authoring time** (the agent has PSI + file access; the runtime does
+> not).
+
+> **Bundle integrity still holds.** A workflow bundle is a producer script +
+> consumer header (+ env var) proposed together (see [Workflow Patterns](#workflow-patterns)).
+> Namespacing does not relax this: within one bundle the producer's stored
+> env-var name and the consumer's referenced env-var name MUST be identical,
+> and both MUST carry the same namespace key. Either half alone is still broken.
+
+### Namespace-key resolution order
+
+The agent resolves the namespace key for a target app in this order, and records
+which branch it used so the user can correct a wrong guess before saving:
+
+1. **IntelliJ Module name** of the target endpoints' source classes, via
+   `ModuleHelper.resolveModuleName(psiElement)` (always available, no framework
+   dependency). The raw module name is normalized through the canonical
+   `NamespaceKeyNormalizer` (see the naming-convention table below) so
+   `OrderService` → `order-service`, `order_service` → `order-service`,
+   `admin portal` → `admin-portal`. The normalized key uses only the
+   character class `[a-z0-9-]` (lower-case ASCII letters, digits, hyphens);
+   every other character is stripped or replaced. This is the same value `runtime.module()`
+   returns at export time, so the agent's literal key and the runtime module
+   name agree whenever this branch is taken.
+
+2. **`spring.application.name`** read at **authoring time** via `read_rule_file`
+   (the ONLY file-reading tool the agent has). Call it with the app's
+   `application.yml` / `application-*.yml` / `application.properties` path —
+   this triggers a one-time `FileReadConsentGate` consent prompt the user must
+   approve. Use this branch only when the module name is absent, empty, or a
+   generic placeholder (`<unnamed>`, the project name, etc.). If the user denies
+   consent or the file is absent, fall back to branch (3).
+   **Do NOT attempt `get_psi_class_info` for this purpose** — it is
+   class-signature only (name, modifiers, annotations, field/method signatures)
+   and cannot read `application.yml` or any non-class file.
+
+3. **`ask_clarification`** (`single_choice`) when both branches above are
+   ambiguous, or when two target apps would resolve to the same key (collision).
+   Offer concrete disambiguation options (the original names + the normalized
+   candidates) before writing any rule — never let the second app silently
+   overwrite the first.
+
+> **Authoring-time vs runtime split is hard.** The namespace key is resolved by
+> the agent (PSI + file access) and baked as a literal into the rule value. The
+> runtime host rule uses `runtime.module()` (the runtime mirror of branch 1); it
+> cannot read `spring.application.name` — `ConfigReader` / `config.get(...)`
+> sees only `.easy.api.config*` plugin rule files, never the project's
+> `application.yml`. If the app name is needed at runtime, it must be a literal
+> the agent baked in at authoring time.
+
+### Per-app env-var naming convention
+
+Every per-app env var in a workflow/host bundle is namespaced by the resolved
+key. The canonical transform is `NamespaceKeyNormalizer.normalize(input)` — the
+same pure utility the agent invokes — so users can predict the result:
+
+| Slot | Placeholder | Notes |
+|------|-------------|-------|
+| Host | `{{<key>}}` | Proposed as `postman.host={{<key>}}` / `hopp.host={{<key>}}`. The Hoppscotch formatter rewrites unresolved `${...}` in header values to `<<key>>` at export time. |
+| Bearer token | `{{<key>-token}}` | Lower-case `-token` suffix by default (matches the lowercase workflow-recipe convention). Allow `-TOKEN` (UPPER) when an existing rule already uses it — reuse the existing casing via `get_existing_rules_for_key` rather than renaming. |
+| Login username | `{{<key>-username}}` | Same casing rule as the token. |
+| Login password | `{{<key>-password}}` | Same casing rule as the token. |
+
+In rule values the namespaced var is written as `${<key>-token}` (e.g.
+`Bearer ${order-service-token}`); the Postman/Hoppscotch formatters convert
+**unresolved** `${...}` in header values to the platform syntax
+(`{{order-service-token}}` / `<<order-service-token>>`) at export time.
+**Resolved** `${...}` (config-backed) and regex-capture `${1}` are left
+untouched.
+
+### Multi-app bundle-split rule
+
+When the ambient `modules:` hint shows more than one API-bearing module (N > 1),
+call `get_module_dependency_graph` and cluster the API-bearing modules into
+connected components (layered modules like `admin-api` + `admin-impl` collapse
+to one app; disjoint apps stay separate). Each connected component is one app
+group. When `list_project_endpoints` / the ambient `moduleNames` set reveals
+more than one app group, propose **one namespaced bundle per app** — one
+`propose_rule_content` call per bundle. Each bundle must still be complete on
+its own (producer script + consumer header + host + env var, all carrying the
+same namespace key) per the bundle-integrity rule above.
+
+For consumers the agent cannot confidently assign to an app group (shared /
+common modules consumed by several apps — e.g. a `common` or `dto` module both
+apps depend on), call `ask_clarification` (`single_choice`, concrete app
+options) rather than guess.
+
+Before proposing any bundle, call `get_existing_rules_for_key` for each key in
+the bundle and skip rules already present in any source (project / global /
+extension / remote) scoped to the same namespace key — the same
+anti-duplication rule from [Workflow Patterns](#workflow-patterns) applies
+per-app.
+
+### Known limitation — body-level namespacing
+
+The v1 runtime enabler converts unresolved `${...}` placeholders **only in
+header values** (the `method.additional.header` value surface, where
+`Authorization: Bearer ${<key>-token}` lives). Conversion of `${...}` in
+`method.additional.param` values and the request body is **deferred** — the
+request body has JSON-structure / JSON5-mode / `ObjectModel` serialization
+concerns that make symmetric conversion riskier and out of scope for v1.
+
+**Do NOT promise body-level namespacing** in your proposals. If a namespaced
+token is needed in a body, propose it as `${<key>-token}` and note that the user
+must wire the env var in the Environments panel until param/body conversion
+ships.
+
+### Resolution-branch recording
+
+The agent's proposal summary MUST state which resolution branch was used
+(module name / `spring.application.name` / user-clarified via
+`ask_clarification`) and the resulting namespace key, so the user can correct a
+wrong guess before saving. For example:
+
+> *Namespacing* — `order-service` resolved from **module name** (branch 1);
+> `payment-service` resolved from **spring.application.name** (branch 2, read
+> via `read_rule_file` from `application.yml`); the admin portal was
+> **user-clarified** (branch 3) after colliding with `payment-service` on the
+> normalized `admin` candidate.
+
+### Single-app still namespaced
+
+Namespacing applies **even when only one app is currently exported**. A
+single-app workspace does not imply a single-app user — the user may export a
+different app later into the same Postman environment, and bare `{{host}}` /
+`${Authorization}` would then collide. Default to the namespaced form
+(`{{<key>-token}}`, etc.) silently; only call `ask_clarification` on genuine
+collision or unresolved ambiguity, not on the single-app case.
+
+### Worked example — two apps in one workspace
+
+A workspace contains `order-service` (IntelliJ module `order-service`, Spring
+Boot app with `spring.application.name=order-service`) and `payment-service`
+(module `payment-service`, `spring.application.name=payment-service`). Each has
+its own `/login` producer and a set of secured consumers.
+
+**Detection.** `list_project_endpoints` + the ambient `moduleNames` set reveal
+two app groups. The agent resolves the key for each via branch 1 (module name) —
+both normalize cleanly (`order-service`, `payment-service`), no collision, no
+clarification needed.
+
+**Bundle 1 — `order-service`** (one `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{order-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.order.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("order-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to order-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.order.api.")]={"name":"Authorization","value":"Bearer ${order-service-token}","desc":"bearer token from order-service login","required":true}
+```
+
+**Bundle 2 — `payment-service`** (a second `propose_rule_content`):
+
+```
+# Host — namespaced per app
+postman.host={{payment-service}}
+
+# Producer (post-response — extracts token, stores in namespaced env var)
+postman.test[groovy: it.containingClass().name() == "com.example.payment.AuthController"]=def token = pm.response.json().token; if (token) { pm.environment.set("payment-service-token", token) }
+
+# Consumer (attaches namespaced Bearer header to payment-service secured endpoints)
+method.additional.header[groovy: it.containingClass().name().startsWith("com.example.payment.api.")]={"name":"Authorization","value":"Bearer ${payment-service-token}","desc":"bearer token from payment-service login","required":true}
+```
+
+**Env vars** (user creates in the Environments panel): `order-service` (host),
+`order-service-token`, `payment-service` (host), `payment-service-token`. The
+two apps never overwrite each other — each token lives in its own namespaced
+slot.
+
+**Proposal summary.** State the branch used per app: `order-service` — module
+name (branch 1); `payment-service` — module name (branch 1). No clarification
+was needed (no collision). Each bundle is complete on its own (producer +
+consumer + host + env var, all carrying the same key).
+
+> **Detection tip for the AI assistant:** before proposing any namespaced
+> bundle, run `list_project_endpoints` and read the ambient `moduleNames` set
+> to detect multi-app workspaces; resolve the key per app via the order above
+> (module name → `spring.application.name` via `read_rule_file` + consent gate
+> → `ask_clarification`); call `get_existing_rules_for_key` for each key to
+> avoid duplicate host / header rules scoped to the same namespace; record the
+> resolution branch per app in the proposal summary. **Propose one complete
+> bundle per app** — a namespaced consumer header without its matching producer
+> script (or vice versa) is still a broken chain.
+
+---
+
 ## Recipes
 
 ### 1. Rename an API endpoint

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/AmbientPerceptionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/AmbientPerceptionTest.kt
@@ -1,10 +1,14 @@
 package com.itangcent.easyapi.ai.agent
 
+import com.intellij.openapi.application.ApplicationManager
+import com.itangcent.easyapi.settings.module.GeneralSettings
+import com.itangcent.easyapi.settings.settings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import java.util.Locale
 
 /**
@@ -117,5 +121,249 @@ class AmbientPerceptionTest : EasyApiLightCodeInsightFixtureTestCase() {
         val ambient = AmbientPerception.capture(project)
 
         assertEquals("ko-KR", ambient.userLanguage)
+    }
+
+    // ── moduleNames — cached set of API-bearing modules ──
+
+    fun testModuleNamesPopulatedFromApiBearingModules() {
+        // The light fixture has a single module (myFixture.module). Adding a
+        // @RestController class to it makes that module API-bearing, so its
+        // name must surface on ambient.moduleNames. (Two modules cannot be
+        // created in a LightCodeInsightFixture, so this asserts the
+        // single-module case.)
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+        addApiBearingController()
+
+        val ambient = AmbientPerception.capture(project)
+
+        val fixtureModule = myFixture.module.name
+        assertTrue(
+            "moduleNames should contain the API-bearing fixture module '$fixtureModule': ${ambient.moduleNames}",
+            ambient.moduleNames.contains(fixtureModule)
+        )
+    }
+
+    fun testModuleNamesEmptyWhenNoApiModules() {
+        // No API-bearing classes in the fixture → moduleNames must be an
+        // empty list (never null — the field defaults to emptyList()).
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+
+        val ambient = AmbientPerception.capture(project)
+
+        assertNotNull("moduleNames must never be null", ambient.moduleNames)
+        assertTrue(
+            "moduleNames should be empty when no API-bearing modules exist: ${ambient.moduleNames}",
+            ambient.moduleNames.isEmpty()
+        )
+    }
+
+    // ── frameworkHints — detected web frameworks ──
+
+    fun testFrameworkHintsFromRecognizers() {
+        // A @RestController class is recognized by SpringControllerRecognizer
+        // (always enabled) → "SpringMVC". With feignEnable=true, a @FeignClient
+        // class is recognized by FeignClientRecognizer → "Feign". Both must
+        // surface on ambient.frameworkHints from the same PSI scan that
+        // populates moduleNames (single scan, ~zero extra cost).
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+        enableFeign()
+        try {
+            addApiBearingController()
+            addFeignClientClass()
+
+            val ambient = AmbientPerception.capture(project)
+
+            assertTrue(
+                "frameworkHints should contain SpringMVC: ${ambient.frameworkHints}",
+                ambient.frameworkHints.contains("SpringMVC")
+            )
+            assertTrue(
+                "frameworkHints should contain Feign (feignEnable=true): ${ambient.frameworkHints}",
+                ambient.frameworkHints.contains("Feign")
+            )
+        } finally {
+            disableFeign()
+        }
+    }
+
+    fun testFeignHintGatedWhenFeignDisabled() {
+        // Req 9.3: with feignEnable=false (the default), the FeignClient
+        // annotation FQN is excluded from allTargetAnnotations, so even with a
+        // @FeignClient class present in the fixture, "Feign" must NOT appear
+        // in frameworkHints — settings gates are respected automatically.
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+        // Explicitly disable feign (default) to be robust against any
+        // application-scoped settings leakage from other tests.
+        disableFeign()
+        addFeignClientClass()
+
+        val ambient = AmbientPerception.capture(project)
+
+        assertFalse(
+            "Feign must NOT appear in frameworkHints when feignEnable=false: ${ambient.frameworkHints}",
+            ambient.frameworkHints.contains("Feign")
+        )
+    }
+
+    fun testFrameworkHintsEmptyWhenNoApiClasses() {
+        // No API-bearing classes in the fixture → frameworkHints must be an
+        // empty list (never null — the field defaults to emptyList()).
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+
+        val ambient = AmbientPerception.capture(project)
+
+        assertNotNull("frameworkHints must never be null", ambient.frameworkHints)
+        assertTrue(
+            "frameworkHints should be empty when no API-bearing classes exist: ${ambient.frameworkHints}",
+            ambient.frameworkHints.isEmpty()
+        )
+    }
+
+    fun testFrameworkHintsCarryNoEnvVarKeysOrValues() {
+        // NFR-5 / Req 9.5: frameworkHints carries only short framework labels
+        // — never env-var keys or values from the Environments panel. Even with
+        // a controller present (so capture ran the recognizer scan) and an
+        // env-var key/value in the process environment, neither may appear in
+        // frameworkHints.
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+        addApiBearingController()
+        System.setProperty("STRIPE_SECRET_KEY", "sk_test_leak")
+        try {
+            val ambient = AmbientPerception.capture(project)
+
+            assertTrue(
+                "frameworkHints should be populated (capture ran): ${ambient.frameworkHints}",
+                ambient.frameworkHints.isNotEmpty()
+            )
+            assertFalse(
+                "frameworkHints must not carry env-var keys (STRIPE_SECRET_KEY): ${ambient.frameworkHints}",
+                ambient.frameworkHints.any { it.contains("STRIPE_SECRET_KEY") }
+            )
+            assertFalse(
+                "frameworkHints must not carry env-var values (sk_test_leak): ${ambient.frameworkHints}",
+                ambient.frameworkHints.any { it.contains("sk_test_leak") }
+            )
+        } finally {
+            System.clearProperty("STRIPE_SECRET_KEY")
+        }
+    }
+
+    // ── Privacy — no env-var keys or values leak ──
+
+    fun testAmbientCarriesNoEnvVarKeysOrValues() {
+        // The Ambient data class carries only module names — never env-var
+        // keys or values from the Environments panel. This pins the contract:
+        // even with a controller present (so capture did real work) and an
+        // env-var key/value present in the process environment, neither may
+        // appear anywhere on the captured Ambient.
+        savedLocale = Locale.getDefault()
+        Locale.setDefault(Locale.ENGLISH)
+        addApiBearingController()
+        System.setProperty("STRIPE_SECRET_KEY", "sk_test_leak")
+        try {
+            val ambient = AmbientPerception.capture(project)
+
+            assertTrue(
+                "moduleNames should be populated (capture ran): ${ambient.moduleNames}",
+                ambient.moduleNames.isNotEmpty()
+            )
+            val dump = ambient.toString()
+            assertFalse(
+                "Ambient must not carry env-var keys (STRIPE_SECRET_KEY): $dump",
+                dump.contains("STRIPE_SECRET_KEY")
+            )
+            assertFalse(
+                "Ambient must not carry env-var values (sk_test_leak): $dump",
+                dump.contains("sk_test_leak")
+            )
+        } finally {
+            System.clearProperty("STRIPE_SECRET_KEY")
+        }
+    }
+
+    /**
+     * Adds a Spring `@RestController`-annotated class to the fixture so the
+     * fixture module becomes API-bearing. Mirrors the fixture style of
+     * `FindClassesByAnnotationToolTest` — `AnnotatedElementsSearch` needs the
+     * annotation type resolvable on the classpath plus an annotated class.
+     */
+    private fun addApiBearingController() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "org/springframework/web/bind/annotation/RestController.java",
+                """
+                package org.springframework.web.bind.annotation;
+                public @interface RestController {}
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "org/springframework/stereotype/Controller.java",
+                """
+                package org.springframework.stereotype;
+                public @interface Controller {}
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/OrderController.java",
+                """
+                package com.example;
+                @org.springframework.web.bind.annotation.RestController
+                public class OrderController {}
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Adds a Spring Cloud `@FeignClient`-annotated interface to the fixture.
+     * The annotation type stub must be resolvable on the classpath for
+     * `AnnotatedElementsSearch` to find annotated classes (mirrors
+     * [addApiBearingController] style).
+     */
+    private fun addFeignClientClass() {
+        ApplicationManager.getApplication().runWriteAction {
+            myFixture.addFileToProject(
+                "org/springframework/cloud/openfeign/FeignClient.java",
+                """
+                package org.springframework.cloud.openfeign;
+                public @interface FeignClient {}
+                """.trimIndent()
+            )
+            myFixture.addFileToProject(
+                "com/example/OrderFeignClient.java",
+                """
+                package com.example;
+                @org.springframework.cloud.openfeign.FeignClient
+                public interface OrderFeignClient {}
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Enables the Feign framework recognizer (`feignEnable=true`) and persists
+     * via [settingBinder] so `CompositeApiClassRecognizer` rebuilds its
+     * cached recognizers. Always pair with [disableFeign] in a `finally`.
+     */
+    private fun enableFeign() {
+        val gs = project.settings<GeneralSettings>()
+        gs.feignEnable = true
+        settingBinder.save(gs)
+    }
+
+    /**
+     * Restores `feignEnable=false` (the default) and persists. Guards against
+     * application-scoped settings leaking across test methods.
+     */
+    private fun disableFeign() {
+        val gs = project.settings<GeneralSettings>()
+        gs.feignEnable = false
+        settingBinder.save(gs)
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/agent/SystemPromptBuilderTest.kt
@@ -96,6 +96,37 @@ class SystemPromptBuilderTest {
     }
 
     @Test
+    fun `preamble mentions multi-app namespacing`() {
+        // Per-app env-var namespacing: the preamble must teach the agent to
+        // resolve a namespace key and namespace every env var in a workflow
+        // bundle by that key. The full recipe lives in rule-guide.md; the
+        // preamble carries only the condensed detection + on-demand-fetch
+        // pointer (Decision 5).
+        val msg = SystemPromptBuilder.build()
+        val text = msg.content
+        Assert.assertTrue(
+            "preamble should mention the Multi-app namespacing subsection",
+            text.contains("Multi-app namespacing")
+        )
+        Assert.assertTrue(
+            "preamble should mention the namespace-key resolution order (module name)",
+            text.contains("module name", ignoreCase = true)
+        )
+        Assert.assertTrue(
+            "preamble should mention the namespace-key resolution order (spring.application.name)",
+            text.contains("spring.application.name")
+        )
+        Assert.assertTrue(
+            "preamble should mention the namespace-key resolution order (ask_clarification)",
+            text.contains("ask_clarification")
+        )
+        Assert.assertTrue(
+            "preamble should name get_module_dependency_graph tool",
+            text.contains("get_module_dependency_graph")
+        )
+    }
+
+    @Test
     fun `ambient message includes project name editing file and existing files`() {
         val msg = SystemPromptBuilder.ambient(
             Ambient(
@@ -185,6 +216,86 @@ class SystemPromptBuilderTest {
         )
     }
 
+    // ── Ambient module-names hint  ─────────────────────────────────
+
+    @Test
+    fun `ambient message renders module names when moduleNames is non-empty`() {
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                moduleNames = listOf("order-service", "payment-service")
+            )
+        )
+        val text = msg.content
+        Assert.assertTrue(
+            "ambient should include 'modules: order-service, payment-service' when moduleNames is non-empty: $text",
+            text.contains("modules: order-service, payment-service")
+        )
+    }
+
+    @Test
+    fun `ambient message omits module names segment when moduleNames is empty`() {
+        // Mirrors the existing userLanguage null-skip pattern — don't surface
+        // empty signals (a workspace with no API-bearing modules yields the
+        // default emptyList(), which carries no useful perception).
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                moduleNames = emptyList()
+            )
+        )
+        val text = msg.content
+        Assert.assertFalse(
+            "ambient should NOT include a 'modules:' segment when moduleNames is empty: $text",
+            text.contains("modules:")
+        )
+    }
+
+    // ── Ambient framework-hints  ─────────────────────────────────
+
+    @Test
+    fun `ambient message renders framework hints when frameworkHints is non-empty`() {
+        // The detected web-framework labels are surfaced so the agent knows
+        // which frameworks are active without a list_project_endpoints call.
+        // Conditional-append style — mirrors moduleNames/userLanguage.
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                frameworkHints = listOf("SpringMVC", "Feign")
+            )
+        )
+        val text = msg.content
+        Assert.assertTrue(
+            "ambient should include 'frameworks active: SpringMVC, Feign' when frameworkHints is non-empty: $text",
+            text.contains("frameworks active: SpringMVC, Feign")
+        )
+    }
+
+    @Test
+    fun `ambient message omits framework segment when frameworkHints is empty`() {
+        // Empty list → no hint (a workspace with no recognized frameworks yields
+        // the default emptyList(), which carries no useful perception).
+        val msg = SystemPromptBuilder.ambient(
+            Ambient(
+                projectName = "demo",
+                editingRuleFile = null,
+                existingRuleFiles = emptyList(),
+                frameworkHints = emptyList()
+            )
+        )
+        val text = msg.content
+        Assert.assertFalse(
+            "ambient should NOT include a 'frameworks active:' segment when frameworkHints is empty: $text",
+            text.contains("frameworks active:")
+        )
+    }
+
     // ── Token-budget tripwire (review Issue #8) ──
 
     @Test
@@ -193,9 +304,15 @@ class SystemPromptBuilderTest {
         // NFR-3 targets a ~600-token preamble budget. T5.1 added a condensed
         // "## Workflow-pattern detection" section (~2.8k chars). This tripwire catches
         // unexpected growth beyond the current actual length + a small headroom.
+        //
+        // Ceiling raised from 16_500 → 17_800 for the condensed "### Multi-app
+        // namespacing" subsection added under "## Workflow-pattern detection"
+        // (per Decision 5: ~600-800-char target subsection + on-demand fetch via
+        // `get_plugin_doc name="rule-guide"` for the full recipe; ceiling is the new
+        // actual ~16.8k + ~1k headroom).
         val msg = SystemPromptBuilder.build()
         val content = msg.content
-        val ceiling = 16_500 // post-script-context-isolation-rule actual ~15.6k + ~0.9k headroom
+        val ceiling = 17_800 // raised for Multi-app namespacing subsection (Decision 5): actual ~16.8k + ~1k headroom
         Assert.assertTrue(
             "Preamble content length (${content.length} chars) must stay under $ceiling chars " +
                 "to stay within NFR-3's token budget. If a future section is added, raise the " +

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphToolTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/GetModuleDependencyGraphToolTest.kt
@@ -1,0 +1,259 @@
+package com.itangcent.easyapi.ai.tools
+
+import com.itangcent.easyapi.ai.AiRuntimeConfig
+import com.itangcent.easyapi.ai.AiProvider
+import com.itangcent.easyapi.ai.agent.AgentMemory
+import com.itangcent.easyapi.ai.agent.ApprovalGate
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.config.source.RuleFileResolver
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+
+/**
+ * Tests for [GetModuleDependencyGraphTool].
+ *
+ * The IntelliJ `LightJavaCodeInsightFixture` supports only ONE module by
+ * default, so a true multi-module fixture with `ModuleOrderEntry` edges is
+ * impractical here. Per the task's guidance, the structural rendering logic
+ * (adjacency list, 24-node cap summary collapse, connected-component
+ * clustering, privacy) is extracted into the pure, testable
+ * [GetModuleDependencyGraphTool.renderGraph] companion function and exercised
+ * directly. The tool-kind / parametersSchema / registration are asserted
+ * against the tool instance, and a smoke test runs `execute()` against the
+ * single-module light fixture to confirm it returns a `ToolResult.Text` and
+ * never throws.
+ *
+ * What is NOT covered here (limitation of the light fixture): a multi-module
+ * fixture exercising live `ModuleOrderEntry` edges, `LibraryOrderEntry` /
+ * `SdkOrderEntry` exclusion at the `ModuleRootManager` level, and a per-module
+ * `ModuleRootManager` read throwing. The pure-function tests cover the
+ * rendering contract that the `execute()` data-collection feeds; the
+ * `execute()` smoke test covers the never-throws / best-effort contract.
+ */
+class GetModuleDependencyGraphToolTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private fun ctx(): ToolContext = ToolContext(
+        project = project,
+        configReader = ConfigReader.getInstance(project),
+        aiSettings = AiRuntimeConfig(
+            provider = AiProvider.OPENAI,
+            baseUrl = "", apiKey = "", model = "",
+            requestTimeoutSec = 30, maxRequests = 8
+        ),
+        ruleFileResolver = RuleFileResolver(project),
+        workingMemory = AgentMemory(),
+        approvals = NoOpApprovalGate()
+    )
+
+    // --- Pure rendering: adjacency list ---
+
+    fun testRenderAdjacencyForSimpleGraph() {
+        val adjacency = linkedMapOf(
+            "a" to listOf("b", "c"),
+            "b" to listOf("c"),
+            "c" to emptyList()
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        val lines = rendered.split("\n")
+        // Order-stable: sorted by module name.
+        Assert.assertEquals("a: [b, c]", lines[0])
+        Assert.assertEquals("b: [c]", lines[1])
+        Assert.assertEquals("c: []", lines[2])
+    }
+
+    fun testRenderAdjacencySortsForDeterminism() {
+        // Unsorted input — the renderer must sort names + deps.
+        val adjacency = linkedMapOf(
+            "zeta" to listOf("alpha", "beta"),
+            "alpha" to listOf("beta"),
+            "beta" to emptyList()
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        val lines = rendered.split("\n")
+        Assert.assertEquals("alpha: [beta]", lines[0])
+        Assert.assertEquals("beta: []", lines[1])
+        Assert.assertEquals("zeta: [alpha, beta]", lines[2])
+    }
+
+    fun testRenderAdjacencyDeduplicatesDependencies() {
+        // A duplicated dependency must collapse to one edge.
+        val adjacency = mapOf(
+            "a" to listOf("b", "b", "c")
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        Assert.assertTrue("expected deduped deps, got: $rendered",
+            rendered.contains("a: [b, c]"))
+    }
+
+    fun testRenderEmptyGraphReturnsPlaceholder() {
+        val rendered = GetModuleDependencyGraphTool.renderGraph(emptyMap())
+        // No modules — the tool returns a short placeholder, never an error.
+        Assert.assertTrue("expected placeholder, got: $rendered", rendered.isNotBlank())
+    }
+
+    // --- Pure rendering: library / SDK exclusion (by design) ---
+    //
+    // The `execute()` implementation collects only `ModuleOrderEntry` edges
+    // (it skips `LibraryOrderEntry` / `SdkOrderEntry`), so the adjacency map
+    // handed to `renderGraph` never contains library/SDK names. This test
+    // asserts the contract the data-collection layer must uphold: given a map
+    // that already reflects module-only edges, no library/SDK token appears.
+
+    fun testRenderOutputContainsOnlyModuleNamesAndEdges() {
+        val adjacency = mapOf(
+            "order-web" to listOf("order-service", "common"),
+            "order-service" to listOf("common"),
+            "common" to emptyList()
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        // Only module names + the structural edge syntax should appear.
+        Assert.assertTrue("should render order-web", rendered.contains("order-web"))
+        Assert.assertTrue("should render order-service", rendered.contains("order-service"))
+        Assert.assertTrue("should render common", rendered.contains("common"))
+        // No library / SDK identifiers leak in (they never enter the map).
+        Assert.assertFalse("guava must not appear", rendered.contains("guava"))
+        Assert.assertFalse("jdk must not appear", rendered.contains("jdk"))
+        Assert.assertFalse("stdlib must not appear", rendered.contains("stdlib"))
+    }
+
+    // --- Pure rendering: 24-node cap summary collapse ---
+
+    fun testSummaryCollapseAboveNodeCap() {
+        // > 24 modules → summary form, NOT the full adjacency list.
+        val adjacency = (1..25).associate { i ->
+            "mod$i" to (if (i < 25) listOf("mod${i + 1}") else emptyList())
+        }
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        // Summary header, not the per-node adjacency lines.
+        Assert.assertTrue(
+            "expected summary form, got: $rendered",
+            rendered.startsWith("25 modules in 1 disjoint clusters:")
+        )
+        // The per-node `name: [` adjacency lines must NOT appear.
+        Assert.assertFalse(
+            "summary must not include adjacency lines, got: $rendered",
+            rendered.contains("mod1: [")
+        )
+    }
+
+    fun testSummaryCollapseReportsDisjointClusters() {
+        // 30 nodes split into 3 disjoint clusters of 10.
+        val prefixes = listOf("a", "b", "c")
+        val adjacency = buildMap {
+            for (cluster in prefixes.indices) {
+                val prefix = prefixes[cluster]
+                for (i in 1..10) {
+                    val name = "$prefix$i"
+                    put(name, if (i < 10) listOf("$prefix${i + 1}") else emptyList())
+                }
+            }
+        }
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        Assert.assertTrue(
+            "expected 3 disjoint clusters, got: $rendered",
+            rendered.startsWith("30 modules in 3 disjoint clusters:")
+        )
+    }
+
+    fun testFullAdjacencyRenderedAtNodeCapBoundary() {
+        // Exactly NODE_CAP (24) nodes — still the full adjacency form.
+        val adjacency = (1..24).associate { i ->
+            "mod$i" to emptyList<String>()
+        }
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        Assert.assertFalse(
+            "at the cap boundary the full adjacency should still render, got: $rendered",
+            rendered.contains("disjoint clusters")
+        )
+        Assert.assertTrue(
+            "should include first node adjacency, got: $rendered",
+            rendered.contains("mod1: []")
+        )
+    }
+
+    // --- Best-effort failure handling ---
+    //
+    // A light fixture cannot easily make `ModuleRootManager` throw for one
+    // module. The contract is asserted at two levels: (1) the pure renderer
+    // tolerates a partially-populated map (a module whose read failed is
+    // simply absent from the map — it is omitted, not an error); (2) the
+    // live `execute()` call returns a `ToolResult.Text` and never throws.
+
+    fun testRendererToleratesPartiallyPopulatedMap() {
+        // Module "broken" was omitted because its read failed; the others
+        // render normally. The renderer must not require every module as a
+        // key, and a dependency target with no key of its own is rendered
+        // as a leaf in the summary path.
+        val adjacency = mapOf(
+            "a" to listOf("broken", "c"),
+            "c" to emptyList()
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        Assert.assertTrue("a's edges should render, got: $rendered",
+            rendered.contains("a: [broken, c]"))
+        Assert.assertTrue("c leaf should render, got: $rendered", rendered.contains("c: []"))
+    }
+
+    fun testExecuteOnLightFixtureReturnsTextAndNeverThrows() {
+        // The light fixture has a single module; execute() must succeed and
+        // return a Text result (best-effort: never throws).
+        val result = runBlocking {
+            GetModuleDependencyGraphTool().execute(emptyMap(), ctx())
+        }
+        Assert.assertTrue("expected Text result, got: $result", result is ToolResult.Text)
+        Assert.assertTrue(
+            "expected non-blank output, got: ${(result as ToolResult.Text).value}",
+            (result).value.isNotBlank()
+        )
+    }
+
+    // --- Privacy (NFR-5 / Req 8.5) ---
+
+    fun testRenderedOutputCarriesNoEnvVarMaterial() {
+        // The renderer is structural: only module names + edges. A typical
+        // env-var secret must never appear even if a module were named after
+        // an env key — and there is no channel for env-var *values* at all.
+        val adjacency = mapOf(
+            "order-service" to listOf("common"),
+            "common" to emptyList()
+        )
+        val rendered = GetModuleDependencyGraphTool.renderGraph(adjacency)
+        Assert.assertFalse("must not leak a secret token", rendered.contains("STRIPE_SECRET_KEY"))
+        Assert.assertFalse("must not leak a bearer token", rendered.contains("Bearer"))
+        Assert.assertFalse("must not leak a placeholder value", rendered.contains("\${"))
+        Assert.assertFalse("must not leak an env-var value syntax", rendered.contains("sk-"))
+    }
+
+    // --- Tool-kind (NFR-6) ---
+
+    fun testToolKindIsPerception() {
+        val tool = GetModuleDependencyGraphTool()
+        Assert.assertEquals(ToolKind.PERCEPTION, tool.kind)
+    }
+
+    fun testRequiresApprovalIsFalse() {
+        Assert.assertFalse(GetModuleDependencyGraphTool().requiresApproval)
+    }
+
+    fun testParametersSchemaIsEmpty() {
+        Assert.assertTrue(
+            "parametersSchema must be empty (no args)",
+            GetModuleDependencyGraphTool().parametersSchema.isEmpty()
+        )
+    }
+
+    // --- Registration ---
+
+    fun testIsRegisteredInStandardToolSet() {
+        val names = standardRuleTools().map { it.name }
+        Assert.assertTrue(
+            "get_module_dependency_graph must be registered",
+            names.contains("get_module_dependency_graph")
+        )
+    }
+
+    private class NoOpApprovalGate : ApprovalGate {
+        override suspend fun await(toolName: String, args: Map<String, Any?>): Boolean = true
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/ai/tools/PerceptionToolsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/ai/tools/PerceptionToolsTest.kt
@@ -378,12 +378,13 @@ class PerceptionToolsTest : EasyApiLightCodeInsightFixtureTestCase() {
         Assert.assertTrue("find_classes_by_annotation", names.contains("find_classes_by_annotation"))
         Assert.assertTrue("find_classes_by_supertype", names.contains("find_classes_by_supertype"))
         Assert.assertTrue("get_existing_rules_for_key", names.contains("get_existing_rules_for_key"))
+        Assert.assertTrue("get_module_dependency_graph", names.contains("get_module_dependency_graph"))
         Assert.assertTrue("propose_rule_content", names.contains("propose_rule_content"))
         Assert.assertFalse(
             "write_rule_file must NOT be registered in v1",
             names.contains("write_rule_file")
         )
-        Assert.assertEquals("exactly 11 tools in v1", 11, tools.size)
+        Assert.assertEquals("exactly 12 tools in v1", 12, tools.size)
     }
 
     // --- helpers ---

--- a/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideContentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/docs/RuleGuideContentTest.kt
@@ -1,0 +1,172 @@
+package com.itangcent.easyapi.docs
+
+import com.itangcent.easyapi.testFramework.ResourceLoader
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Content-assertion test for the `rule-guide.md` "Multi-Application Namespace"
+ * section (Req 6.1, 6.5).
+ *
+ * The existing `RuleGuideWorkflowCatalogTest.kt` is an empty stub (a single
+ * `package com.itangcent` line) and cannot be extended; this dedicated test is
+ * the canonical assertion that the section exists and covers the load-bearing
+ * topics the agent relies on at authoring time.
+ *
+ * Reads the resource via [ResourceLoader.readRaw] (CRLF→LF collapse) per the
+ * AGENTS.md cross-platform golden-file rule — never [kotlin.io.path] /
+ * `File.readText()`. Plain JUnit: no `Project`, no PSI/VFS, no IntelliJ
+ * fixture required (the resource ships on the main classpath).
+ */
+class RuleGuideContentTest {
+
+    private val ruleGuide: String by lazy {
+        ResourceLoader.readRaw(RULE_GUIDE_RESOURCE)
+    }
+
+    @Test
+    fun `rule guide contains the Multi-Application Namespace section header`() {
+        assertTrue(
+            "rule-guide.md must contain a '## Multi-Application Namespace' section header",
+            ruleGuide.contains("## Multi-Application Namespace")
+        )
+    }
+
+    @Test
+    fun `section documents the namespace-key resolution order`() {
+        // The three branches of the resolution order (Req 1.1/1.4/1.5).
+        assertTrue(
+            "section must reference module name as the first resolution branch",
+            ruleGuide.contains("Module name", ignoreCase = true)
+        )
+        assertTrue(
+            "section must reference spring.application.name as the second resolution branch",
+            ruleGuide.contains("spring.application.name")
+        )
+        assertTrue(
+            "section must reference ask_clarification as the final resolution branch",
+            ruleGuide.contains("ask_clarification")
+        )
+    }
+
+    @Test
+    fun `section documents the per-app env-var naming convention`() {
+        // The full naming convention surface (Req 1.1, 3.1, 3.2): host, bearer
+        // token, and login params, all namespaced by <key>.
+        assertTrue(
+            "section must document the host placeholder {{<key>}}",
+            ruleGuide.contains("{{<key>}}")
+        )
+        assertTrue(
+            "section must document the bearer-token placeholder {{<key>-token}}",
+            ruleGuide.contains("{{<key>-token}}")
+        )
+        assertTrue(
+            "section must document the login-username placeholder {{<key>-username}}",
+            ruleGuide.contains("{{<key>-username}}")
+        )
+        assertTrue(
+            "section must document the login-password placeholder {{<key>-password}}",
+            ruleGuide.contains("{{<key>-password}}")
+        )
+    }
+
+    @Test
+    fun `section documents the multi-app bundle-split rule`() {
+        // Req 4.2: one propose_rule_content per app; bundle integrity still
+        // required per app.
+        assertTrue(
+            "section must reference the propose_rule_content tool",
+            ruleGuide.contains("propose_rule_content")
+        )
+        assertTrue(
+            "section must describe splitting bundles per app (multi-app detection)",
+            ruleGuide.contains("bundle", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `section contains a worked example with two apps in one workspace`() {
+        // The flagship worked example: order-service + payment-service sharing
+        // one workspace, each namespaced independently.
+        assertTrue(
+            "section must contain a worked example with the order-service app",
+            ruleGuide.contains("order-service")
+        )
+        assertTrue(
+            "worked example must contain a second app (payment-service)",
+            ruleGuide.contains("payment-service")
+        )
+        assertTrue(
+            "worked example must show a namespaced host placeholder for one of the apps",
+            ruleGuide.contains("{{order-service}}") || ruleGuide.contains("{{payment-service}}")
+        )
+    }
+
+    @Test
+    fun `section records the body-level namespacing limitation`() {
+        // Req 5.5 (deferred per Decision 3): the v1 enabler converts header
+        // values only; param/body conversion is deferred. The agent must not
+        // promise body-level namespacing.
+        assertTrue(
+            "section must document the body-level namespacing limitation (Req 5.5)",
+            ruleGuide.contains("body", ignoreCase = true) &&
+                (ruleGuide.contains("deferred", ignoreCase = true) ||
+                    ruleGuide.contains("limitation", ignoreCase = true))
+        )
+    }
+
+    @Test
+    fun `section records the resolution branch used in the proposal summary`() {
+        // Req 1.5: the proposal summary must state which branch was used and
+        // the resulting key so the user can correct a wrong guess.
+        assertTrue(
+            "section must instruct the agent to record the resolution branch in the proposal summary",
+            ruleGuide.contains("proposal summary", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `section documents the dependency-graph clustering step`() {
+        // Req 4.1, 8.4: the rule-guide must name get_module_dependency_graph
+        // as the tool to call when N > 1 to cluster modules into app groups.
+        assertTrue(
+            "section must reference the get_module_dependency_graph tool",
+            ruleGuide.contains("get_module_dependency_graph")
+        )
+    }
+
+    @Test
+    fun `section documents the namespace-key normalization convention and examples`() {
+        // Req 2.1: the normalization convention lives as prose in the rule-guide
+        // (it governs the LLM agent's behavior, which performs the transform in
+        // its own reasoning and bakes the literal — no Kotlin code calls a
+        // normalizer). The load-bearing examples from Req 2.1 MUST be present so
+        // the agent (and humans) can predict the result.
+        assertTrue(
+            "section must state the camelCase splitting rule",
+            ruleGuide.contains("camelCase", ignoreCase = true)
+        )
+        assertTrue(
+            "section must state the allowed character class [a-z0-9-]",
+            ruleGuide.contains("[a-z0-9-]")
+        )
+        // The three canonical Req 2.1 examples.
+        assertTrue(
+            "section must show the OrderService -> order-service example",
+            ruleGuide.contains("OrderService") && ruleGuide.contains("order-service")
+        )
+        assertTrue(
+            "section must show the order_service -> order-service example",
+            ruleGuide.contains("order_service")
+        )
+        assertTrue(
+            "section must show the admin portal -> admin-portal example",
+            ruleGuide.contains("admin portal") && ruleGuide.contains("admin-portal")
+        )
+    }
+
+    companion object {
+        private const val RULE_GUIDE_RESOURCE = "/docs/knowledge-base/rule-guide.md"
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/PlaceholderSyntaxConverterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/PlaceholderSyntaxConverterTest.kt
@@ -1,0 +1,174 @@
+package com.itangcent.easyapi.exporter.channel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Plain-JUnit tests for [PlaceholderSyntaxConverter] (no IntelliJ fixture required).
+ *
+ * The `isResolvable` lambda is supplied by the caller; in tests a simple lambda
+ * treats `resolvedVar` as resolvable and everything else as unresolved.
+ */
+class PlaceholderSyntaxConverterTest {
+
+    /** Treats only `resolvedVar` as config-resolvable; everything else is unresolved. */
+    private val resolvedVarOnly: (String) -> Boolean = { name -> name == "resolvedVar" }
+
+    @Test
+    fun `unresolved dollar-brace placeholder is rewritten to double-brace for POSTMAN`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer \${order-service-token}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer {{order-service-token}}", result)
+    }
+
+    @Test
+    fun `unresolved dollar-brace placeholder is rewritten to hoppscotch syntax for HOPPSCOTCH`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer \${order-service-token}",
+            target = PlaceholderTargetSyntax.HOPPSCOTCH,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer <<order-service-token>>", result)
+    }
+
+    @Test
+    fun `resolved placeholder is left untouched for POSTMAN`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Host: \${resolvedVar}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Host: \${resolvedVar}", result)
+    }
+
+    @Test
+    fun `resolved placeholder is left untouched for HOPPSCOTCH`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Host: \${resolvedVar}",
+            target = PlaceholderTargetSyntax.HOPPSCOTCH,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Host: \${resolvedVar}", result)
+    }
+
+    @Test
+    fun `regex-capture reference numeric placeholder is left untouched`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Basic \${1}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Basic \${1}", result)
+    }
+
+    @Test
+    fun `multi-digit regex-capture reference is left untouched`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Basic \${12}",
+            target = PlaceholderTargetSyntax.HOPPSCOTCH,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Basic \${12}", result)
+    }
+
+    @Test
+    fun `value with no dollar-brace returns unchanged byte-for-byte (fast path)`() {
+        val value = "Bearer abc123 plain text no placeholders here"
+        val result = PlaceholderSyntaxConverter.convert(
+            value = value,
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        // Fast path: the same instance is returned (no allocation).
+        assertSame(value, result)
+        assertEquals(value, result)
+    }
+
+    @Test
+    fun `mixed resolved and unresolved placeholders in one value`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "\${resolvedVar} Bearer \${unresolvedVar}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("\${resolvedVar} Bearer {{unresolvedVar}}", result)
+    }
+
+    @Test
+    fun `already-present double-brace placeholder is left untouched for POSTMAN`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer {{existing-token}}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer {{existing-token}}", result)
+    }
+
+    @Test
+    fun `already-present hoppscotch placeholder is left untouched for HOPPSCOTCH`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer <<existing-token>>",
+            target = PlaceholderTargetSyntax.HOPPSCOTCH,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer <<existing-token>>", result)
+    }
+
+    @Test
+    fun `malformed dollar-brace with no closing brace is left as-is`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer \${unterminated",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer \${unterminated", result)
+    }
+
+    @Test
+    fun `UTF-8 multi-byte header value preserves bytes outside the placeholder`() {
+        val value = "应用令牌: \${order-service-token} 中文测试"
+        val result = PlaceholderSyntaxConverter.convert(
+            value = value,
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("应用令牌: {{order-service-token}} 中文测试", result)
+    }
+
+    @Test
+    fun `JSON-escaped quotes are preserved during conversion`() {
+        val value = "{\"auth\": \"Bearer \${unresolvedVar}\"}"
+        val result = PlaceholderSyntaxConverter.convert(
+            value = value,
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("{\"auth\": \"Bearer {{unresolvedVar}}\"}", result)
+    }
+
+    @Test
+    fun `multiple unresolved placeholders in one value are all rewritten`() {
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "\${a}\${b}\${c}",
+            target = PlaceholderTargetSyntax.POSTMAN,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("{{a}}{{b}}{{c}}", result)
+    }
+
+    @Test
+    fun `empty dollar-brace pair is not matched by the regex and left as-is`() {
+        // DOLLAR_BRACE_PATTERN requires [^}]+ (one or more non-} chars), so `\${}`
+        // does not match and is left untouched.
+        val result = PlaceholderSyntaxConverter.convert(
+            value = "Bearer \${}",
+            target = PlaceholderTargetSyntax.HOPPSCOTCH,
+            isResolvable = resolvedVarOnly,
+        )
+        assertEquals("Bearer \${}", result)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppHeaderVarConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/hoppscotch/HoppHeaderVarConversionTest.kt
@@ -1,0 +1,122 @@
+package com.itangcent.easyapi.exporter.channel.hoppscotch
+
+import com.itangcent.easyapi.config.ConfigReader
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.HoppKeyValue
+import com.itangcent.easyapi.exporter.channel.hoppscotch.model.hoppscotchGson
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.HttpMetadata
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.ResultLoader
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Formatter-level test for unresolved `${...}` placeholder conversion in Hoppscotch
+ * header values (`${x}` → `<<x>>`).
+ *
+ * Symmetric to `PostmanHeaderVarConversionTest` (Task 4.1) but targets the
+ * Hoppscotch `<<...>>` variable syntax via [HoppscotchFormatter.buildHeaders].
+ *
+ * - _Requirements: Req 5.2, 5.3, 5.4; NFR-3_
+ */
+class HoppHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    /**
+     * `baseUrl` is resolvable via the config layer; `order-service-token` is NOT
+     * (unresolved → converts to `<<order-service-token>>`).
+     */
+    override fun createConfigReader(): ConfigReader? {
+        return TestConfigReader.fromRules(project, "baseUrl" to "https://api.example.com")
+    }
+
+    private fun formatter(): HoppscotchFormatter = HoppscotchFormatter(
+        project = project,
+        options = HoppscotchFormatOptions(appendTimestamp = false)
+    )
+
+    /** Invokes the private `buildHeaders` via reflection (same pattern as HoppscotchFormatterPrivateMethodsTest). */
+    private fun invokeBuildHeaders(meta: HttpMetadata): List<HoppKeyValue> {
+        val method = HoppscotchFormatter::class.java.getDeclaredMethod(
+            "buildHeaders", HttpMetadata::class.java
+        )
+        method.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(formatter(), meta) as List<HoppKeyValue>
+    }
+
+    // ==================== Req 5.2: unresolved ${x} → <<x>> ====================
+
+    @Test
+    fun testUnresolvedPlaceholderConvertsToAngleBrackets() {
+        val meta = httpMetadata(
+            path = "/api/orders",
+            method = HttpMethod.GET,
+            headers = listOf(
+                ApiHeader(name = "Authorization", value = "Bearer \${order-service-token}")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals(1, headers.size)
+        assertEquals("Authorization", headers[0].key)
+        assertEquals("Bearer <<order-service-token>>", headers[0].value)
+    }
+
+    // ==================== Req 5.3: resolved ${x} left untouched ====================
+
+    @Test
+    fun testResolvedPlaceholderLeftUntouched() {
+        val meta = httpMetadata(
+            path = "/api/orders",
+            method = HttpMethod.GET,
+            headers = listOf(
+                ApiHeader(name = "X-Base", value = "\${baseUrl}")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals(1, headers.size)
+        assertEquals("\${baseUrl}", headers[0].value)
+    }
+
+    // ==================== Req 5.4: regex-capture ${1} left untouched ====================
+
+    @Test
+    fun testRegexCaptureReferenceLeftUntouched() {
+        val meta = httpMetadata(
+            path = "/api/orders",
+            method = HttpMethod.GET,
+            headers = listOf(
+                ApiHeader(name = "X-Capture", value = "Basic \${1}")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        assertEquals(1, headers.size)
+        assertEquals("Basic \${1}", headers[0].value)
+    }
+
+    // ==================== NFR-3: byte-parity golden (placeholder-free) ====================
+
+    /**
+     * A placeholder-free header set must serialize byte-identically to the
+     * pre-feature golden — the converter's fast path returns the value
+     * unchanged when no `${` is present, so existing single-app exports are
+     * not altered.
+     */
+    @Test
+    fun testPlaceholderFreeHeadersByteParityGolden() {
+        val meta = httpMetadata(
+            path = "/api/orders",
+            method = HttpMethod.GET,
+            headers = listOf(
+                ApiHeader(name = "Authorization", value = "Bearer static-token"),
+                ApiHeader(name = "Accept", value = "application/json")
+            )
+        )
+        val headers = invokeBuildHeaders(meta)
+        val actual = hoppscotchGson(prettyPrint = true).toJson(headers)
+        val expected = ResultLoader.load()
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanHeaderVarConversionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/exporter/channel/postman/PostmanHeaderVarConversionTest.kt
@@ -1,0 +1,108 @@
+package com.itangcent.easyapi.exporter.channel.postman
+
+import com.itangcent.easyapi.exporter.channel.postman.model.PostmanGson
+import com.itangcent.easyapi.exporter.model.ApiEndpoint
+import com.itangcent.easyapi.exporter.model.ApiHeader
+import com.itangcent.easyapi.exporter.model.HttpMethod
+import com.itangcent.easyapi.exporter.model.httpMetadata
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.ResultLoader
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Tests [PostmanFormatter] header-value `${...}` → `{{...}}` conversion for
+ * unresolved placeholders, while leaving resolved placeholders and regex-capture
+ * references untouched.
+ *
+ * Backs Req 5.1, 5.3, 5.4 and the NFR-3 byte-parity guarantee for placeholder-free
+ * single-app exports.
+ *
+ * The test project's rule config defines `baseUrl` so `${baseUrl}` is treated as
+ * resolvable by the config layer (Decision 2 — `ConfigReader.getFirst` is the
+ * resolvability oracle). Namespaced vars like `${order-service-token}` and the
+ * regex-capture `${1}` are exercised against the same config.
+ */
+class PostmanHeaderVarConversionTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    override fun createConfigReader() = TestConfigReader.fromRules(
+        project,
+        "baseUrl" to "https://api.example.com"
+    )
+
+    @Test
+    fun testUnresolvedNamespacedVarConvertedToDoubleBrace(): Unit = runBlocking {
+        val endpoint = endpointWithHeaders(
+            "Get Orders",
+            "Authorization" to "Bearer \${order-service-token}"
+        )
+        val item = formatter().toItem(endpoint)
+        val authHeader = item.request?.header?.firstOrNull { it.key == "Authorization" }
+        assertNotNull(authHeader)
+        assertEquals("Bearer {{order-service-token}}", authHeader?.value)
+    }
+
+    @Test
+    fun testResolvedVarLeftAsDollarBrace(): Unit = runBlocking {
+        val endpoint = endpointWithHeaders(
+            "Get Config",
+            "X-Base" to "\${baseUrl}"
+        )
+        val item = formatter().toItem(endpoint)
+        val header = item.request?.header?.firstOrNull { it.key == "X-Base" }
+        assertNotNull(header)
+        // baseUrl is resolvable via the config layer — left as ${baseUrl} (Req 5.3).
+        assertEquals("\${baseUrl}", header?.value)
+    }
+
+    @Test
+    fun testRegexCaptureReferenceLeftUntouched(): Unit = runBlocking {
+        val endpoint = endpointWithHeaders(
+            "Capture",
+            "X-Capture" to "Basic \${1}"
+        )
+        val item = formatter().toItem(endpoint)
+        val header = item.request?.header?.firstOrNull { it.key == "X-Capture" }
+        assertNotNull(header)
+        // ${1} is a regex-capture reference — left untouched (Req 5.4).
+        assertEquals("Basic \${1}", header?.value)
+    }
+
+    @Test
+    fun testPlaceholderFreeExportByteParity(): Unit = runBlocking {
+        val endpoint = endpointWithHeaders(
+            "Get User",
+            "Authorization" to "Bearer abc123",
+            "Content-Type" to "application/json"
+        )
+        val item = formatter().toItem(endpoint)
+        val actual = PostmanGson.pretty.toJson(item)
+        // NFR-3: a placeholder-free single-app endpoint exports byte-identically
+        // to the pre-feature golden. The converter fast-path returns the value
+        // unchanged when no `${` is present, so the output is unaffected.
+        // Explicit caller class avoids the coroutine-continuation name that
+        // runBlocking injects into the stack trace.
+        val expected = ResultLoader.load(
+            PostmanHeaderVarConversionTest::class.java,
+            "placeholder_free_export"
+        )
+        assertEquals(expected, actual)
+    }
+
+    private fun formatter() = PostmanFormatter(project = project)
+
+    private fun endpointWithHeaders(
+        name: String,
+        vararg headers: Pair<String, String>
+    ): ApiEndpoint = ApiEndpoint(
+        name = name,
+        metadata = httpMetadata(
+            path = "/api/users",
+            method = HttpMethod.GET,
+            headers = headers.map { ApiHeader(name = it.first, value = it.second) }
+        )
+    )
+}

--- a/src/test/resources/result/com.itangcent.easyapi.exporter.channel.hoppscotch.HoppHeaderVarConversionTest.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.exporter.channel.hoppscotch.HoppHeaderVarConversionTest.txt
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "Authorization",
+    "value": "Bearer static-token",
+    "active": true,
+    "description": null
+  },
+  {
+    "key": "Accept",
+    "value": "application/json",
+    "active": true,
+    "description": null
+  }
+]

--- a/src/test/resources/result/com.itangcent.easyapi.exporter.channel.postman.PostmanHeaderVarConversionTest.placeholder_free_export.txt
+++ b/src/test/resources/result/com.itangcent.easyapi.exporter.channel.postman.PostmanHeaderVarConversionTest.placeholder_free_export.txt
@@ -1,0 +1,35 @@
+{
+  "name": "Get User",
+  "request": {
+    "method": "GET",
+    "header": [
+      {
+        "key": "Authorization",
+        "value": "Bearer abc123",
+        "type": "text",
+        "description": ""
+      },
+      {
+        "key": "Content-Type",
+        "value": "application/json",
+        "type": "text",
+        "description": ""
+      }
+    ],
+    "url": {
+      "raw": "{{host}}/api/users",
+      "host": [
+        "{{host}}"
+      ],
+      "path": [
+        "api",
+        "users"
+      ],
+      "query": [],
+      "variable": []
+    },
+    "description": ""
+  },
+  "response": [],
+  "event": []
+}


### PR DESCRIPTION
## Summary

Implements the **Per-Application Environment-Variable Namespace** so the rule-authoring agent namespaces every per-app env var, and adds the one runtime enabler that makes those namespaced variables actually resolve in Postman/Hoppscotch.

The previous workflow-pattern agent (b39ad264) assumed a **single application** per workspace. In a multi-module workspace (`order-service` + `payment-service`), every app exported the same bare env-var names, so:
- Two apps both wrote `Authorization` → the second export overwrote the first's token.
- Every collection pointed at `{{host}}` → all apps shared one host.
- Login params (`username`/`password`) collided across apps.

## Changes

**Runtime enabler (Phase 1–2)**
- `PlaceholderSyntaxConverter` — pure object that rewrites unresolved `${x}` header placeholders into Postman `{{x}}` / Hoppscotch `<<x>>` syntax. Resolved vars and `${1}` regex-capture refs are left untouched; placeholder-free values short-circuit byte-for-byte.
- Wired into `PostmanFormatter.toHttpItem` and `HoppscotchFormatter.buildHeaders` via `ConfigReader.getFirst` as the resolvability oracle.

**Agent perception (Phase 3)**
- `Ambient.moduleNames` + `Ambient.frameworkHints` — cached per `capture()` in a single PSI scan, rendered as `modules:` / `frameworks active:` hints in the system prompt. Privacy-preserving: module/framework labels only, no env-var material.
- `get_module_dependency_graph` — one new read-only `PERCEPTION` tool returning the workspace module adjacency graph (with a 24-node summary cap). Lets the agent cluster API-bearing modules into app groups via connected components instead of over/under-splitting layered apps.

**Knowledge base + preamble (Phase 4)**
- New "Multi-Application Namespace" section in `rule-guide.md` (both the `src/main/resources` and `skills/.../docs` copies) covering namespace-key resolution order, per-app env-var naming convention, multi-app bundle-split rule, and a worked two-app example.
- Condensed "Multi-app namespacing" subsection in `agent-preamble.md` (token-budget ceiling raised).
- Mirrored guidance in the external `skills/easy-yapi-assistant/SKILL.md`.

## Design decisions (NFRs)
- **NFR-1:** zero new `RuleKeys` — namespacing uses only existing keys' *values*.
- **NFR-2:** no new `pm.*` / `session.*` bindings; the only runtime change is formatter-level `${}`→`{{}}`.
- **NFR-3:** single-app placeholder-free exports are byte-identical (golden parity tests for both channels).
- **NFR-5:** no env-var keys/values enter the transcript — verified by privacy assertions in `AmbientPerceptionTest` and `GetModuleDependencyGraphToolTest`.
- **NFR-6:** exactly one new tool, `get_module_dependency_graph`, `PERCEPTION` kind, no args.

## Known limitation
Param/body placeholder conversion (Req 5.5) is **deferred** per design Decision 3 — only header values convert in v1. This is recorded as a known limitation in the rule-guide so the agent does not promise body-level namespacing.

## Test plan
- [x] `PlaceholderSyntaxConverterTest` — pure-utility cases (resolved/unresolved, `${1}`, UTF-8, JSON-escaped, fast path)
- [x] `PostmanHeaderVarConversionTest` / `HoppHeaderVarConversionTest` — formatter wiring + NFR-3 byte-parity goldens
- [x] `AmbientPerceptionTest` — `moduleNames` + `frameworkHints` capture + privacy assertions
- [x] `SystemPromptBuilderTest` — ambient rendering + preamble namespacing mentions + raised token ceiling
- [x] `GetModuleDependencyGraphToolTest` — adjacency, library/SDK exclusion, 24-node cap, failure handling, privacy, tool kind
- [x] `RuleGuideContentTest` — section + convention assertions in both rule-guide copies

All 7 spec-related test classes pass locally (`./gradlew test --tests ...`).