### PR TITLE
fix: 读取 Kotlin KDoc 描述作为接口标题与分类名

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/JavaPsiAdapter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/JavaPsiAdapter.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiEnumConstant
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.javadoc.PsiDocComment
 import com.intellij.psi.javadoc.PsiDocTag
 import com.itangcent.easyapi.core.psi.doc.DocComment
 import com.itangcent.easyapi.core.psi.doc.DocTag
@@ -73,8 +74,26 @@ class JavaPsiAdapter : PsiLanguageAdapter {
                 null
             }
         }
+        val description = extractDescription(psiDocComment)
 
-        return DocComment(text = text, tags = tags)
+        return DocComment(text = text, tags = tags, description = description)
+    }
+
+    /**
+     * Extracts the free-form description body from a Javadoc comment
+     * (content before `@` tags), mirroring [com.itangcent.easyapi.core.psi.helper.UnifiedDocHelper.getDocCommentContent].
+     */
+    private fun extractDescription(psiDocComment: PsiDocComment): String? {
+        val text = psiDocComment.descriptionElements
+            .joinToString(separator = "") { it.text?.trimEnd() ?: "" }
+            .trim()
+        if (text.isEmpty()) return null
+        return text.lines()
+            .asSequence()
+            .map { it.removePrefix(" ").trimEnd() }
+            .joinToString(separator = "\n")
+            .trim()
+            .takeIf { it.isNotEmpty() }
     }
 
     override fun resolveEnumConstants(psiClass: PsiClass): List<String> {

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/KotlinPsiAdapter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/KotlinPsiAdapter.kt
@@ -124,7 +124,10 @@ class KotlinPsiAdapter : PsiLanguageAdapter {
             }
         }
 
-        return DocComment(text = text, tags = tags)
+        val description = kDoc.getDefaultSection().getContent()
+            .trim()
+            .takeIf { it.isNotEmpty() }
+        return DocComment(text = text, tags = tags, description = description)
     }
 
     private fun KDocTag.contentOrLink(): String? {

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/PsiLanguageAdapterLoader.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/PsiLanguageAdapterLoader.kt
@@ -45,9 +45,9 @@ object PsiLanguageAdapterLoader {
     /**
      * Registry of all supported language adapters.
      *
-     * Order matters: adapters are checked in registration order by [findAdapter].
-     * More specific adapters (Kotlin, Scala, Groovy) should come after
-     * the general Java adapter, as [findAdapter] returns the first match.
+     * [findAdapter] does not simply take the first registration match: when multiple
+     * adapters support an element (e.g. Kotlin light PSI reporting language as JAVA),
+     * non-[JavaPsiAdapter] adapters are preferred so KDoc / Scaladoc can be resolved.
      */
     private val registry = listOf(
         AdapterEntry(onClass = null, factory = { JavaPsiAdapter() }),
@@ -76,13 +76,19 @@ object PsiLanguageAdapterLoader {
     fun loadAdapters(): List<PsiLanguageAdapter> = adapters
 
     /**
-     * Finds the first adapter that supports the given [element].
+     * Finds an adapter that supports the given [element].
+     *
+     * When several adapters match (common for Kotlin light classes whose language
+     * id is reported as JAVA), prefers a non-[JavaPsiAdapter] so language-native
+     * documentation (KDoc, Scaladoc, …) can be read.
      *
      * @param element The PSI element to find an adapter for
-     * @return The first supporting adapter, or `null` if none matches
+     * @return A supporting adapter, or `null` if none matches
      */
     fun findAdapter(element: PsiElement): PsiLanguageAdapter? {
-        return adapters.firstOrNull { it.supportsElement(element) }
+        val matching = adapters.filter { it.supportsElement(element) }
+        if (matching.isEmpty()) return null
+        return matching.firstOrNull { it !is JavaPsiAdapter } ?: matching.first()
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/ScalaPsiAdapter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/adapter/ScalaPsiAdapter.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiDocCommentOwner
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.javadoc.PsiDocComment
 import com.itangcent.easyapi.core.psi.doc.DocComment
 import com.itangcent.easyapi.core.psi.doc.DocTag
 
@@ -142,7 +143,26 @@ class ScalaPsiAdapter : PsiLanguageAdapter {
             }
         }
 
-        return DocComment(text = text, tags = tags)
+        val description = extractDescription(scDocComment as? PsiDocComment)
+        return DocComment(text = text, tags = tags, description = description)
+    }
+
+    /**
+     * Extracts the free-form description body from a Scaladoc comment
+     * (content before `@` tags) via the standard [PsiDocComment] API.
+     */
+    private fun extractDescription(psiDocComment: PsiDocComment?): String? {
+        if (psiDocComment == null) return null
+        val text = psiDocComment.descriptionElements
+            .joinToString(separator = "") { it.text?.trimEnd() ?: "" }
+            .trim()
+        if (text.isEmpty()) return null
+        return text.lines()
+            .asSequence()
+            .map { it.removePrefix(" ").trimEnd() }
+            .joinToString(separator = "\n")
+            .trim()
+            .takeIf { it.isNotEmpty() }
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/doc/DocComment.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/doc/DocComment.kt
@@ -23,18 +23,21 @@ package com.itangcent.easyapi.core.psi.doc
  *     tags = [
  *         DocTag("param", "id the user ID"),
  *         DocTag("return", "the user")
- *     ]
+ *     ],
+ *     description = "Gets user by ID."
  * )
  * ```
  *
  * @param text The raw comment text
  * @param tags The parsed documentation tags
+ * @param description The free-form description body (before tags), used as API title / folder name
  * @see DocTag for tag representation
  * @see com.itangcent.easyapi.core.psi.adapter.PsiLanguageAdapter for comment parsing
  */
 data class DocComment(
     val text: String,
-    val tags: List<DocTag> = emptyList()
+    val tags: List<DocTag> = emptyList(),
+    val description: String? = null
 )
 
 /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedAnnotationHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedAnnotationHelper.kt
@@ -37,10 +37,6 @@ import com.itangcent.easyapi.core.psi.adapter.PsiLanguageAdapterLoader
  */
 class UnifiedAnnotationHelper : AnnotationHelper, com.itangcent.easyapi.core.logging.IdeaLog {
 
-    private val adapters: List<PsiLanguageAdapter> by lazy {
-        PsiLanguageAdapterLoader.loadAdapters()
-    }
-
     override suspend fun hasAnn(element: PsiElement, annFqn: String): Boolean {
         return read {
             findPsiAnnotations(element, annFqn).isNotEmpty()
@@ -78,7 +74,7 @@ class UnifiedAnnotationHelper : AnnotationHelper, com.itangcent.easyapi.core.log
     }
 
     private fun findPsiAnnotations(element: PsiElement, annFqn: String): List<PsiAnnotation> {
-        val adapter = adapters.firstOrNull { it.supportsElement(element) } ?: return emptyList()
+        val adapter = PsiLanguageAdapterLoader.findAdapter(element) ?: return emptyList()
         return adapter.resolveAnnotations(element).filter { it.qualifiedName == annFqn }
     }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedDocHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedDocHelper.kt
@@ -107,7 +107,8 @@ class UnifiedDocHelper(private val project: Project) : DocHelper {
                     return@read getDocCommentContent(sourceOwner.docComment!!)
                 }
             }
-            null
+            // Kotlin light PSI is not PsiDocCommentOwner; fall back to language-adapter description (KDoc).
+            resolveDocComment(psiElement)?.description
         }
     }
 
@@ -179,27 +180,36 @@ class UnifiedDocHelper(private val project: Project) : DocHelper {
     }
 
     private fun resolveDocComment(psiElement: PsiElement): DocComment? {
-        val adapter = findAdapter(psiElement)
-        val docComment = adapter?.resolveDocComment(psiElement)
-        if (docComment != null) return docComment
+        resolveDocCommentWithAdapters(psiElement)?.let { return it }
 
         val sourceElement = sourceHelper.getSourceElementSync(psiElement)
         if (sourceElement !== psiElement) {
-            val sourceAdapter = findAdapter(sourceElement)
-            return sourceAdapter?.resolveDocComment(sourceElement)
+            return resolveDocCommentWithAdapters(sourceElement)
         }
 
         return null
     }
 
     /**
-     * Finds the first language adapter that supports the given element.
+     * Tries every matching language adapter until one returns a [DocComment].
      *
-     * @param element The PSI element to find an adapter for
-     * @return The supporting adapter, or `null` if none matches
+     * Uses [PsiLanguageAdapterLoader.findAdapter] ordering (prefer non-Java) so
+     * Kotlin light classes that report language as JAVA still resolve KDoc.
      */
-    private fun findAdapter(element: PsiElement): PsiLanguageAdapter? {
-        return adapters.firstOrNull { it.supportsElement(element) }
+    private fun resolveDocCommentWithAdapters(element: PsiElement): DocComment? {
+        val matching = adapters.filter { it.supportsElement(element) }
+        if (matching.isEmpty()) return null
+        val preferred = PsiLanguageAdapterLoader.findAdapter(element)
+        val ordered = buildList {
+            if (preferred != null) add(preferred)
+            for (adapter in matching) {
+                if (adapter !== preferred) add(adapter)
+            }
+        }
+        for (adapter in ordered) {
+            adapter.resolveDocComment(element)?.let { return it }
+        }
+        return null
     }
 
     // ========== EOL Comment Extraction Utilities ==========

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/JavaPsiAdapterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/JavaPsiAdapterTest.kt
@@ -54,6 +54,11 @@ class JavaPsiAdapterTest : EasyApiLightCodeInsightFixtureTestCase() {
         val doc = adapter.resolveDocComment(repo!!)
         assertNotNull("Should resolve Javadoc for generic interface", doc)
         assertTrue("Should contain description", doc!!.text.contains("Generic repository interface"))
+        assertNotNull("Should extract Javadoc description body", doc.description)
+        assertTrue(
+            "Description should contain interface summary",
+            doc.description!!.contains("Generic repository interface")
+        )
         assertTrue("Should have @param tags for type params",
             doc.tags.any { it.name == "param" && it.value.contains("<T>") })
     }

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/KotlinPsiAdapterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/KotlinPsiAdapterTest.kt
@@ -59,6 +59,8 @@ class KotlinPsiAdapterTest : EasyApiLightCodeInsightFixtureTestCase() {
         val doc = adapter.resolveDocComment(apiResponse!!)
         assertNotNull("Should resolve KDoc for data class", doc)
         assertTrue("Should contain description", doc!!.text.contains("Represents an API response"))
+        assertEquals("Should extract KDoc description body",
+            "Represents an API response.", doc.description)
         assertTrue("Should have @property tags",
             doc.tags.any { it.name == "property" })
         assertTrue("Should have @param T tag",
@@ -117,7 +119,9 @@ class KotlinPsiAdapterTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertNotNull("Should find fetchById", fetchById)
         val doc = adapter.resolveDocComment(fetchById!!)
         assertNotNull("Should resolve KDoc for interface method", doc)
-        assertTrue("Should have @param tag", doc!!.tags.any { it.name == "param" })
+        assertEquals("Should extract method KDoc description",
+            "Fetches data by ID.", doc!!.description)
+        assertTrue("Should have @param tag", doc.tags.any { it.name == "param" })
         assertTrue("Should have @return tag", doc.tags.any { it.name == "return" })
         assertTrue("Should have @throws tag", doc.tags.any { it.name == "throws" })
     }

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/PsiLanguageAdapterLoaderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/adapter/PsiLanguageAdapterLoaderTest.kt
@@ -28,6 +28,20 @@ class PsiLanguageAdapterLoaderTest : EasyApiLightCodeInsightFixtureTestCase() {
         assertTrue("Should be JavaPsiAdapter for Java element", adapter is JavaPsiAdapter)
     }
 
+    fun testFindAdapterPrefersKotlinForLightClass() {
+        loadFile("adapter/ComplexKotlinSource.kt")
+        val psiClass = findClass("com.test.adapter.ApiResponse")
+        assertNotNull("Should find the Kotlin class", psiClass)
+        // KtLightClass may report language as JAVA; both adapters can match.
+        // Prefer Kotlin so class-level KDoc (folder name) can be resolved.
+        val adapter = PsiLanguageAdapterLoader.findAdapter(psiClass!!)
+        assertNotNull("Should find an adapter for Kotlin light class", adapter)
+        assertTrue(
+            "Should prefer KotlinPsiAdapter when light PSI also matches Java",
+            adapter is KotlinPsiAdapter
+        )
+    }
+
     fun testFindAdapterReturnsNullForUnsupportedElement() {
         val adapters = PsiLanguageAdapterLoader.loadAdapters()
         assertNotNull("Adapters list should not be null", adapters)

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/doc/DocCommentTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/doc/DocCommentTest.kt
@@ -10,6 +10,7 @@ class DocCommentTest {
         val comment = DocComment("/** Hello */")
         assertEquals("/** Hello */", comment.text)
         assertEquals(emptyList<DocTag>(), comment.tags)
+        assertNull(comment.description)
     }
 
     @Test
@@ -18,20 +19,35 @@ class DocCommentTest {
             DocTag("param", "id the user ID"),
             DocTag("return", "the user")
         )
-        val comment = DocComment("/** Gets user by ID. */", tags)
+        val comment = DocComment("/** Gets user by ID. */", tags, description = "Gets user by ID.")
         assertEquals("/** Gets user by ID. */", comment.text)
         assertEquals(2, comment.tags.size)
         assertEquals("param", comment.tags[0].name)
         assertEquals("id the user ID", comment.tags[0].value)
         assertEquals("return", comment.tags[1].name)
+        assertEquals("Gets user by ID.", comment.description)
+    }
+
+    @Test
+    fun testWithDescriptionOnly() {
+        val comment = DocComment("/** Hello */", description = "Hello")
+        assertEquals("Hello", comment.description)
+        assertEquals(emptyList<DocTag>(), comment.tags)
     }
 
     @Test
     fun testEquality() {
         val tags = listOf(DocTag("param", "id"))
-        val c1 = DocComment("/** text */", tags)
-        val c2 = DocComment("/** text */", tags)
+        val c1 = DocComment("/** text */", tags, description = "text")
+        val c2 = DocComment("/** text */", tags, description = "text")
         assertEquals(c1, c2)
+    }
+
+    @Test
+    fun testInequality_differentDescription() {
+        val c1 = DocComment("/** text */", description = "a")
+        val c2 = DocComment("/** text */", description = "b")
+        assertNotEquals(c1, c2)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedDocHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/UnifiedDocHelperTest.kt
@@ -2,6 +2,7 @@ package com.itangcent.easyapi.core.psi.helper
 
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import kotlinx.coroutines.runBlocking
+import org.junit.AssumptionViolatedException
 
 class UnifiedDocHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
 
@@ -432,6 +433,56 @@ class UnifiedDocHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
         val desc = docHelper.getAttrOfDocComment(method)
         assertNotNull("Should find method doc description", desc)
         assertTrue("Method description should contain 'Gets the user name'", desc!!.contains("Gets the user name"))
+    }
+
+    // --- Kotlin KDoc getAttrOfDocComment (light PSI is not PsiDocCommentOwner) ---
+
+    fun testGetAttrOfDocCommentOnKotlinClass() = runBlocking {
+        assumeKotlinPluginAvailable()
+        loadFile("helper/UnifiedKtDocAttrClass.kt", """
+            package com.test.helper
+            /**
+             * Shipping location APIs.
+             */
+            class UnifiedKtDocAttrClass
+        """.trimIndent())
+        val psiClass = findClass("com.test.helper.UnifiedKtDocAttrClass")!!
+        val desc = docHelper.getAttrOfDocComment(psiClass)
+        assertNotNull("Should find Kotlin class KDoc description", desc)
+        assertTrue(
+            "Class description should come from KDoc body",
+            desc!!.contains("Shipping location APIs")
+        )
+    }
+
+    fun testGetAttrOfDocCommentOnKotlinMethod() = runBlocking {
+        assumeKotlinPluginAvailable()
+        loadFile("helper/UnifiedKtDocAttrMethod.kt", """
+            package com.test.helper
+            class UnifiedKtDocAttrMethod {
+                /**
+                 * List shipping locations.
+                 * @return location list
+                 */
+                fun listShippingLocations(): List<String> = emptyList()
+            }
+        """.trimIndent())
+        val psiClass = findClass("com.test.helper.UnifiedKtDocAttrMethod")!!
+        val method = findMethod(psiClass, "listShippingLocations")!!
+        val desc = docHelper.getAttrOfDocComment(method)
+        assertNotNull("Should find Kotlin method KDoc description", desc)
+        assertTrue(
+            "Method description should come from KDoc body",
+            desc!!.contains("List shipping locations")
+        )
+    }
+
+    private fun assumeKotlinPluginAvailable() {
+        try {
+            Class.forName("org.jetbrains.kotlin.idea.KotlinLanguage")
+        } catch (e: ClassNotFoundException) {
+            throw AssumptionViolatedException("Kotlin plugin not available")
+        }
     }
 
     // --- getInstance ---


### PR DESCRIPTION
## 摘要
- 修复导出 Kotlin Spring Controller 到 YApi 时，接口标题 / 分类名未使用 KDoc 正文描述的问题
- `UnifiedDocHelper.getAttrOfDocComment` 在 Java Javadoc 路径失败后，回退到语言适配器解析的 `DocComment.description`
- Fixes #1424

## 测试计划
- [x] 将带 KDoc 的 Kotlin Spring Controller 导出到 YApi
- [x] 确认接口标题 = 方法 KDoc 正文第一行
- [x] 确认分类名 = 类 KDoc 正文第一行
- [x] 确认 Java Controller 仍按 Javadoc 正常导出标题 / 分类名