### PR TITLE
fix(settings): add apiScanEnabled master toggle for API scanning

### DIFF
--- a/docs/knowledge-base/settings-guide.md
+++ b/docs/knowledge-base/settings-guide.md
@@ -37,7 +37,8 @@ Framework recognition and output formatting.
 | Form Expanded | `true` | Expand form parameters in the exported tree | `formExpanded` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `50`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
-| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
+| API Scanning | `true` | Master toggle for API scanning. When `false`, auto-scan, concurrent scan, and the gutter icon (which navigates via the API index) are all forced off. | `apiScanEnabled` |
+| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor (only effective when API scanning is enabled) | `gutterIconEnabled` |
 | Switch Notice | `true` | Show a notification when switching settings scope | `switchNotice` |
 
 ---
@@ -92,8 +93,8 @@ Smart inference and auto-detection.
 
 | Field | Default | Effect | Property |
 |-------|---------|--------|----------|
-| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
-| Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
+| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints (only effective when API scanning is enabled) | `autoScanEnabled` |
+| Concurrent Scan | `false` | Use parallel scanning for faster discovery (only effective when API scanning is enabled) | `concurrentScanEnabled` |
 | Enum Field Auto Infer | `false` | Automatically infer enum field values | `enumFieldAutoInferEnabled` |
 
 ---

--- a/skills/easy-yapi-assistant/docs/settings-guide.md
+++ b/skills/easy-yapi-assistant/docs/settings-guide.md
@@ -37,7 +37,8 @@ Framework recognition and output formatting.
 | Form Expanded | `true` | Expand form parameters in the exported tree | `formExpanded` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `50`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
-| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
+| API Scanning | `true` | Master toggle for API scanning. When `false`, auto-scan, concurrent scan, and the gutter icon (which navigates via the API index) are all forced off. | `apiScanEnabled` |
+| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor (only effective when API scanning is enabled) | `gutterIconEnabled` |
 | Switch Notice | `true` | Show a notification when switching settings scope | `switchNotice` |
 
 ---
@@ -92,8 +93,8 @@ Smart inference and auto-detection.
 
 | Field | Default | Effect | Property |
 |-------|---------|--------|----------|
-| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
-| Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
+| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints (only effective when API scanning is enabled) | `autoScanEnabled` |
+| Concurrent Scan | `false` | Use parallel scanning for faster discovery (only effective when API scanning is enabled) | `concurrentScanEnabled` |
 | Enum Field Auto Infer | `false` | Automatically infer enum field values | `enumFieldAutoInferEnabled` |
 
 ---

--- a/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiFileChangeListener.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiFileChangeListener.kt
@@ -52,7 +52,13 @@ class ApiFileChangeListener(private val project: Project) : BulkFileListener, Di
     }
 
     override fun after(events: MutableList<out VFileEvent>) {
-        if (!project.settings<GeneralSettings>().autoScanEnabled) {
+        val settings = project.settings<GeneralSettings>()
+        // Master toggle: when API scanning is off, skip all processing.
+        if (!settings.apiScanEnabled) {
+            return
+        }
+
+        if (!settings.autoScanEnabled) {
             return
         }
 

--- a/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManager.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManager.kt
@@ -13,6 +13,8 @@ import com.itangcent.easyapi.core.dashboard.ApiScanner
 import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
 import com.itangcent.easyapi.core.ide.DumbModeHelper
 import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.settings
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -65,6 +67,12 @@ class ApiIndexManager(private val project: Project) : Disposable, IdeaLog {
     @Volatile
     private var started = false
 
+    /**
+     * `true` once [start] has successfully initialized the scan consumers.
+     * Test-visible for lifecycle assertions in [ApiScanStartupControllerTest].
+     */
+    internal fun isStarted(): Boolean = started
+
     fun start(triggerInitialScan: Boolean = true) {
         if (started) {
             if (triggerInitialScan) {
@@ -106,8 +114,28 @@ class ApiIndexManager(private val project: Project) : Disposable, IdeaLog {
 
     /**
      * Requests a full scan. Returns immediately.
+     *
+     * Defense-in-depth: if the index services were never started (e.g. the
+     * project was opened with `apiScanEnabled=false` and the settings-changed
+     * listener somehow didn't fire), start them now so the dashboard's Refresh
+     * action still triggers a scan rather than silently dropping the request
+     * on a closed [fullScanChannel]. The scan is dispatched immediately rather
+     * than via [start]'s delayed initial-scan path, so the user sees results
+     * without the normal 5-second startup delay.
      */
     fun requestScan() {
+        if (!started) {
+            val apiScanEnabled = project.settings<GeneralSettings>().apiScanEnabled
+            if (apiScanEnabled) {
+                LOG.info("requestScan called before start — starting API index services on demand")
+                // Skip the delayed initial scan; we'll dispatch the request
+                // ourselves immediately below once the consumer is running.
+                start(triggerInitialScan = false)
+            } else {
+                LOG.info("Full scan requested while apiScanEnabled=false — ignoring")
+                return
+            }
+        }
         LOG.info("Full scan requested")
         val sent = fullScanChannel.trySend(Unit)
         LOG.info("Full scan request sent: ${sent.isSuccess}")

--- a/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiScanStartupController.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiScanStartupController.kt
@@ -1,0 +1,86 @@
+package com.itangcent.easyapi.core.cache.api
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.core.cache.VcsBranchChangeListener
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.settings.SettingsChangeListener
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.settings
+
+/**
+ * Bridges settings changes to the lifecycle of the API index services.
+ *
+ * The startup activity ([com.itangcent.easyapi.core.ide.ApiIndexStartupActivity])
+ * only runs once at project open. If `apiScanEnabled` is `false` at that moment,
+ * [ApiFileChangeListener], [VcsBranchChangeListener], and [ApiIndexManager] are
+ * never started. When the user later flips `apiScanEnabled` to `true` in
+ * Settings, this controller starts them on the fly so the dashboard's refresh
+ * and auto-scan work without a project restart.
+ *
+ * Each `start()` call on the underlying services is idempotent (re-subscribes
+ * the message bus connection), so this controller can fire on every settings
+ * change without double-registering.
+ */
+@Service(Service.Level.PROJECT)
+class ApiScanStartupController(private val project: Project) : Disposable, IdeaLog {
+
+    @Volatile
+    private var servicesStarted = false
+
+    fun onSettingsChanged() {
+        val apiScanEnabled = project.settings<GeneralSettings>().apiScanEnabled
+        if (apiScanEnabled) {
+            startIndexServicesIfNeeded()
+        }
+    }
+
+    private fun startIndexServicesIfNeeded() {
+        if (servicesStarted) return
+        servicesStarted = true
+        LOG.info("apiScanEnabled flipped to true — starting API index services")
+        ApiFileChangeListener.getInstance(project).start()
+        VcsBranchChangeListener.getInstance(project).start()
+        // triggerInitialScan=true so a fresh enable kicks off a scan even if
+        // autoScanEnabled is false (the user can still click Refresh).
+        ApiIndexManager.getInstance(project).start(triggerInitialScan = true)
+    }
+
+    override fun dispose() {
+        // Services own their own disposables; nothing to release here.
+    }
+
+    companion object {
+        fun getInstance(project: Project): ApiScanStartupController = project.service()
+    }
+}
+
+/**
+ * Project-wide listener that forwards settings changes to the
+ * [ApiScanStartupController], so the index services start when
+ * `apiScanEnabled` is flipped to `true` at runtime.
+ */
+@Service(Service.Level.PROJECT)
+class ApiScanSettingsListener(private val project: Project) : Disposable, IdeaLog {
+
+    init {
+        project.messageBus.connect(this).subscribe(
+            SettingsChangeListener.TOPIC,
+            object : SettingsChangeListener {
+                override fun settingsChanged() {
+                    ApiScanStartupController.getInstance(project).onSettingsChanged()
+                }
+            }
+        )
+    }
+
+    override fun dispose() {
+        // connection auto-disposed via connect(this)
+    }
+
+    companion object {
+        fun getInstance(project: Project): ApiScanSettingsListener = project.service()
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardToolWindowFactory.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardToolWindowFactory.kt
@@ -2,15 +2,22 @@ package com.itangcent.easyapi.core.dashboard
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.onSettingsChanged
+import com.itangcent.easyapi.core.settings.settings
 
 /**
  * Factory for creating the API Dashboard tool window in IntelliJ IDEA.
- * 
- * This factory is registered in plugin.xml and creates the tool window content
- * when the user opens the API Dashboard. It connects the panel to the project-level
- * service for state management.
+ *
+ * The tool window is registered in plugin.xml, but its visibility is gated by
+ * the `apiScanEnabled` master toggle: when API scanning is disabled, the API
+ * index that the dashboard consumes is never built, so the dashboard would be
+ * an empty shell — it is hidden from the stripe via [ToolWindow.setAvailable]
+ * until scanning is re-enabled. Toggling the setting at runtime re-shows/hides
+ * the tool window without a project restart.
  */
 class ApiDashboardToolWindowFactory : ToolWindowFactory {
     /**
@@ -25,8 +32,30 @@ class ApiDashboardToolWindowFactory : ToolWindowFactory {
         val service = ApiDashboardService.getInstance(project)
         service.setDashboardPanel(panel)
 
+        // One disposable ties together the panel disposal and the settings
+        // listener, so both are cleaned up when the content is removed.
+        val disposable = Disposer.newDisposable()
+        Disposer.register(disposable, Disposable { panel.dispose() })
+
         val content = toolWindow.contentManager.factory.createContent(panel, "", false)
-        content.setDisposer(Disposable { panel.dispose() })
+        content.setDisposer(disposable)
         toolWindow.contentManager.addContent(content)
+
+        // Apply the master-toggle availability now, then keep it in sync with
+        // settings changes for the lifetime of the tool window.
+        applyAvailability(project, toolWindow)
+        project.onSettingsChanged(disposable) {
+            applyAvailability(project, toolWindow)
+        }
+    }
+
+    /**
+     * Sets the tool window's availability based on the current value of
+     * `apiScanEnabled`. When unavailable, the stripe button is hidden and the
+     * dashboard cannot be activated.
+     */
+    private fun applyAvailability(project: Project, toolWindow: ToolWindow) {
+        val enabled = project.settings<GeneralSettings>().apiScanEnabled
+        toolWindow.setAvailable(enabled)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/ApiIndexStartupActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/ApiIndexStartupActivity.kt
@@ -43,6 +43,16 @@ class ApiIndexStartupActivity : ProjectActivity {
             if (project.isDisposed) return@backgroundAsync
 
             ConfigSyncService.getInstance(project).start()
+
+            val settings = project.settings<GeneralSettings>()
+            // When the API scanning master toggle is off, skip all scanning-related
+            // services (file change listener, VCS branch listener, index manager).
+            // The gutter icon and API Dashboard both depend on the index that
+            // scanning produces, so they are effectively disabled too.
+            if (!settings.apiScanEnabled) {
+                return@backgroundAsync
+            }
+
             ApiFileChangeListener.getInstance(project).start()
             VcsBranchChangeListener.getInstance(project).start()
 
@@ -50,7 +60,7 @@ class ApiIndexStartupActivity : ProjectActivity {
 
             if (project.isDisposed) return@backgroundAsync
 
-            val autoScan = project.settings<GeneralSettings>().autoScanEnabled
+            val autoScan = settings.autoScanEnabled
 
             ApiIndexManager.getInstance(project).start(triggerInitialScan = autoScan)
         }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/action/OpenApiDashboardAction.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/action/OpenApiDashboardAction.kt
@@ -5,18 +5,26 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.wm.ToolWindowManager
 import com.itangcent.easyapi.core.logging.IdeaLog
 import com.itangcent.easyapi.core.logging.console
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.settings
 
 /**
  * Action to open the API Dashboard tool window.
  *
  * Activates the "API Dashboard" tool window, which provides a centralized
- * view for browsing and testing API endpoints.
+ * view for browsing and testing API endpoints. No-ops when API scanning is
+ * disabled, since the dashboard would be an empty shell without the index.
  */
 class OpenApiDashboardAction : AnAction(), IdeaLog {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val console = project.console
         console.info("OpenApiDashboardAction.actionPerformed: project=${project.name}")
+        // The tool window is hidden via setAvailable(false) when scanning is
+        // off; bail out early to avoid activating an unavailable window.
+        if (!project.settings<GeneralSettings>().apiScanEnabled) {
+            return
+        }
         ToolWindowManager.getInstance(project).getToolWindow("API Dashboard")?.activate(null)
     }
 }

--- a/src/main/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProvider.kt
@@ -69,7 +69,10 @@ class ApiMethodLineMarkerProvider : LineMarkerProvider {
     }
 
     private fun isGutterIconEnabled(project: Project): Boolean {
-        return project.settings<GeneralSettings>().gutterIconEnabled
+        val settings = project.settings<GeneralSettings>()
+        // The gutter icon navigates via the API index that scanning produces,
+        // so it is suppressed when the API scanning master toggle is off.
+        return settings.apiScanEnabled && settings.gutterIconEnabled
     }
 
     private fun isApiMethod(method: PsiMethod): Boolean {

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivity.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/migration/SettingsMigrationActivity.kt
@@ -98,6 +98,7 @@ class SettingsMigrationActivity : StartupActivity {
         // below. The legacy booleans are read from `legacy` (ApplicationSettingsState.State)
         // which retains them as @Deprecated read-only fields for one-time migration.
         appState.setValue(generalKey, "autoScanEnabled", legacy.autoScanEnabled.toString())
+        appState.setValue(generalKey, "apiScanEnabled", legacy.apiScanEnabled.toString())
         appState.setValue(generalKey, "concurrentScanEnabled", legacy.concurrentScanEnabled.toString())
         appState.setValue(generalKey, "gutterIconEnabled", legacy.gutterIconEnabled.toString())
         appState.setValue(generalKey, "switchNotice", legacy.switchNotice.toString())

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/module/GeneralSettings.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/module/GeneralSettings.kt
@@ -12,6 +12,13 @@ import com.itangcent.easyapi.core.settings.StorageScope
  * Persisted at APPLICATION scope via the unified [com.itangcent.easyapi.core.settings.state.UnifiedAppSettingsState].
  */
 data class GeneralSettings(
+    /**
+     * Master toggle for API scanning. When `false`, all scanning features
+     * (auto-scan, concurrent scan) and index-dependent features (gutter icon,
+     * which navigates via the API index) are disabled. The API Dashboard and
+     * gutter icon both depend on the API index that scanning produces.
+     */
+    @StorageScope(Scope.APPLICATION) var apiScanEnabled: Boolean = true,
     @StorageScope(Scope.APPLICATION) var autoScanEnabled: Boolean = true,
     @StorageScope(Scope.APPLICATION) var concurrentScanEnabled: Boolean = false,
     @StorageScope(Scope.APPLICATION) var gutterIconEnabled: Boolean = true,
@@ -29,6 +36,7 @@ data class GeneralSettings(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         other as GeneralSettings
+        if (apiScanEnabled != other.apiScanEnabled) return false
         if (autoScanEnabled != other.autoScanEnabled) return false
         if (concurrentScanEnabled != other.concurrentScanEnabled) return false
         if (gutterIconEnabled != other.gutterIconEnabled) return false
@@ -45,7 +53,8 @@ data class GeneralSettings(
     }
 
     override fun hashCode(): Int {
-        var result = autoScanEnabled.hashCode()
+        var result = apiScanEnabled.hashCode()
+        result = 31 * result + autoScanEnabled.hashCode()
         result = 31 * result + concurrentScanEnabled.hashCode()
         result = 31 * result + gutterIconEnabled.hashCode()
         result = 31 * result + switchNotice.hashCode()

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/state/ApplicationSettingsState.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/state/ApplicationSettingsState.kt
@@ -80,6 +80,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
         var outputCharset: String = "UTF-8",
         var builtInConfig: String? = null,
         var remoteConfig: Array<String> = emptyArray(),
+        var apiScanEnabled: Boolean = true,
         var autoScanEnabled: Boolean = true,
         var grpcArtifactConfigs: Array<String> = emptyArray(),
         var grpcAdditionalJars: Array<String> = emptyArray(),
@@ -125,6 +126,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             if (outputCharset != other.outputCharset) return false
             if (builtInConfig != other.builtInConfig) return false
             if (!remoteConfig.contentEquals(other.remoteConfig)) return false
+            if (apiScanEnabled != other.apiScanEnabled) return false
             if (autoScanEnabled != other.autoScanEnabled) return false
             if (!grpcArtifactConfigs.contentEquals(other.grpcArtifactConfigs)) return false
             if (!grpcAdditionalJars.contentEquals(other.grpcAdditionalJars)) return false
@@ -168,6 +170,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             result = 31 * result + outputCharset.hashCode()
             result = 31 * result + (builtInConfig?.hashCode() ?: 0)
             result = 31 * result + remoteConfig.contentHashCode()
+            result = 31 * result + apiScanEnabled.hashCode()
             result = 31 * result + autoScanEnabled.hashCode()
             result = 31 * result + grpcArtifactConfigs.contentHashCode()
             result = 31 * result + grpcAdditionalJars.contentHashCode()
@@ -210,6 +213,7 @@ class ApplicationSettingsState : PersistentStateComponent<ApplicationSettingsSta
             target.outputCharset = outputCharset
             target.builtInConfig = builtInConfig
             target.remoteConfig = remoteConfig
+            target.apiScanEnabled = apiScanEnabled
             target.autoScanEnabled = autoScanEnabled
             target.grpcArtifactConfigs = grpcArtifactConfigs
             target.grpcAdditionalJars = grpcAdditionalJars

--- a/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/settings/ui/SettingsPanels.kt
@@ -113,6 +113,10 @@ interface SettingsPanel<T : Settings> {
  * mirroring the cross-module pattern used by [FeaturesSettingsPanel].
  */
 class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Project) : SettingsPanel<GeneralSettings> {
+    private val apiScanEnabled = JBCheckBox("Enable API scanning", true).apply {
+        toolTipText = "Master toggle for API scanning. When off, auto-scan, concurrent scan, " +
+            "and the gutter icon (which navigates via the API index produced by scanning) are all disabled."
+    }
     private val autoScanEnabled = JBCheckBox("Enable automatic API scanning on file changes", true).apply {
         toolTipText = "Automatically re-scan APIs when source files are modified"
     }
@@ -160,6 +164,23 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
     private val repositoryTable = TableView(repositoryTableModel)
 
     init {
+        // Master toggle: when API scanning is disabled, cascade-disable and
+        // uncheck the dependent checkboxes — auto-scan & concurrent scan (which
+        // drive scanning) and the gutter icon (which navigates via the API index
+        // that scanning produces). The gutter icon lives in the "Editor" panel
+        // but is cascaded here because it depends on the index.
+        apiScanEnabled.addActionListener {
+            val enabled = apiScanEnabled.isSelected
+            autoScanEnabled.isEnabled = enabled
+            concurrentScanEnabled.isEnabled = enabled
+            gutterIconEnabled.isEnabled = enabled
+            if (!enabled) {
+                autoScanEnabled.isSelected = false
+                concurrentScanEnabled.isSelected = false
+                gutterIconEnabled.isSelected = false
+            }
+        }
+
         val projectRow = JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
             add(JLabel("Project Cache:"))
             add(projectCacheSizeLabel)
@@ -381,7 +402,7 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         .addComponent(
             SettingsUiKit.titledPanel(
                 "Scanning", listOf(
-                    autoScanEnabled, concurrentScanEnabled
+                    apiScanEnabled, autoScanEnabled, concurrentScanEnabled
                 )
             )
         )
@@ -412,9 +433,16 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
         .panel
 
     override fun resetFrom(settings: GeneralSettings?) {
-        autoScanEnabled.isSelected = settings?.autoScanEnabled ?: true
-        concurrentScanEnabled.isSelected = settings?.concurrentScanEnabled ?: false
-        gutterIconEnabled.isSelected = settings?.gutterIconEnabled ?: true
+        apiScanEnabled.isSelected = settings?.apiScanEnabled ?: true
+        // Apply cascading enabled/disabled state based on master toggle. When
+        // the master is off, dependents are forced off visually.
+        val scanEnabled = apiScanEnabled.isSelected
+        autoScanEnabled.isEnabled = scanEnabled
+        concurrentScanEnabled.isEnabled = scanEnabled
+        gutterIconEnabled.isEnabled = scanEnabled
+        autoScanEnabled.isSelected = if (scanEnabled) (settings?.autoScanEnabled ?: true) else false
+        concurrentScanEnabled.isSelected = if (scanEnabled) (settings?.concurrentScanEnabled ?: false) else false
+        gutterIconEnabled.isSelected = if (scanEnabled) (settings?.gutterIconEnabled ?: true) else false
         switchNotice.isSelected = settings?.switchNotice ?: true
         logLevelCombo.selectedItem = CommonSettingsHelper.VerbosityLevel.toLevel(settings?.logLevel ?: 0)
         outputCharsetCombo.selectedItem = settings?.outputCharset ?: "UTF-8"
@@ -436,9 +464,12 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
     }
 
     override fun applyTo(settings: GeneralSettings) {
-        settings.autoScanEnabled = autoScanEnabled.isSelected
-        settings.concurrentScanEnabled = concurrentScanEnabled.isSelected
-        settings.gutterIconEnabled = gutterIconEnabled.isSelected
+        val scanEnabled = apiScanEnabled.isSelected
+        settings.apiScanEnabled = scanEnabled
+        // When the master toggle is off, dependent features are forced off.
+        settings.autoScanEnabled = if (scanEnabled) autoScanEnabled.isSelected else false
+        settings.concurrentScanEnabled = if (scanEnabled) concurrentScanEnabled.isSelected else false
+        settings.gutterIconEnabled = if (scanEnabled) gutterIconEnabled.isSelected else false
         settings.switchNotice = switchNotice.isSelected
         settings.logLevel = (logLevelCombo.selectedItem as? CommonSettingsHelper.VerbosityLevel)?.level ?: 0
         settings.outputCharset = outputCharsetCombo.selectedItem?.toString() ?: "UTF-8"
@@ -456,7 +487,8 @@ class GeneralSettingsPanel(private val project: com.intellij.openapi.project.Pro
 
     override fun isModified(settings: GeneralSettings?): Boolean {
         val s = settings ?: return false
-        return autoScanEnabled.isSelected != s.autoScanEnabled ||
+        return apiScanEnabled.isSelected != s.apiScanEnabled ||
+                autoScanEnabled.isSelected != s.autoScanEnabled ||
                 concurrentScanEnabled.isSelected != s.concurrentScanEnabled ||
                 gutterIconEnabled.isSelected != s.gutterIconEnabled ||
                 switchNotice.isSelected != s.switchNotice ||
@@ -1798,6 +1830,7 @@ class BackupSettingsPanel(private val project: com.intellij.openapi.project.Proj
 
         binder.update(com.itangcent.easyapi.core.settings.module.GeneralSettings::class) {
             obj.get("autoScanEnabled")?.asBoolean?.let { autoScanEnabled = it }
+            obj.get("apiScanEnabled")?.asBoolean?.let { apiScanEnabled = it }
             obj.get("concurrentScanEnabled")?.asBoolean?.let { concurrentScanEnabled = it }
             obj.get("gutterIconEnabled")?.asBoolean?.let { gutterIconEnabled = it }
             obj.get("switchNotice")?.asBoolean?.let { switchNotice = it }
@@ -1884,6 +1917,7 @@ class BackupSettingsPanel(private val project: com.intellij.openapi.project.Proj
 
         val general = binder.read(com.itangcent.easyapi.core.settings.module.GeneralSettings::class)
         obj.addProperty("autoScanEnabled", general.autoScanEnabled)
+        obj.addProperty("apiScanEnabled", general.apiScanEnabled)
         obj.addProperty("concurrentScanEnabled", general.concurrentScanEnabled)
         obj.addProperty("gutterIconEnabled", general.gutterIconEnabled)
         obj.addProperty("switchNotice", general.switchNotice)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -107,6 +107,8 @@
                         serviceImplementation="com.itangcent.easyapi.channel.postman.sync.EnvironmentSyncService"/>
         <projectService serviceImplementation="com.itangcent.easyapi.core.psi.helper.DocMetadataResolver"/>
         <projectService serviceImplementation="com.itangcent.easyapi.core.cache.VcsBranchChangeListener"/>
+        <projectService serviceImplementation="com.itangcent.easyapi.core.cache.api.ApiScanStartupController"/>
+        <projectService serviceImplementation="com.itangcent.easyapi.core.cache.api.ApiScanSettingsListener"/>
         <projectService serviceImplementation="com.itangcent.easyapi.core.ide.PropertiesService"/>
 
         <postStartupActivity implementation="com.itangcent.easyapi.core.ide.ApiIndexStartupActivity"/>

--- a/src/main/resources/docs/knowledge-base/settings-guide.md
+++ b/src/main/resources/docs/knowledge-base/settings-guide.md
@@ -37,7 +37,8 @@ Framework recognition and output formatting.
 | Form Expanded | `true` | Expand form parameters in the exported tree | `formExpanded` |
 | Output Charset | `UTF-8` | Character encoding for exported files | `outputCharset` |
 | Log Level | `100` (SILENT) | Console verbosity. Lower = more verbose. `100`=SILENT, `50`=WARN, `20`=INFO, `10`=DEBUG, `0`=TRACE | `logLevel` |
-| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor | `gutterIconEnabled` |
+| API Scanning | `true` | Master toggle for API scanning. When `false`, auto-scan, concurrent scan, and the gutter icon (which navigates via the API index) are all forced off. | `apiScanEnabled` |
+| Gutter Icon | `true` | Show gutter icons for API endpoints in the editor (only effective when API scanning is enabled) | `gutterIconEnabled` |
 | Switch Notice | `true` | Show a notification when switching settings scope | `switchNotice` |
 
 ---
@@ -92,8 +93,8 @@ Smart inference and auto-detection.
 
 | Field | Default | Effect | Property |
 |-------|---------|--------|----------|
-| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints | `autoScanEnabled` |
-| Concurrent Scan | `false` | Use parallel scanning for faster discovery | `concurrentScanEnabled` |
+| Auto Scan Enabled | `true` | Automatically scan the project for API endpoints (only effective when API scanning is enabled) | `autoScanEnabled` |
+| Concurrent Scan | `false` | Use parallel scanning for faster discovery (only effective when API scanning is enabled) | `concurrentScanEnabled` |
 | Enum Field Auto Infer | `false` | Automatically infer enum field values | `enumFieldAutoInferEnabled` |
 
 ---

--- a/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiFileChangeListenerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiFileChangeListenerTest.kt
@@ -56,4 +56,24 @@ class ApiFileChangeListenerTest : EasyApiLightCodeInsightFixtureTestCase() {
         project.settings<GeneralSettings>().autoScanEnabled = true
         SettingBinder.getInstance(project).save(project.settings<GeneralSettings>())
     }
+
+    fun testApiScanMasterToggleDisabled() {
+        // When the API scanning master toggle is off, the listener must skip
+        // all processing — even if autoScanEnabled is true.
+        val settings = project.settings<GeneralSettings>()
+        settings.apiScanEnabled = false
+        settings.autoScanEnabled = true
+        SettingBinder.getInstance(project).save(settings)
+
+        listener.start()
+        listener.after(mutableListOf())
+
+        runBlocking {
+            delay(100)
+        }
+
+        // Reset
+        settings.apiScanEnabled = true
+        SettingBinder.getInstance(project).save(settings)
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManagerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManagerTest.kt
@@ -3,6 +3,8 @@ package com.itangcent.easyapi.core.cache.api
 import com.itangcent.easyapi.core.export.ApiEndpoint
 import com.itangcent.easyapi.core.export.HttpMethod
 import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 import com.itangcent.easyapi.testFramework.TestConfigReader
 import com.itangcent.easyapi.testFramework.waitUntil
@@ -196,5 +198,73 @@ class ApiIndexManagerTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         assertTrue("Cache should be valid after scan", apiIndex.isValid())
         assertTrue("Should have endpoints", endpoints.isNotEmpty())
+    }
+
+    /**
+     * Reproduces the bug: project opened with `apiScanEnabled=false`, so the
+     * startup activity never calls `ApiIndexManager.start()`. The user then
+     * enables the toggle in Settings and clicks Refresh in the API Dashboard.
+     *
+     * `requestScan()` must auto-start the index services on demand (defense
+     * in depth) so the scan actually runs without a project restart.
+     */
+    fun testRequestScanAutoStartsServicesWhenNotStarted() = runTest {
+        // Tear down the manager started in setUp() to simulate "services never
+        // started because apiScanEnabled was false at project open".
+        apiIndexManager.stop()
+        runBlocking { apiIndex.invalidate() }
+        assertFalse("Index should be invalid after invalidate", apiIndex.isValid())
+
+        // apiScanEnabled defaults to true in GeneralSettings, so requestScan
+        // must auto-start services and dispatch the scan immediately.
+        apiIndexManager.requestScan()
+
+        val endpoints = waitForEndpoints()
+        assertTrue("Cache should be valid after auto-start scan", apiIndex.isValid())
+        assertTrue("Auto-start scan should populate endpoints", endpoints.isNotEmpty())
+    }
+
+    /**
+     * When `apiScanEnabled=false`, `requestScan()` must remain a no-op even
+     * if the index services were never started. This guards against scans
+     * running while the master toggle is off.
+     */
+    fun testRequestScanNoOpWhenApiScanDisabledAndNotStarted() = runTest {
+        apiIndexManager.stop()
+        runBlocking { apiIndex.invalidate() }
+
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+        }
+
+        try {
+            apiIndexManager.requestScan()
+            // Give the background dispatcher a brief window to prove the
+            // negative — if a scan were dispatched, the cache would become
+            // valid shortly. Polling for a short timeout keeps the test fast.
+            val settledInvalid = waitUntilSettledInvalid(timeoutMs = 1500)
+            assertTrue(
+                "Cache should remain invalid when apiScanEnabled is false",
+                settledInvalid
+            )
+        } finally {
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
+        }
+    }
+
+    /**
+     * Polls briefly to confirm the cache stays invalid. Returns `true` if the
+     * cache remained invalid for the entire [timeoutMs] window, `false` if it
+     * became valid (indicating a scan ran despite expectations).
+     */
+    private suspend fun waitUntilSettledInvalid(timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (apiIndex.isValid()) return false
+            kotlinx.coroutines.delay(50)
+        }
+        return !apiIndex.isValid()
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiScanStartupControllerTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/cache/api/ApiScanStartupControllerTest.kt
@@ -1,0 +1,235 @@
+package com.itangcent.easyapi.core.cache.api
+
+import com.itangcent.easyapi.core.cache.VcsBranchChangeListener
+import com.itangcent.easyapi.core.settings.SettingsChangeListener
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.settings
+import com.itangcent.easyapi.core.settings.update
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+import com.itangcent.easyapi.testFramework.waitUntil
+import com.itangcent.easyapi.testFramework.waitUntilNotEmpty
+import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for [ApiScanStartupController] and [ApiScanSettingsListener].
+ *
+ * These services close the gap left by [com.itangcent.easyapi.core.ide.ApiIndexStartupActivity]:
+ * when the project is opened with `apiScanEnabled=false` the startup activity
+ * never starts the index services, so flipping the toggle at runtime must
+ * start them on the fly. The controller must also be idempotent — repeated
+ * settings changes must not double-start the services.
+ */
+class ApiScanStartupControllerTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var controller: ApiScanStartupController
+    private lateinit var listener: ApiScanSettingsListener
+    private lateinit var apiIndexManager: ApiIndexManager
+    private lateinit var apiFileChangeListener: ApiFileChangeListener
+    private lateinit var vcsBranchChangeListener: VcsBranchChangeListener
+
+    override fun setUp() {
+        super.setUp()
+        controller = ApiScanStartupController.getInstance(project)
+        listener = ApiScanSettingsListener.getInstance(project)
+        apiIndexManager = ApiIndexManager.getInstance(project)
+        apiFileChangeListener = ApiFileChangeListener.getInstance(project)
+        vcsBranchChangeListener = VcsBranchChangeListener.getInstance(project)
+
+        // Ensure we start from a clean state: services not yet started and
+        // apiScanEnabled defaulted to true. The controller's `servicesStarted`
+        // flag is one-shot for the lifetime of the project service instance,
+        // so we rely on a fresh project per test (the fixture's contract).
+        runBlocking { ApiIndex.getInstance(project).invalidate() }
+    }
+
+    override fun tearDown() {
+        // Stop the manager if this test started it, so background coroutines
+        // don't leak into sibling tests.
+        runBlocking {
+            apiIndexManager.stop()
+            apiFileChangeListener.dispose()
+            vcsBranchChangeListener.dispose()
+        }
+        super.tearDown()
+    }
+
+    fun testGetInstance_returnsSameInstance() {
+        assertSame(
+            "ApiScanStartupController should be a project singleton",
+            controller,
+            ApiScanStartupController.getInstance(project)
+        )
+        assertSame(
+            "ApiScanSettingsListener should be a project singleton",
+            listener,
+            ApiScanSettingsListener.getInstance(project)
+        )
+    }
+
+    /**
+     * When `apiScanEnabled` is already true, `onSettingsChanged()` must start
+     * the index services so a refresh / auto-scan works immediately.
+     */
+    fun testOnSettingsChanged_startsIndexServicesWhenEnabled() {
+        // apiScanEnabled defaults to true in GeneralSettings.
+        controller.onSettingsChanged()
+
+        // The ApiIndexManager should now be running (started flag set). We
+        // verify by requesting a scan — if services weren't started this would
+        // either no-op or hit a closed channel; either way `start()` would
+        // not have been called.
+        assertTrue(
+            "ApiIndexManager should be started after onSettingsChanged with apiScanEnabled=true",
+            apiIndexManager.isStarted()
+        )
+    }
+
+    /**
+     * When `apiScanEnabled` is false, `onSettingsChanged()` must NOT start the
+     * index services — the master toggle is off, so scanning must remain off.
+     */
+    fun testOnSettingsChanged_doesNotStartServicesWhenDisabled() {
+        // Stop any manager that might have been auto-started by the base
+        // class's `branchHasChanged("test-setup")` event (which triggers
+        // `requestScan()` → defense-in-depth auto-start when apiScanEnabled
+        // is still true at that point).
+        apiIndexManager.stop()
+
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+        }
+
+        try {
+            controller.onSettingsChanged()
+
+            assertFalse(
+                "ApiIndexManager should NOT be started when apiScanEnabled is false",
+                apiIndexManager.isStarted()
+            )
+        } finally {
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
+        }
+    }
+
+    /**
+     * The controller must be idempotent: repeated `onSettingsChanged()` calls
+     * (e.g. the user toggles unrelated settings) must not double-start the
+     * services or throw.
+     */
+    fun testOnSettingsChanged_isIdempotent() {
+        controller.onSettingsChanged()
+        controller.onSettingsChanged()
+        controller.onSettingsChanged()
+
+        assertTrue(
+            "ApiIndexManager should be started after repeated onSettingsChanged calls",
+            apiIndexManager.isStarted()
+        )
+    }
+
+    /**
+     * The settings listener must forward `SettingsChangeListener` events to
+     * the controller. Publishing on the message bus should start the index
+     * services when `apiScanEnabled` is true.
+     */
+    fun testSettingsListener_forwardsEventsToController() {
+        project.messageBus.syncPublisher(SettingsChangeListener.TOPIC).settingsChanged()
+
+        assertTrue(
+            "ApiIndexManager should be started after settingsChanged is published",
+            apiIndexManager.isStarted()
+        )
+    }
+
+    /**
+     * The settings listener must NOT start services when `apiScanEnabled` is
+     * false at the time the event fires.
+     */
+    fun testSettingsListener_doesNotStartServicesWhenDisabled() {
+        // Stop any manager that might have been auto-started before this test.
+        apiIndexManager.stop()
+
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+        }
+
+        try {
+            project.messageBus.syncPublisher(SettingsChangeListener.TOPIC).settingsChanged()
+
+            assertFalse(
+                "ApiIndexManager should NOT be started when apiScanEnabled is false",
+                apiIndexManager.isStarted()
+            )
+        } finally {
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
+        }
+    }
+
+    /**
+     * `dispose()` on both services must not throw. This covers the disposal
+     * paths (currently no-ops, but protected by contract).
+     */
+    fun testDispose_doesNotThrow() {
+        controller.dispose()
+        listener.dispose()
+    }
+
+    /**
+     * After the controller starts services, a real scan must be dispatched
+     * (`triggerInitialScan = true`) so enabling the toggle at runtime results
+     * in a populated index, not just running consumers.
+     *
+     * This is the end-to-end path the bug report describes: project opened
+     * with `apiScanEnabled=false`, user flips the toggle, dashboard should
+     * show endpoints without a restart.
+     */
+    fun testControllerStartTriggersInitialScan() = runTest {
+        // Load the full set of test API files (mirrors ApiIndexManagerTest's
+        // loadTestFiles) so the scanner has something to find.
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("spring/PostMapping.java")
+        loadFile("spring/RestController.java")
+        loadFile("spring/Controller.java")
+        loadFile("spring/ResponseBody.java")
+        loadFile("spring/RequestParam.java")
+        loadFile("spring/PathVariable.java")
+        loadFile("spring/RequestBody.java")
+        loadFile("model/Result.java")
+        loadFile("model/UserInfo.java")
+        loadFile("api/UserCtrl.java")
+
+        val apiIndex = ApiIndex.getInstance(project)
+
+        controller.onSettingsChanged()
+
+        // The controller-triggered initial scan may find 0 endpoints before
+        // PSI is fully resolved (same race as ApiIndexManagerTest). Re-request
+        // a scan when the cache is valid but empty, mirroring waitForEndpoints.
+        waitUntil(timeout = 30.seconds) { apiIndex.isReady() }
+        val endpoints = waitUntilNotEmpty(timeout = 30.seconds) {
+            val eps = apiIndex.endpoints()
+            if (eps.isEmpty() && apiIndex.isValid()) {
+                apiIndexManager.requestScan()
+            }
+            eps
+        }
+
+        assertTrue(
+            "Index should be valid after controller-triggered initial scan",
+            apiIndex.isValid()
+        )
+        assertTrue(
+            "Index should have endpoints after controller-triggered initial scan",
+            endpoints.isNotEmpty()
+        )
+    }
+
+    override fun createConfigReader() = TestConfigReader.empty(project)
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardToolWindowFactoryTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/dashboard/ApiDashboardToolWindowFactoryTest.kt
@@ -1,5 +1,10 @@
 package com.itangcent.easyapi.core.dashboard
 
+import com.intellij.openapi.wm.RegisterToolWindowTask
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class ApiDashboardToolWindowFactoryTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -8,4 +13,47 @@ class ApiDashboardToolWindowFactoryTest : EasyApiLightCodeInsightFixtureTestCase
         val factory = ApiDashboardToolWindowFactory()
         assertNotNull("Factory should be instantiable", factory)
     }
+
+    fun testCreateContentDoesNotThrowWhenApiScanEnabled() {
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = true
+        }
+
+        val toolWindow = registerDashboardToolWindow()
+        try {
+            val factory = ApiDashboardToolWindowFactory()
+            factory.createToolWindowContent(project, toolWindow)
+        } catch (e: Exception) {
+            fail("createToolWindowContent should not throw when apiScanEnabled is true: ${e.message}")
+        }
+    }
+
+    fun testCreateContentDoesNotThrowWhenApiScanDisabled() {
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+        }
+
+        val toolWindow = registerDashboardToolWindow()
+        try {
+            val factory = ApiDashboardToolWindowFactory()
+            factory.createToolWindowContent(project, toolWindow)
+        } catch (e: Exception) {
+            fail("createToolWindowContent should not throw when apiScanEnabled is false: ${e.message}")
+        } finally {
+            // Reset for subsequent tests
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
+        }
+    }
+
+    /**
+     * Registers a test "API Dashboard" tool window so the factory can populate
+     * it. The tool window is disposed with the project at tearDown.
+     */
+    private fun registerDashboardToolWindow(): ToolWindow =
+        ToolWindowManager.getInstance(project)
+            .registerToolWindow(
+                RegisterToolWindowTask("API Dashboard")
+            )
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ide/action/OpenApiDashboardActionTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ide/action/OpenApiDashboardActionTest.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.Presentation
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.update
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class OpenApiDashboardActionTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -62,6 +64,35 @@ class OpenApiDashboardActionTest : EasyApiLightCodeInsightFixtureTestCase() {
             action.actionPerformed(event)
         } catch (e: Exception) {
             fail("actionPerformed should not throw with project: ${e.message}")
+        }
+    }
+
+    fun testActionPerformedDoesNotThrowWhenApiScanDisabled() {
+        // When apiScanEnabled is false, the action should no-op (bail out
+        // early) without throwing — the tool window is hidden via
+        // setAvailable(false) and activating it would be a no-op anyway.
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+        }
+
+        val presentation = Presentation()
+        val event = AnActionEvent.createEvent(
+            DataContext { project },
+            presentation,
+            "test",
+            ActionUiKind.NONE,
+            null
+        )
+
+        try {
+            action.actionPerformed(event)
+        } catch (e: Exception) {
+            fail("actionPerformed should not throw when apiScanEnabled is false: ${e.message}")
+        } finally {
+            // Reset for subsequent tests
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
         }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/ide/linemarker/ApiMethodLineMarkerProviderTest.kt
@@ -130,6 +130,7 @@ class ApiMethodLineMarkerProviderTest : EasyApiLightCodeInsightFixtureTestCase()
 
     fun testLineMarkerWhenGutterIconEnabled() = runTest {
         settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = true
             gutterIconEnabled = true
         }
 
@@ -154,5 +155,40 @@ class ApiMethodLineMarkerProviderTest : EasyApiLightCodeInsightFixtureTestCase()
             "Should show gutter icon on at least one API method when gutterIconEnabled is true",
             foundMarker
         )
+    }
+
+    fun testNoLineMarkerWhenApiScanDisabled() = runTest {
+        // Master toggle off should suppress gutter icons even if
+        // gutterIconEnabled is true, because the gutter icon navigates via
+        // the API index that scanning produces.
+        settingBinder.update(GeneralSettings::class) {
+            apiScanEnabled = false
+            gutterIconEnabled = true
+        }
+
+        try {
+            val file = myFixture.configureByFile("api/UserCtrl.java")
+            val classes = PsiTreeUtil.getChildrenOfType(file, PsiClass::class.java) ?: emptyArray()
+            assertTrue("Should have classes in test file", classes.isNotEmpty())
+
+            val methods = classes.flatMap { it.methods.toList() }
+            assertTrue("Should have methods in test file", methods.isNotEmpty())
+
+            methods.forEach { method ->
+                val identifier = method.nameIdentifier
+                if (identifier != null) {
+                    val marker = lineMarkerProvider.getLineMarkerInfo(identifier)
+                    assertNull(
+                        "Should not show gutter icon when apiScanEnabled is false",
+                        marker
+                    )
+                }
+            }
+        } finally {
+            // Reset master toggle so subsequent tests are not affected.
+            settingBinder.update(GeneralSettings::class) {
+                apiScanEnabled = true
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/SettingsDefaultsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/SettingsDefaultsTest.kt
@@ -77,6 +77,32 @@ class SettingsDefaultsTest {
     }
 
     @Test
+    fun `test GeneralSettings default apiScanEnabled is true`() {
+        val settings = GeneralSettings()
+        assertTrue("apiScanEnabled should default to true", settings.apiScanEnabled)
+    }
+
+    @Test
+    fun `test ApplicationSettingsState State default apiScanEnabled is true`() {
+        val state = ApplicationSettingsState.State()
+        assertTrue(
+            "ApplicationSettingsState default apiScanEnabled should be true",
+            state.apiScanEnabled
+        )
+    }
+
+    @Test
+    fun `test GeneralSettings and ApplicationSettingsState have matching apiScanEnabled defaults`() {
+        val settings = GeneralSettings()
+        val appState = ApplicationSettingsState.State()
+        assertEquals(
+            "apiScanEnabled defaults should match between GeneralSettings and ApplicationSettingsState",
+            settings.apiScanEnabled,
+            appState.apiScanEnabled
+        )
+    }
+
+    @Test
     fun `test ParsingOutputSettings default enumFieldAutoInferEnabled is false`() {
         val settings = ParsingOutputSettings()
         assertFalse(

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/state/ApplicationSettingsStateTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/state/ApplicationSettingsStateTest.kt
@@ -34,6 +34,7 @@ class ApplicationSettingsStateTest {
         assertEquals("UTF-8", s.outputCharset)
         assertNull(s.builtInConfig)
         assertArrayEquals(emptyArray(), s.remoteConfig)
+        assertTrue(s.apiScanEnabled)
         assertTrue(s.autoScanEnabled)
         assertTrue(s.gutterIconEnabled)
     }
@@ -84,6 +85,13 @@ class ApplicationSettingsStateTest {
     }
 
     @Test
+    fun testState_inequality_apiScanEnabled() {
+        val s1 = ApplicationSettingsState.State(apiScanEnabled = true)
+        val s2 = ApplicationSettingsState.State(apiScanEnabled = false)
+        assertNotEquals(s1, s2)
+    }
+
+    @Test
     fun testState_equalityWithArrays() {
         val s1 = ApplicationSettingsState.State(remoteConfig = arrayOf("http://a.com"))
         val s2 = ApplicationSettingsState.State(remoteConfig = arrayOf("http://a.com"))
@@ -120,6 +128,15 @@ class ApplicationSettingsStateTest {
         assertTrue("target gutterIconEnabled should default to true", target.gutterIconEnabled)
         source.copyTo(target)
         assertFalse("gutterIconEnabled should be copied as false", target.gutterIconEnabled)
+    }
+
+    @Test
+    fun testState_copyTo_apiScanEnabled() {
+        val source = ApplicationSettingsState.State(apiScanEnabled = false)
+        val target = ApplicationSettingsState.State()
+        assertTrue("target apiScanEnabled should default to true", target.apiScanEnabled)
+        source.copyTo(target)
+        assertFalse("apiScanEnabled should be copied as false", target.apiScanEnabled)
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelLogicTest.kt
@@ -95,6 +95,7 @@ class GeneralSettingsPanelLogicTest {
         assertFalse(settings.enabledFrameworks.contains("Feign"))
         assertFalse(settings.disabledFrameworks.contains("JAX-RS"))
         assertFalse(settings.enabledFrameworks.contains("SpringActuator"))
+        assertTrue(settings.apiScanEnabled)
         assertTrue(settings.autoScanEnabled)
         assertFalse(settings.concurrentScanEnabled)
         assertTrue(settings.gutterIconEnabled)
@@ -108,6 +109,7 @@ class GeneralSettingsPanelLogicTest {
         val settings = GeneralSettings(
             enabledFrameworks = arrayOf("Feign", "SpringActuator"),
             disabledFrameworks = arrayOf("JAX-RS"),
+            apiScanEnabled = false,
             autoScanEnabled = false,
             concurrentScanEnabled = true,
             gutterIconEnabled = false,
@@ -118,6 +120,7 @@ class GeneralSettingsPanelLogicTest {
         assertTrue(settings.enabledFrameworks.contains("Feign"))
         assertTrue(settings.disabledFrameworks.contains("JAX-RS"))
         assertTrue(settings.enabledFrameworks.contains("SpringActuator"))
+        assertFalse(settings.apiScanEnabled)
         assertFalse(settings.autoScanEnabled)
         assertTrue(settings.concurrentScanEnabled)
         assertFalse(settings.gutterIconEnabled)
@@ -139,6 +142,19 @@ class GeneralSettingsPanelLogicTest {
         val s1 = GeneralSettings()
         val s2 = GeneralSettings(enabledFrameworks = arrayOf("Feign"))
         assertNotEquals(s1, s2)
+    }
+
+    @Test
+    fun testSettingsApiScanEnabledInequality() {
+        // Specifically exercise the `apiScanEnabled` branch of equals() —
+        // the field was added in this PR and Codecov flagged it as a partial.
+        val s1 = GeneralSettings(apiScanEnabled = true)
+        val s2 = GeneralSettings(apiScanEnabled = false)
+        assertNotEquals(s1, s2)
+        assertNotEquals(s2, s1)
+        // Same apiScanEnabled value should still be equal on this field.
+        assertEquals(GeneralSettings(apiScanEnabled = true), GeneralSettings(apiScanEnabled = true))
+        assertEquals(GeneralSettings(apiScanEnabled = false), GeneralSettings(apiScanEnabled = false))
     }
 
     @Test

--- a/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelPlatformTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/settings/ui/GeneralSettingsPanelPlatformTest.kt
@@ -1,7 +1,9 @@
 package com.itangcent.easyapi.core.settings.ui
 
+import com.intellij.ui.components.JBCheckBox
 import com.itangcent.easyapi.core.settings.module.GeneralSettings
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import java.awt.event.ActionEvent
 
 /**
  * Platform tests for the *behavior* fields of [GeneralSettingsPanel]
@@ -55,6 +57,8 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
 
     fun testRoundTripWithAllFieldsModified() {
         val modified = GeneralSettings().apply {
+            // Keep master toggle on so dependent fields can be individually modified.
+            apiScanEnabled = true
             autoScanEnabled = false
             concurrentScanEnabled = true
             gutterIconEnabled = false
@@ -67,12 +71,179 @@ class GeneralSettingsPanelPlatformTest : EasyApiLightCodeInsightFixtureTestCase(
         val target = GeneralSettings()
         panel.applyTo(target)
 
+        assertTrue(target.apiScanEnabled)
         assertFalse(target.autoScanEnabled)
         assertTrue(target.concurrentScanEnabled)
         assertFalse(target.gutterIconEnabled)
         assertFalse(target.switchNotice)
         assertEquals(100, target.logLevel)
         assertEquals("ISO-8859-1", target.outputCharset)
+    }
+
+    fun testApiScanMasterToggleDisablesDependentCheckboxes() {
+        // When apiScanEnabled is off, dependent checkboxes are forced off
+        // after resetFrom + applyTo, even if their stored values were true.
+        val settings = GeneralSettings().apply {
+            apiScanEnabled = false
+            autoScanEnabled = true
+            concurrentScanEnabled = true
+            gutterIconEnabled = true
+        }
+        panel.resetFrom(settings)
+
+        val target = GeneralSettings()
+        panel.applyTo(target)
+
+        assertFalse("apiScanEnabled should be false", target.apiScanEnabled)
+        assertFalse("autoScanEnabled should be cascaded to false", target.autoScanEnabled)
+        assertFalse("concurrentScanEnabled should be cascaded to false", target.concurrentScanEnabled)
+        assertFalse("gutterIconEnabled should be cascaded to false", target.gutterIconEnabled)
+    }
+
+    /**
+     * Covers the [GeneralSettingsPanel.apiScanEnabled] action listener's
+     * "disable cascade" path: when the user unchecks the master toggle, the
+     * dependent checkboxes (auto-scan, concurrent scan, gutter icon) must be
+     * disabled and unselected immediately — before Apply is clicked.
+     */
+    fun testApiScanActionListener_uncheckingDisablesAndClearsDependents() {
+        // Start from a state where everything is on.
+        val settings = GeneralSettings().apply {
+            apiScanEnabled = true
+            autoScanEnabled = true
+            concurrentScanEnabled = true
+            gutterIconEnabled = true
+        }
+        panel.resetFrom(settings)
+
+        // Sanity: dependents should be enabled and selected.
+        val autoScan = checkBoxField("autoScanEnabled")
+        val concurrentScan = checkBoxField("concurrentScanEnabled")
+        val gutterIcon = checkBoxField("gutterIconEnabled")
+        assertTrue("autoScanEnabled should be enabled", autoScan.isEnabled)
+        assertTrue("concurrentScanEnabled should be enabled", concurrentScan.isEnabled)
+        assertTrue("gutterIconEnabled should be enabled", gutterIcon.isEnabled)
+        assertTrue("autoScanEnabled should be selected", autoScan.isSelected)
+        assertTrue("concurrentScanEnabled should be selected", concurrentScan.isSelected)
+        assertTrue("gutterIconEnabled should be selected", gutterIcon.isSelected)
+
+        // Simulate the user unchecking the master toggle.
+        setApiScanEnabled(false)
+
+        // The action listener must cascade-disable and unselect the dependents.
+        assertFalse(
+            "autoScanEnabled checkbox should be disabled after master toggle off",
+            autoScan.isEnabled
+        )
+        assertFalse(
+            "concurrentScanEnabled checkbox should be disabled after master toggle off",
+            concurrentScan.isEnabled
+        )
+        assertFalse(
+            "gutterIconEnabled checkbox should be disabled after master toggle off",
+            gutterIcon.isEnabled
+        )
+        assertFalse(
+            "autoScanEnabled checkbox should be unselected after master toggle off",
+            autoScan.isSelected
+        )
+        assertFalse(
+            "concurrentScanEnabled checkbox should be unselected after master toggle off",
+            concurrentScan.isSelected
+        )
+        assertFalse(
+            "gutterIconEnabled checkbox should be unselected after master toggle off",
+            gutterIcon.isSelected
+        )
+    }
+
+    /**
+     * Covers the [GeneralSettingsPanel.apiScanEnabled] action listener's
+     * "enable" path: when the user re-checks the master toggle, the dependent
+     * checkboxes must become enabled again. They must NOT be auto-checked — the
+     * user has to opt back into each one (only `resetFrom` populates their
+     * selection state).
+     */
+    fun testApiScanActionListener_checkingReEnablesDependents() {
+        // Start from a state where the master is off and dependents are off.
+        val settings = GeneralSettings().apply {
+            apiScanEnabled = false
+            autoScanEnabled = false
+            concurrentScanEnabled = false
+            gutterIconEnabled = false
+        }
+        panel.resetFrom(settings)
+
+        val autoScan = checkBoxField("autoScanEnabled")
+        val concurrentScan = checkBoxField("concurrentScanEnabled")
+        val gutterIcon = checkBoxField("gutterIconEnabled")
+
+        // Sanity: dependents should be disabled (cascaded by resetFrom).
+        assertFalse("autoScanEnabled should be disabled initially", autoScan.isEnabled)
+        assertFalse("concurrentScanEnabled should be disabled initially", concurrentScan.isEnabled)
+        assertFalse("gutterIconEnabled should be disabled initially", gutterIcon.isEnabled)
+
+        // Simulate the user re-checking the master toggle.
+        setApiScanEnabled(true)
+
+        // The action listener must re-enable the dependents, but must NOT
+        // auto-check them — the user opts back in manually.
+        assertTrue(
+            "autoScanEnabled checkbox should be re-enabled after master toggle on",
+            autoScan.isEnabled
+        )
+        assertTrue(
+            "concurrentScanEnabled checkbox should be re-enabled after master toggle on",
+            concurrentScan.isEnabled
+        )
+        assertTrue(
+            "gutterIconEnabled checkbox should be re-enabled after master toggle on",
+            gutterIcon.isEnabled
+        )
+        // Selection state is NOT changed by the enable path — only by resetFrom
+        // or explicit user clicks on each dependent checkbox.
+        assertFalse(
+            "autoScanEnabled checkbox should remain unchecked after master toggle on",
+            autoScan.isSelected
+        )
+        assertFalse(
+            "concurrentScanEnabled checkbox should remain unchecked after master toggle on",
+            concurrentScan.isSelected
+        )
+        assertFalse(
+            "gutterIconEnabled checkbox should remain unchecked after master toggle on",
+            gutterIcon.isSelected
+        )
+    }
+
+    /**
+     * The action listener is idempotent: re-checking the master toggle when it
+     * is already on must not throw, and dependents must remain enabled.
+     */
+    fun testApiScanActionListener_isIdempotentWhenAlreadyChecked() {
+        panel.resetFrom(GeneralSettings()) // master on, dependents on
+        setApiScanEnabled(true)
+        setApiScanEnabled(true)
+
+        assertTrue("autoScanEnabled should still be enabled", checkBoxField("autoScanEnabled").isEnabled)
+        assertTrue("concurrentScanEnabled should still be enabled", checkBoxField("concurrentScanEnabled").isEnabled)
+        assertTrue("gutterIconEnabled should still be enabled", checkBoxField("gutterIconEnabled").isEnabled)
+    }
+
+    // --- Reflection helpers (avoid adding internal functions to production code) ---
+
+    private fun checkBoxField(name: String): JBCheckBox {
+        val field = GeneralSettingsPanel::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(panel) as JBCheckBox
+    }
+
+    private fun setApiScanEnabled(selected: Boolean) {
+        val checkbox = checkBoxField("apiScanEnabled")
+        checkbox.isSelected = selected
+        // Fire the action listener manually because headless JComboBox does
+        // not dispatch ActionEvent on setSelected.
+        checkbox.actionListeners.forEach { it.actionPerformed(ActionEvent(checkbox, 0, "")) }
     }
 
     fun testResetFromNullDoesNotThrow() {


### PR DESCRIPTION
## Description

Adds a top-level `apiScanEnabled` master toggle that controls all API scanning features (auto-scan, concurrent scan) and index-dependent features (gutter icon, API Dashboard). When off, the API Dashboard tool window is hidden, the gutter icon is suppressed, and the dashboard open action is a no-op.

Also fixes the bug where enabling `apiScanEnabled` at runtime and clicking Refresh in the API Dashboard did not trigger a scan, because the index services were never started when the project was opened with the toggle off.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Closes #1427

## Changes Made

- Added `apiScanEnabled` field to `GeneralSettings` (defaults to `true`) and surfaced it as the first checkbox in the General settings tab. When unchecked, the dependent checkboxes (`autoScanEnabled`, `concurrentScanEnabled`, `gutterIconEnabled`) are auto-disabled and cleared.
- Hidden the API Dashboard tool window (`setAvailable(false)`) and made `OpenApiDashboardAction` a no-op when `apiScanEnabled=false`. The tool window reactively follows settings changes.
- Suppressed the gutter icon (`ApiMethodLineMarkerProvider`) when `apiScanEnabled=false`.
- Skipped starting the index services in `ApiIndexStartupActivity` when `apiScanEnabled=false` at project open.
- Added `ApiScanStartupController` + `ApiScanSettingsListener` to start the index services on the fly when `apiScanEnabled` flips to `true` at runtime, so no project restart is needed.
- Defense-in-depth: `ApiIndexManager.requestScan()` now auto-starts services on demand when called while not yet started (and `apiScanEnabled=true`), so the dashboard's Refresh action works even if the settings listener didn't fire. When `apiScanEnabled=false`, it remains a no-op.
- Updated docs (`settings-guide.md`) and tests across settings, dashboard, action, line marker, file change listener, and `ApiIndexManager`.

## Testing

- [x] Unit tests pass
- [x] New tests added for new functionality

New/updated tests:
- `ApiIndexManagerTest.testRequestScanAutoStartsServicesWhenNotStarted` — verifies the dashboard Refresh path starts services and populates the index when the project was opened with scanning disabled.
- `ApiIndexManagerTest.testRequestScanNoOpWhenApiScanDisabledAndNotStarted` — verifies `requestScan()` stays a no-op while the master toggle is off.
- `ApiFileChangeListenerTest`, `ApiDashboardToolWindowFactoryTest`, `OpenApiDashboardActionTest`, `ApiMethodLineMarkerProviderTest`, `SettingsDefaultsTest`, `ApplicationSettingsStateTest`, `GeneralSettingsPanelLogicTest`, `GeneralSettingsPanelPlatformTest` — cover the new toggle, tool window visibility, action no-op, and gutter suppression paths.

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes