### PR TITLE
fix: prevent read-access error in rule scripts (#1432)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,31 @@ IdeDispatchers.isWriteAccessAllowed  // on write thread
 IdeDispatchers.isDispatchThread      // on EDT
 ```
 
+### Thread-contract tiers (golden rules)
+
+Before writing code that touches PSI/VFS/UI, classify it by **who controls the caller** — the distinguishing question is whether the set of callers is closed (ours) or open (anyone's).
+
+| Tier | Examples | Contract |
+|------|----------|----------|
+| **Pure** | DTOs, `ObjectModelUtils`, string helpers | Callable on any thread; no threading rules |
+| **Internal pipeline** | `core/export/`, `core/psi/` helpers | `@requires ReadAction` (or WriteAction) in KDoc; the entry point acquires the action once, callees run unwrapped |
+| **Boundary (open callers)** | `ScriptXxxContext` objects handed to Groovy, EP implementations invoked by the platform | **Every public member must self-protect** — no `@requires` escape hatch |
+
+Known thread entry points:
+
+- **EDT** — `core/ide/action/` AnActions, dialogs, linemarkers, settings UI, dashboard panel
+- **`EasyAPI-background` pool** — startup activities (`ApiIndexStartupActivity`, `SettingsMigrationActivity`, …), `backgroundAsync` call sites, export orchestration
+- **Rule engine (uncontrolled)** — `Jsr223ScriptParser` evaluates Groovy rules inside `withContext(IdeDispatchers.Background)` with **no read action**. Scripts can invoke ANY public member of the bound context objects — including implicit `toString()` via string interpolation, `hashCode`, `equals`, and property access. This is where issue #1432 crashed.
+
+Golden rules:
+
+1. Pure code is callable anywhere.
+2. Internal pipeline code performing PSI/VFS reads: `suspend` + `read {}`, or sync + `readSync {}` — *unless* documented with `@requires ReadAction` AND all callers are internal. Never publish a `@requires` member on a boundary class.
+3. PSI writes / UI updates go through `write {}` / `swing {}`; never bypass.
+4. **Boundary classes self-protect unconditionally**: every public member (and implicit hooks `toString`/`hashCode`/`equals`, plus `by lazy` initializers reachable from them) wraps its own PSI access in `readSync`. `readSync` is a no-op inside an existing read action, so nesting costs nothing.
+5. Read-action granularity: fine-grained at the boundary; coarse `read {}` blocks only where the work is fast. Never wrap a whole Groovy script evaluation in one read action (slow scripts + long read action blocks writes and freezes the IDE).
+6. `runBlocking` from a boundary member is acceptable only if every suspend callee performs its own `read {}` internally; it blocks the calling thread but does not itself violate threading.
+
 ### IntelliJ context propagation warning
 
 IntelliJ wraps tasks submitted to managed executors (including `Dispatchers.Default`) with `ContextRunnable`, propagating EDT/write-intent markers across thread boundaries. **Use `IdeDispatchers.Background`** (or `actionContext.runAsync` / `backgroundAsync`) when launching from `StartupActivity` or `DumbService.runWhenSmart`, to avoid "slow operations on EDT" violations.

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
@@ -119,7 +119,7 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
         val engine = RuleEngine.getInstance(project)
 
         // Apply json.rule.convert uniformly to all ResolvedType instances
-        val qualifiedName = resolvedType.qualifiedName()
+        val qualifiedName = readSync { resolvedType.qualifiedName() }
         LOG.info("buildObjectModel(resolvedType): evaluating json.rule.convert for: $qualifiedName")
         val converted = engine.evaluate(RuleKeys.JSON_RULE_CONVERT, resolvedType, resolvedType.contextElement())
         LOG.info("buildObjectModel(resolvedType): json.rule.convert result for '$qualifiedName': ${converted ?: "(null)"}")

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContexts.kt
@@ -649,7 +649,7 @@ class ScriptTypeContext(private val context: RuleContext, private val resolvedTy
         Array(fields.size) { i -> ScriptResolvedFieldContext(context, fields[i]) }
     }
 
-    override fun toString(): String = resolvedType.qualifiedName()
+    override fun toString(): String = name()
 
     fun isExtend(superClass: String): Boolean = when (resolvedType) {
         is ResolvedType.ClassType -> InheritanceHelper.isInheritor(resolvedType.psiClass, superClass)
@@ -852,7 +852,7 @@ class ScriptPsiTypeContext(
 
     override fun toJson5(): String = typeContext.toJson5()
 
-    override fun toString(): String = resolvedType.qualifiedName()
+    override fun toString(): String = readSync { resolvedType.qualifiedName() }
 }
 
 /**

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContextsTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/context/ScriptPsiContextsTest.kt
@@ -4,7 +4,9 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
+import com.intellij.psi.util.PsiTypesUtil
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
+import com.itangcent.easyapi.core.psi.type.ResolvedType
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
 
 class ScriptPsiContextsTest : EasyApiLightCodeInsightFixtureTestCase() {
@@ -1124,6 +1126,62 @@ class ScriptPsiContextsTest : EasyApiLightCodeInsightFixtureTestCase() {
 
         assertNotNull("toJson5 should not return null for collection type", json5)
         assertTrue("toJson5 for collection type should start with [ but got: $json5", json5.trimStart().startsWith("["))
+    }
+
+    //endregion
+
+    //region Threading regression (issue #1432)
+
+    /**
+     * Rule scripts run on the EasyAPI-background pool without a read action
+     * (Jsr223ScriptParser evaluates inside withContext(IdeDispatchers.Background)).
+     * Groovy string interpolation calls toString() implicitly, so toString() must
+     * self-protect — see AGENTS.md "Thread-contract tiers (golden rules)".
+     */
+    fun testToStringOnNonReadActionThread() {
+        val psiClass = fixture.addClass(
+            """
+            package com.test;
+            public class TypeToStringModel {
+                public String name;
+            }
+            """.trimIndent()
+        ) as PsiClass
+
+        val ruleContext = RuleContext.from(project, psiClass)
+        val typeContext = ScriptTypeContext(ruleContext, ResolvedType.ClassType(psiClass))
+
+        val classType = PsiTypesUtil.getClassType(psiClass)
+        val psiTypeContext = ScriptPsiTypeContext(
+            RuleContext.withPsiType(project, classType),
+            classType
+        )
+
+        var error: Throwable? = null
+        val thread = Thread {
+            try {
+                assertEquals(
+                    "ScriptTypeContext.toString() should return qualified name",
+                    "com.test.TypeToStringModel",
+                    typeContext.toString()
+                )
+                assertEquals(
+                    "ScriptPsiTypeContext.toString() should return qualified name",
+                    "com.test.TypeToStringModel",
+                    psiTypeContext.toString()
+                )
+            } catch (t: Throwable) {
+                error = t
+            }
+        }
+        thread.name = "EasyAPI-background-test"
+        thread.start()
+        thread.join(10_000)
+
+        assertNull(
+            "toString() must not throw on a thread without read access (issue #1432): $error",
+            error
+        )
     }
 
     //endregion


### PR DESCRIPTION
## Summary

- Fix the "Read access is allowed from inside read-action only" IDE error reported in #1432: Groovy rule scripts evaluate on the EasyAPI-background pool with no read action, and string interpolation (`"${it.type()}"`) implicitly called `ScriptTypeContext.toString()` / `ScriptPsiTypeContext.toString()`, which read `psiClass.qualifiedName` unprotected
- Wrap the affected PSI reads in `readSync` (a no-op inside an existing read action): both `toString()` overrides in `ScriptPsiContexts.kt` and the `qualifiedName` computation in `DefaultPsiClassHelper.buildObjectModel` (same latent pattern)
- Document the threading contract in `AGENTS.md` — three tiers (pure / internal pipeline / boundary), the thread entry points, and golden rules requiring script-facing context classes to self-protect every public member, including implicit hooks (`toString`/`hashCode`/`equals`) and reachable lazy initializers

Fixes #1432

## Test plan

- [x] New regression test `ScriptPsiContextsTest.testToStringOnNonReadActionThread`: calls `ScriptTypeContext.toString()` and `ScriptPsiTypeContext.toString()` on a plain thread with no read access — no exception, correct qualified name returned
- [x] Full `ScriptPsiContextsTest` suite passes: 65 tests, 0 failures, 0 errors
- [ ] Manual: on IntelliJ 2025.3 with a rule like `groovy:"type is ${it.type()}"`, export no longer raises the read-access error
