### PR TITLE
test: add MyBatis-Plus IPage response coverage

### DIFF
--- a/src/test/kotlin/com/itangcent/easyapi/framework/springmvc/IPageResponseExportTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/springmvc/IPageResponseExportTest.kt
@@ -1,0 +1,78 @@
+package com.itangcent.easyapi.framework.springmvc
+
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.core.psi.model.ObjectModel
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Verifies that a controller returning Result<IPage<UserInfo>> exports
+ * the full IPage structure (records/total/size/current) with the generic
+ * record element type expanded.
+ */
+class IPageResponseExportTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var exporter: SpringMvcClassExporter
+
+    override fun setUp() {
+        super.setUp()
+        loadTestFiles()
+        exporter = SpringMvcClassExporter(project)
+    }
+
+    private fun loadTestFiles() {
+        loadJDKClass("java.util.List")
+        loadJDKClass("java.util.Collection")
+        loadFile("spring/RestController.java")
+        loadFile("spring/RequestMapping.java")
+        loadFile("spring/GetMapping.java")
+        loadFile("model/Result.java")
+        loadFile("model/IResult.java")
+        loadFile("model/UserInfo.java")
+        loadFile("com/baomidou/mybatisplus/core/metadata/IPage.java")
+        loadFile("api/mybatisplus/PageController.java")
+    }
+
+    override fun createConfigReader() = TestConfigReader.empty(project)
+
+    fun testIPageResponseExpandsRecords() = runTest {
+        val psiClass = findClass("com.itangcent.mybatisplus.PageController")
+        assertNotNull(psiClass)
+
+        val endpoints = exporter.export(psiClass!!)
+        val listUsers = endpoints.find { it.httpMetadata?.path == "/page/users" }
+        assertNotNull("Should find /page/users endpoint", listUsers)
+
+        val responseBody = listUsers!!.httpMetadata?.responseBody
+        assertNotNull("responseBody should be populated", responseBody)
+        val resultObj = responseBody as? ObjectModel.Object
+        assertNotNull("responseBody should be an Object model (Result), but was: $responseBody", resultObj)
+        val resultFields = resultObj!!.fields
+        assertTrue("Result should contain 'code'", resultFields.containsKey("code"))
+        assertTrue("Result should contain 'msg'", resultFields.containsKey("msg"))
+
+        val dataField = resultFields["data"]
+        assertNotNull("Result should contain 'data'", dataField)
+        val pageObj = dataField!!.model as? ObjectModel.Object
+        assertNotNull(
+            "'data' (IPage<UserInfo>) should expand into an object with records/total/size/current, but was: ${dataField.model}",
+            pageObj
+        )
+        val pageFields = pageObj!!.fields
+        assertTrue("IPage should contain 'records', but had: ${pageFields.keys}", pageFields.containsKey("records"))
+        assertTrue("IPage should contain 'total'", pageFields.containsKey("total"))
+        assertTrue("IPage should contain 'size'", pageFields.containsKey("size"))
+        assertTrue("IPage should contain 'current'", pageFields.containsKey("current"))
+
+        val recordsModel = pageFields["records"]!!.model
+        assertTrue("'records' should be an array, but was: $recordsModel", recordsModel is ObjectModel.Array)
+        val elementModel = (recordsModel as ObjectModel.Array).item
+        val userObj = elementModel as? ObjectModel.Object
+        assertNotNull("'records' element should be a UserInfo object, but was: $elementModel", userObj)
+        assertTrue(
+            "UserInfo should contain 'name', but had: ${userObj!!.fields.keys}",
+            userObj.fields.containsKey("name")
+        )
+        assertTrue("UserInfo should contain 'age'", userObj.fields.containsKey("age"))
+    }
+}

--- a/src/test/resources/api/mybatisplus/PageController.java
+++ b/src/test/resources/api/mybatisplus/PageController.java
@@ -1,0 +1,26 @@
+package com.itangcent.mybatisplus;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.itangcent.model.Result;
+import com.itangcent.model.UserInfo;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * apis for paginated users, returning MyBatis-Plus IPage
+ */
+@RestController
+@RequestMapping("/page")
+public class PageController {
+
+    /**
+     * list users with pagination
+     *
+     * @return paged user list
+     */
+    @GetMapping("/users")
+    public Result<IPage<UserInfo>> listUsers() {
+        return Result.success(null);
+    }
+}

--- a/src/test/resources/com/baomidou/mybatisplus/core/metadata/IPage.java
+++ b/src/test/resources/com/baomidou/mybatisplus/core/metadata/IPage.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2011-2025, baomidou (jobob@qq.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.baomidou.mybatisplus.core.metadata;
+import java.io.Serializable;
+import java.util.List;
+import java.util.function.Function;
+import static java.util.stream.Collectors.toList;
+/**
+ * 分页 Page 对象接口
+ *
+ * @author hubin
+ * @since 2018-06-09
+ */
+public interface IPage<T> extends Serializable {
+    /**
+     * 获取排序信息，排序的字段和正反序
+     *
+     * @return 排序信息
+     */
+    List<OrderItem> orders();
+    /**
+     * 自动优化 COUNT SQL【 默认：true 】
+     *
+     * @return true 是 / false 否
+     */
+    default boolean optimizeCountSql() {
+        return true;
+    }
+    /**
+     * {@link com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor#isOptimizeJoin()}
+     * 两个参数都为 true 才会进行sql处理
+     *
+     * @since 3.4.4 @2021-09-13
+     */
+    default boolean optimizeJoinOfCountSql() {
+        return true;
+    }
+    /**
+     * 进行 count 查询 【 默认: true 】
+     *
+     * @return true 是 / false 否
+     */
+    default boolean searchCount() {
+        return true;
+    }
+    /**
+     * 计算当前分页偏移量
+     */
+    default long offset() {
+        long current = getCurrent();
+        if (current <= 1L) {
+            return 0L;
+        }
+        return Math.max((current - 1) * getSize(), 0L);
+    }
+    /**
+     * 最大每页分页数限制,优先级高于分页插件内的 maxLimit
+     *
+     * @since 3.4.0 @2020-07-17
+     */
+    default Long maxLimit() {
+        return null;
+    }
+    /**
+     * 当前分页总页数
+     */
+    default long getPages() {
+        if (getSize() == 0) {
+            return 0L;
+        }
+        long pages = getTotal() / getSize();
+        if (getTotal() % getSize() != 0) {
+            pages++;
+        }
+        return pages;
+    }
+    /**
+     * 内部什么也不干
+     * <p>只是为了 json 反序列化时不报错</p>
+     * @deprecated 3.5.8
+     */
+    @Deprecated
+    default IPage<T> setPages(long pages) {
+        // to do nothing
+        return this;
+    }
+    /**
+     * 分页记录列表
+     *
+     * @return 分页对象记录列表
+     */
+    List<T> getRecords();
+    /**
+     * 设置分页记录列表
+     */
+    IPage<T> setRecords(List<T> records);
+    /**
+     * 当前满足条件总行数
+     *
+     * @return 总条数
+     */
+    long getTotal();
+    /**
+     * 设置当前满足条件总行数
+     */
+    IPage<T> setTotal(long total);
+    /**
+     * 获取每页显示条数
+     *
+     * @return 每页显示条数
+     */
+    long getSize();
+    /**
+     * 设置每页显示条数
+     */
+    IPage<T> setSize(long size);
+    /**
+     * 当前页
+     *
+     * @return 当前页
+     */
+    long getCurrent();
+    /**
+     * 设置当前页
+     */
+    IPage<T> setCurrent(long current);
+    /**
+     * IPage 的泛型转换
+     *
+     * @param mapper 转换函数
+     * @param <R>    转换后的泛型
+     * @return 转换泛型后的 IPage
+     */
+    @SuppressWarnings("unchecked")
+    default <R> IPage<R> convert(Function<? super T, ? extends R> mapper) {
+        List<R> collect = this.getRecords().stream().map(mapper).collect(toList());
+        return ((IPage<R>) this).setRecords(collect);
+    }
+    /**
+     * 老分页插件不支持
+     * <p>
+     * MappedStatement 的 id
+     *
+     * @return id
+     * @since 3.4.0 @2020-06-19
+     */
+    default String countId() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Description

Add test coverage for MyBatis-Plus paginated responses. A controller returning `Result<IPage<UserInfo>>` must export the full IPage structure — `records` (expanded as an array of the generic element type), `total`, `size`, `current` — rather than an empty object.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

None — standalone test-case supplement.

## Changes Made

- Add `IPageResponseExportTest` covering `Result<IPage<UserInfo>>` responses exported via `SpringMvcClassExporter`
- Add `PageController` fixture exposing `GET /page/users`
- Add an `IPage` test fixture copied verbatim from the upstream MyBatis-Plus source, so the fixture surface matches the real library (fluent setters, default methods, deprecated `setPages`)

## Testing

- [x] Unit tests pass
- [x] Manual testing completed (verified against a real Spring Boot project using MyBatis-Plus 3.5.3.1)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

The `IPage` fixture under `src/test/resources/com/baomidou/mybatisplus/core/metadata/` is a verbatim copy of `com.baomidou.mybatisplus.core.metadata.IPage` from baomidou/mybatis-plus (Apache 2.0). Keeping it identical to upstream ensures the test keeps exercising the real library surface as it evolves.
