### PR TITLE
perf(rule): speed up field-model building

### DIFF
--- a/src/main/resources/extensions/field-utils.config
+++ b/src/main/resources/extensions/field-utils.config
@@ -20,16 +20,23 @@ field.ignore=groovy:!(it.hasModifier("private")||it.hasModifier("protected"))
 ignore_static_and_final_field=false
 
 # Ignore some common classes
-field.ignore=groovy:it.type().name()=="java.lang.Class"
-field.ignore=groovy:it.type().name()=="java.lang.ClassLoader"
-field.ignore=groovy:it.type().name()=="java.lang.Thread"
-field.ignore=groovy:it.type().name()=="java.lang.ThreadLocal"
-field.ignore=groovy:it.type().name()=="java.lang.Runtime"
-field.ignore=groovy:it.type().name()=="java.lang.System"
-field.ignore=groovy:it.type().name()=="java.lang.Process"
-field.ignore=groovy:it.type().name()=="java.lang.ProcessBuilder"
-field.ignore=groovy:it.type().name()=="java.lang.Appendable"
-field.ignore=groovy:it.type().name()=="java.lang.CharSequence"
-field.ignore=groovy:it.type().name()=="java.lang.Comparable"
-field.ignore=groovy:it.type().name()=="java.lang.Iterable"
-field.ignore=groovy:it.type().name()=="java.lang.Readable"
+# NOTE: kept as a single rule (list membership) instead of one rule per type —
+# each `field.ignore` entry is a separate Groovy evaluation per field.
+field.ignore=groovy:```
+    def commonTypes = [
+        "java.lang.Class",
+        "java.lang.ClassLoader",
+        "java.lang.Thread",
+        "java.lang.ThreadLocal",
+        "java.lang.Runtime",
+        "java.lang.System",
+        "java.lang.Process",
+        "java.lang.ProcessBuilder",
+        "java.lang.Appendable",
+        "java.lang.CharSequence",
+        "java.lang.Comparable",
+        "java.lang.Iterable",
+        "java.lang.Readable"
+    ]
+    return commonTypes.contains(it.type().name())
+```

--- a/src/test/kotlin/com/itangcent/easyapi/core/extension/BuiltInExtensionOnClassAndNegativeConditionScenarioTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/extension/BuiltInExtensionOnClassAndNegativeConditionScenarioTest.kt
@@ -20,6 +20,10 @@ class BuiltInExtensionOnClassAndNegativeConditionScenarioTest : EasyApiLightCode
         super.setUp()
         ExtensionConfigRegistry.loadExtensions()
         loadJDKClass("java.util.List")
+        loadJDKClass("java.lang.Class")
+        loadJDKClass("java.lang.ClassLoader")
+        loadJDKClass("java.lang.Thread")
+        loadJDKClass("java.lang.CharSequence")
         harness = BuiltInExtensionExecutionHarness(
             project = project,
             loadPsiFile = { path, content -> loadFile(path, content) },
@@ -290,6 +294,46 @@ class BuiltInExtensionOnClassAndNegativeConditionScenarioTest : EasyApiLightCode
             assertFalse(
                 message(scenario, "assert", condition, "inherited java.lang field"),
                 inheritedModel.fields.containsKey("traceId")
+            )
+        }
+    }
+
+    fun testFieldUtilsIgnoresCommonClassTypedFields() = runTest {
+        val scenario = scenario("field-utils")
+        harness.execute(
+            scenario,
+            fixturePlan("api/fieldutils/FieldUtilsDTO.java")
+        ) { session ->
+            val condition = "common-class type list rule"
+            assertSourceSelection(scenario, null, "no user override", condition)
+            val services = installExtension(session, RuleKeys.FIELD_IGNORE.name, condition)
+            val utilityDto = requireClass("com.itangcent.fieldutils.FieldUtilsDTO", scenario, condition)
+            val utilityModel = requireObject(
+                services.psiClassHelper.buildObjectModel(utilityDto, JsonOption.ALL),
+                scenario,
+                condition,
+                "field-utils DTO model"
+            )
+
+            assertTrue(
+                message(scenario, "assert", condition, "normal private field"),
+                utilityModel.fields.containsKey("normalField")
+            )
+            assertFalse(
+                message(scenario, "assert", condition, "Class-typed field"),
+                utilityModel.fields.containsKey("rawTypeField")
+            )
+            assertFalse(
+                message(scenario, "assert", condition, "ClassLoader-typed field"),
+                utilityModel.fields.containsKey("classLoaderField")
+            )
+            assertFalse(
+                message(scenario, "assert", condition, "Thread-typed field"),
+                utilityModel.fields.containsKey("threadField")
+            )
+            assertFalse(
+                message(scenario, "assert", condition, "CharSequence-typed field"),
+                utilityModel.fields.containsKey("charSequenceField")
             )
         }
     }

--- a/src/test/resources/api/fieldutils/FieldUtilsDTO.java
+++ b/src/test/resources/api/fieldutils/FieldUtilsDTO.java
@@ -10,6 +10,14 @@ public class FieldUtilsDTO {
 
     public String publicField;
 
+    private Class rawTypeField;
+
+    private ClassLoader classLoaderField;
+
+    private Thread threadField;
+
+    private CharSequence charSequenceField;
+
     public String getNormalField() { return normalField; }
     public void setNormalField(String normalField) { this.normalField = normalField; }
     public String getTransientField() { return transientField; }


### PR DESCRIPTION
## Description

The built-in `field-utils` extension declared 13 separate `field.ignore` rules under "Ignore some common classes" (one per java.lang type). The rule engine evaluates every same-key rule independently, each as a full Groovy `engine.eval()` with no script compilation cache, and each rule re-resolved the field type via `it.type()`. Fields that survive filtering (the common case) ran all 16 `field.ignore` rules.

This merges the 13 per-type rules into a single list-membership rule using the existing multi-line `groovy:``` block syntax (precedent: `yapi-mock.config`, `swagger3.config`), reducing per-field Groovy evaluations from 16 to 4 and resolving the field type once.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Performance improvement
- [x] Test coverage improvement

## Related Issues

N/A — identified during a code review of the rule evaluation hot path.

## Changes Made

- Merged 13 per-type `field.ignore` rules in `field-utils.config` into one list-membership rule (`commonTypes.contains(it.type().name())`); matching semantics unchanged (same 13 qualified names, same equality check)
- Extended `FieldUtilsDTO.java` fixture with `Class`/`ClassLoader`/`Thread`/`CharSequence`-typed fields
- Added `testFieldUtilsIgnoresCommonClassTypedFields` regression test asserting common-class-typed fields are still ignored while normal fields are kept

## Testing

- [x] Unit tests pass
- [ ] Manual testing completed
- [x] New tests added for new functionality

`BuiltInExtensionOnClassAndNegativeConditionScenarioTest` (incl. new test) and `BuiltInExtensionScenarioLedgerTest` (4/4, validates parsing of all 30 built-in extension configs incl. the new multi-line value) pass locally.

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Rule-engine context for reviewers: `RuleEngine.forEachApplicable` evaluates same-key rules sequentially and `BooleanRuleMode.ANY` only short-circuits on `true`, so non-ignored fields paid the full cost of every rule. `EnginePool` reuses `ScriptEngine` instances but has no compiled-script cache, so each rule is a fresh `eval()` per field.
