### PR TITLE
test: cover read-access fix for rule scripts

### DIFF
--- a/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/SourceHelperTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/psi/helper/SourceHelperTest.kt
@@ -1,5 +1,6 @@
 package com.itangcent.easyapi.core.psi.helper
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiClass
 import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
@@ -262,5 +263,61 @@ class SourceHelperTest : EasyApiLightCodeInsightFixtureTestCase() {
         val psiClass = findClass("com.test.source.StandaloneClass")!!
         val result = sourceHelper.getSourceElementSync(psiClass)
         assertSame("Should handle PsiClass directly", psiClass, result)
+    }
+
+    // --- threading regression (issue #1432: helper.findClass path) ---
+
+    /**
+     * Rule scripts run on the EasyAPI-background pool without a read action
+     * (Jsr223ScriptParser evaluates inside withContext(IdeDispatchers.Background)).
+     * A Groovy script calling helper.findClass(...) reaches
+     * [SourceHelper.getSourceClassSync], which must self-protect its PSI reads
+     * (psiClass.containingClass in isLocalClass) with readSync — see AGENTS.md
+     * "Thread-contract tiers (golden rules)".
+     *
+     * Records whether read access is actually held while isLocalClass reads
+     * containingClass, so removing the readSync wrapper fails this test even
+     * though unit-test mode relaxes ThreadingAssertions.
+     */
+    fun testGetSourceClassSyncHoldsReadAccessOnBackgroundThread() {
+        loadFile("source/BackgroundAccessClass.java", """
+            package com.test.source;
+            /**
+             * A class for the background read-access regression test.
+             */
+            public class BackgroundAccessClass {}
+        """.trimIndent())
+        val psiClass = findClass("com.test.source.BackgroundAccessClass")!!
+
+        var readAccessDuringCall: Boolean? = null
+        val recordingClass = object : PsiClass by psiClass {
+            override fun getContainingClass(): PsiClass? {
+                readAccessDuringCall = ApplicationManager.getApplication().isReadAccessAllowed
+                return psiClass.containingClass
+            }
+        }
+
+        var error: Throwable? = null
+        val thread = Thread {
+            try {
+                val result = sourceHelper.getSourceClassSync(recordingClass)
+                assertSame("Should return the same class", recordingClass, result)
+            } catch (t: Throwable) {
+                error = t
+            }
+        }
+        thread.name = "EasyAPI-background-test"
+        thread.start()
+        thread.join(10_000)
+
+        assertNull(
+            "getSourceClassSync must not throw on a thread without read access (issue #1432): $error",
+            error
+        )
+        assertEquals(
+            "getSourceClassSync must hold read access while reading PSI (issue #1432 findClass path)",
+            true,
+            readAccessDuringCall
+        )
     }
 }


### PR DESCRIPTION
## Description

Adds a regression test pinning the #1432 read-action fix. Rule scripts (`helper.findClass(...)`) are evaluated by `Jsr223ScriptParser` on the EasyAPI-background pool **without a read action**, so `SourceHelper.getSourceClassSync` must self-protect its PSI reads with `readSync`. The new test calls it from a bare thread (no read access) with a delegating `PsiClass` that records whether read access is actually held while `getContainingClass` is read — so removing the `readSync` wrapper fails the test even though unit-test mode relaxes `ThreadingAssertions`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage improvement

## Related Issues

<!-- Link to related issues using #issue_number -->

Refs #1432 (production fix already merged via #1433; this PR pins it against regression)

## Changes Made

<!-- List the main changes made in this PR -->

- Added `testGetSourceClassSyncHoldsReadAccessOnBackgroundThread` to `SourceHelperTest`
- Test invokes `getSourceClassSync` on a bare `EasyAPI-background-test` thread and asserts both: no throw without read access, and read access held during `getContainingClass`

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass
- [ ] Manual testing completed
- [x] New tests added for new functionality

Ran `./gradlew test --tests "com.itangcent.easyapi.core.psi.helper.SourceHelperTest"` — all 13 tests pass, including the new regression test.

## Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

<!-- Add any additional notes or context about the PR -->

The stack trace in #1432 matched pre-fix line numbers (`SourceHelper.kt:144` calling `tryGetSourceClass` directly), i.e. the crash came from builds at or before v3.2.2. Master already contains the `readSync` wrapper; this test-only PR guards the boundary-class "self-protect unconditionally" contract from AGENTS.md.
