### PR TITLE
fix: propagate required flag to @RequestHeader-derived headers

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/DocMetadataResolver.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/helper/DocMetadataResolver.kt
@@ -233,6 +233,17 @@ class DocMetadataResolver internal constructor(
         return engine.evaluate(RuleKeys.PARAM_REQUIRED, parameter)
     }
 
+    /**
+     * Resolves the raw `param.required` rule result for a parameter.
+     *
+     * Returns `null` when no rule is configured, so the caller can apply a
+     * framework-specific default (e.g. Spring's `@RequestHeader` is required
+     * unless `required = false` is declared).
+     */
+    suspend fun resolveParamRequired(parameter: PsiParameter): Boolean? {
+        return engine.evaluateOrNull(RuleKeys.PARAM_REQUIRED, parameter)
+    }
+
     suspend fun isParamIgnored(parameter: PsiParameter): Boolean {
         return engine.evaluate(RuleKeys.PARAM_IGNORE, parameter)
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
@@ -110,6 +110,18 @@ class RuleEngine internal constructor(
     }
 
     /**
+     * Evaluates a boolean rule and returns `null` when no rule is configured
+     * for the key, letting the caller apply a framework-specific default.
+     */
+    suspend fun evaluateOrNull(
+        key: RuleKey.BooleanKey,
+        element: PsiElement,
+        fieldContext: String? = null
+    ): Boolean? {
+        return forEachApplicable(key) { RuleContext.from(project, element, fieldContext) }
+    }
+
+    /**
      * Evaluates a member rule from the perspective of [containingClass].
      * This preserves the distinction between a member's current containing
      * class and its original declaring class for inherited members.

--- a/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporter.kt
@@ -413,7 +413,15 @@ class CustomClassExporter(
             val name = resolveParamName(p, param.name, binding)
             val defaultValue = metadataResolver.resolveParamDefaultValue(p)
             val example = metadataResolver.resolveParamDemo(p)
-            headers.add(ApiHeader(name = name, value = defaultValue ?: example))
+            headers.add(
+                ApiHeader(
+                    name = name,
+                    value = defaultValue ?: example,
+                    // Honour `param.required` for header-bound parameters instead of
+                    // always emitting false.
+                    required = metadataResolver.isParamRequired(p)
+                )
+            )
         }
         return headers
     }

--- a/src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsClassExporter.kt
@@ -203,7 +203,17 @@ class JaxRsClassExporter(
                 val resolved = parameterResolver.resolve(p)
                 for (param in resolved) {
                     if (param.binding == ParameterBinding.Header) {
-                        headers.add(ApiHeader(name = param.name, value = param.defaultValue ?: param.example))
+                        headers.add(
+                            ApiHeader(
+                                name = param.name,
+                                value = param.defaultValue ?: param.example,
+                                // Honour `param.required` for header parameters. Resolved
+                                // from the PsiParameter because the entries returned by
+                                // the parameter resolver are produced before
+                                // `param.required` is applied to the ApiParameter list.
+                                required = metadataResolver.isParamRequired(p)
+                            )
+                        )
                     }
                 }
             }

--- a/src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcClassExporter.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcClassExporter.kt
@@ -431,9 +431,35 @@ class SpringMvcClassExporter(
             val name = metadataResolver.resolveParamName(p, param.name)
             val defaultValue = metadataResolver.resolveParamDefaultValue(p)
             val example = metadataResolver.resolveParamDemo(p)
-            headers.add(ApiHeader(name = name, value = defaultValue ?: example))
+            headers.add(
+                ApiHeader(
+                    name = name,
+                    value = defaultValue ?: example,
+                    // `param.required` wins when configured; otherwise fall back to
+                    // the Spring default (@RequestHeader is required unless declared
+                    // otherwise).
+                    required = metadataResolver.resolveParamRequired(p)
+                        ?: isRequestHeaderRequiredByDefault(p)
+                )
+            )
         }
         return headers
+    }
+
+    /**
+     * Spring default for `@RequestHeader`: the header is required unless
+     * `required = false` is declared explicitly. Only consulted when no
+     * `param.required` rule is configured.
+     */
+    private suspend fun isRequestHeaderRequiredByDefault(parameter: PsiParameter): Boolean {
+        if (!annotationHelper.hasAnn(parameter, SpringMvcConstants.Annotations.REQUEST_HEADER)) {
+            return false
+        }
+        return annotationHelper.findAttrAsString(
+            parameter,
+            SpringMvcConstants.Annotations.REQUEST_HEADER,
+            "required"
+        ) != "false"
     }
 
     /**

--- a/src/test/kotlin/com/itangcent/easyapi/channel/yapi/YapiFormatterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/channel/yapi/YapiFormatterTest.kt
@@ -101,6 +101,29 @@ class YapiFormatterTest {
     }
 
     @Test
+    fun testFormatEndpointPropagatesHeaderRequiredFlag() {
+        val endpoint = ApiEndpoint(
+            name = "Protected API",
+            metadata = httpMetadata(
+                path = "/api/protected",
+                method = HttpMethod.GET,
+                headers = listOf(
+                    ApiHeader(name = "x-user-id", value = "42", required = true),
+                    ApiHeader(name = "x-timezone-id", value = "UTC", required = false)
+                )
+            )
+        )
+
+        val doc = formatter.format(endpoint)
+
+        assertEquals(2, doc.reqHeaders?.size)
+        assertEquals("x-user-id", doc.reqHeaders?.get(0)?.name)
+        assertEquals(1, doc.reqHeaders?.get(0)?.required)
+        assertEquals("x-timezone-id", doc.reqHeaders?.get(1)?.name)
+        assertEquals(0, doc.reqHeaders?.get(1)?.required)
+    }
+
+    @Test
     fun testFormatEndpointWithFormParams() {
         val endpoint = ApiEndpoint(
             name = "Login",

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngineTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngineTest.kt
@@ -187,6 +187,54 @@ class RuleEngineTest : EasyApiLightCodeInsightFixtureTestCase() {
     }
 
     @Test
+    fun testEvaluateOrNullWithEmptyConfig() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.empty(project)
+        )
+
+        val ruleEngine = RuleEngine.getInstance(project)
+        val mockElement = mock<PsiElement>()
+
+        val result = ruleEngine.evaluateOrNull(RuleKey.boolean("nonexistent.key"), mockElement)
+        assertNull("evaluateOrNull must return null when no rule is configured", result)
+    }
+
+    @Test
+    fun testEvaluateOrNullWithTrueValue() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "ignore" to "true"
+            )
+        )
+
+        val ruleEngine = RuleEngine.getInstance(project)
+        val mockElement = mock<PsiElement>()
+
+        val result = ruleEngine.evaluateOrNull(RuleKey.boolean("ignore"), mockElement)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun testEvaluateOrNullWithFalseValue() = runTest {
+        project.registerServiceInstance(
+            serviceInterface = ConfigReader::class.java,
+            instance = TestConfigReader.fromRules(
+                project,
+                "ignore" to "false"
+            )
+        )
+
+        val ruleEngine = RuleEngine.getInstance(project)
+        val mockElement = mock<PsiElement>()
+
+        val result = ruleEngine.evaluateOrNull(RuleKey.boolean("ignore"), mockElement)
+        assertEquals(false, result)
+    }
+
+    @Test
     fun testEvaluateIntWithValue() = runTest {
         project.registerServiceInstance(
             serviceInterface = ConfigReader::class.java,

--- a/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/custom/CustomClassExporterTest.kt
@@ -305,4 +305,57 @@ class CustomClassExporterTest {
             assertNotNull("getByCookie should have a cookie parameter", cookieParam)
         }
     }
+
+    /** Reference ruleset + a `param.required` rule matching @RequestHeader. */
+    class WithParamRequiredRule : EasyApiLightCodeInsightFixtureTestCase() {
+
+        private lateinit var exporter: CustomClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadTestFiles()
+            exporter = CustomClassExporter(project)
+        }
+
+        private fun loadTestFiles() {
+            loadFile("spring/Controller.java")
+            loadFile("spring/RestController.java")
+            loadFile("spring/ResponseBody.java")
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/GetMapping.java")
+            loadFile("spring/PostMapping.java")
+            loadFile("spring/PathVariable.java")
+            loadFile("spring/RequestParam.java")
+            loadFile("spring/RequestBody.java")
+            loadFile("spring/RequestHeader.java")
+            loadFile("spring/CookieValue.java")
+            loadFile("spring/ModelAttribute.java")
+            loadFile("spring/AliasFor.java")
+            loadFile("spring/Component.java")
+            loadFile("model/Result.java")
+            loadFile("model/UserInfo.java")
+            loadFile("custom/api/SpringParityCtrl.java")
+        }
+
+        override fun createConfigReader(): com.itangcent.easyapi.core.config.ConfigReader {
+            val ruleset = javaClass.getResourceAsStream("/custom/custom-spring-reference.rules")!!
+                .reader().readText()
+            return TestConfigReader.fromConfigText(
+                project,
+                ruleset + "\nparam.required=groovy:it.hasAnn(\"org.springframework.web.bind.annotation.RequestHeader\")"
+            )
+        }
+
+        fun testParamRequiredRuleReachesHeader() = runTest {
+            val psiClass = findClass("com.itangcent.custom.SpringParityCtrl")
+            assertNotNull(psiClass)
+
+            val endpoints = exporter.export(psiClass!!)
+            val getByHeader = endpoints.find { it.sourceMethod?.name == "getByHeader" }
+            assertNotNull(getByHeader)
+            val headerParam = getByHeader!!.httpMetadata!!.parameters.find { it.binding == ParameterBinding.Header }
+            assertNotNull("getByHeader should have a header parameter", headerParam)
+            assertTrue("header param should be required when param.required matches", headerParam!!.required)
+        }
+    }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsHeaderRequiredTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/jaxrs/JaxRsHeaderRequiredTest.kt
@@ -1,0 +1,105 @@
+package com.itangcent.easyapi.framework.jaxrs
+
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.export.ApiHeader
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Regression coverage for the JAX-RS side of header required-flag propagation.
+ *
+ * `JaxRsClassExporter.extractParamHeaders` builds [ApiHeader] from the resolved
+ * parameter list without consulting `param.required`, so header parameters never
+ * carried a required flag. JAX-RS has no `required` attribute on `@HeaderParam`,
+ * so `param.required` is the only source of truth here.
+ */
+class JaxRsHeaderRequiredTest {
+
+    abstract class Base : EasyApiLightCodeInsightFixtureTestCase() {
+
+        protected lateinit var exporter: JaxRsClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadJaxRsStubs()
+            exporter = JaxRsClassExporter(project)
+        }
+
+        protected fun loadJaxRsStubs() {
+            loadFile("jaxrs/Path.java")
+            loadFile("jaxrs/POST.java")
+            loadFile("jaxrs/HeaderParam.java")
+            loadFile("model/Result.java")
+            loadFile("model/IResult.java")
+            loadFile(
+                "api/jaxrs/HeaderResource.java",
+                """
+                package com.itangcent.jaxrs;
+                import com.itangcent.model.Result;
+                import javax.ws.rs.HeaderParam;
+                import javax.ws.rs.POST;
+                import javax.ws.rs.Path;
+
+                @Path("/headers")
+                public class HeaderResource {
+
+                    @POST
+                    @Path("/apply")
+                    public Result<String> apply(@HeaderParam("x-user-id") String userId) {
+                        return Result.success("ok");
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        protected suspend fun exportUserIdHeader(): ApiHeader {
+            val psiClass = findClass("com.itangcent.jaxrs.HeaderResource")
+            assertNotNull("HeaderResource should be resolvable", psiClass)
+            val endpoints = exporter.export(psiClass!!)
+            val endpoint = endpoints.singleOrNull { it.httpMetadata?.path == "/headers/apply" }
+            assertNotNull(
+                "Should export /headers/apply; actual=${endpoints.map { it.httpMetadata?.path }}",
+                endpoint
+            )
+            val headers = endpoint!!.httpMetadata!!.headers
+            val header = headers.singleOrNull { it.name == "x-user-id" }
+            assertNotNull(
+                "@HeaderParam(\"x-user-id\") should be exported as a header; " +
+                    "actual=[${headers.joinToString { "${it.name}(required=${it.required})" }}]",
+                header
+            )
+            return header!!
+        }
+    }
+
+    class WithParamRequiredRule : Base() {
+
+        override fun createConfigReader(): ConfigReader {
+            return TestConfigReader.fromRules(
+                project,
+                "param.required[@javax.ws.rs.HeaderParam]" to "true"
+            )
+        }
+
+        fun testParamRequiredRuleReachesTheHeader() = runTest {
+            assertTrue(
+                "A param.required rule must be honoured for JAX-RS header parameters",
+                exportUserIdHeader().required
+            )
+        }
+    }
+
+    class WithoutAnyRule : Base() {
+
+        override fun createConfigReader(): ConfigReader = TestConfigReader.empty(project)
+
+        fun testHeaderRequiredDefaultsToFalseWithoutRules() = runTest {
+            assertFalse(
+                "Without a param.required rule the header stays optional",
+                exportUserIdHeader().required
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcRequestHeaderRequiredTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/framework/springmvc/SpringMvcRequestHeaderRequiredTest.kt
@@ -1,0 +1,167 @@
+package com.itangcent.easyapi.framework.springmvc
+
+import com.itangcent.easyapi.core.config.ConfigReader
+import com.itangcent.easyapi.core.export.httpMetadata
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import com.itangcent.easyapi.testFramework.TestConfigReader
+
+/**
+ * Regression coverage for `@RequestHeader` required-flag propagation.
+ *
+ * Header-bound parameters are exported through a dedicated branch
+ * (`extractParamHeaders`) that builds [com.itangcent.easyapi.core.export.ApiHeader]
+ * independently of the `ApiParameter` pipeline. The `param.required` rule must be
+ * honoured for these parameters, and — when no rule is configured — the Spring
+ * default applies: `@RequestHeader` is required unless `required = false` is
+ * declared explicitly.
+ */
+class SpringMvcRequestHeaderRequiredTest {
+
+    abstract class Base : EasyApiLightCodeInsightFixtureTestCase() {
+
+        protected lateinit var exporter: SpringMvcClassExporter
+
+        override fun setUp() {
+            super.setUp()
+            loadSpringStubs()
+            exporter = SpringMvcClassExporter(project)
+        }
+
+        protected fun loadSpringStubs() {
+            loadFile("spring/RestController.java")
+            loadFile("spring/RequestMapping.java")
+            loadFile("spring/PostMapping.java")
+            loadFile("spring/RequestHeader.java")
+            loadFile("spring/RequestParam.java")
+            loadFile("model/Result.java")
+            loadFile("model/IResult.java")
+        }
+
+        protected fun loadHeaderController() {
+            loadFile(
+                "api/HeaderRequiredCtrl.java",
+                """
+                package com.itangcent.api;
+                import com.itangcent.model.Result;
+                import org.springframework.web.bind.annotation.PostMapping;
+                import org.springframework.web.bind.annotation.RequestHeader;
+                import org.springframework.web.bind.annotation.RequestMapping;
+                import org.springframework.web.bind.annotation.RestController;
+
+                @RestController
+                @RequestMapping(value = "/statuses")
+                public class HeaderRequiredCtrl {
+
+                    /**
+                     * update message
+                     *
+                     * @param userId      caller id
+                     * @param timezoneId  caller timezone
+                     * @return update result
+                     */
+                    @PostMapping(value = "/classifications")
+                    public Result<String> updateMessage(
+                            @RequestHeader("x-user-id") String userId,
+                            @RequestHeader(value = "x-timezone-id", required = false) String timezoneId) {
+                        return Result.success("ok");
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+
+        /**
+         * With an empty rule set the exported header name falls back to the Java
+         * parameter name, so the two `@RequestHeader` parameters surface as
+         * `userId` and `timezoneId`.
+         */
+        protected suspend fun exportHeaders(): List<com.itangcent.easyapi.core.export.ApiHeader> {
+            loadHeaderController()
+            val psiClass = findClass("com.itangcent.api.HeaderRequiredCtrl")
+            assertNotNull("HeaderRequiredCtrl should be resolvable", psiClass)
+            val endpoints = exporter.export(psiClass!!)
+            val endpoint = endpoints.singleOrNull { it.httpMetadata?.path == "/statuses/classifications" }
+            assertNotNull(
+                "Should export /statuses/classifications; actual=${endpoints.map { it.httpMetadata?.path }}",
+                endpoint
+            )
+            return endpoint!!.httpMetadata!!.headers
+        }
+
+        protected fun assertRequiredMatchesSpringDeclaration(
+            headers: List<com.itangcent.easyapi.core.export.ApiHeader>
+        ) {
+            val dump = headers.joinToString { "${it.name}(required=${it.required})" }
+            val userId = headers.singleOrNull { it.name == "userId" }
+            assertNotNull("userId should be exported as a header; actual headers=[$dump]", userId)
+            assertTrue(
+                "@RequestHeader without required=false is required, so the header must be marked required",
+                userId!!.required
+            )
+
+            val timezoneId = headers.singleOrNull { it.name == "timezoneId" }
+            assertNotNull("timezoneId should be exported as a header; actual headers=[$dump]", timezoneId)
+            assertFalse(
+                "@RequestHeader(required = false) must be exported as an optional header",
+                timezoneId!!.required
+            )
+        }
+    }
+
+    /**
+     * No `param.required` rule configured: the Spring default applies in code —
+     * `@RequestHeader` is required, `@RequestHeader(required = false)` is optional.
+     */
+    class WithSpringDefaultBehavior : Base() {
+
+        override fun createConfigReader(): ConfigReader = TestConfigReader.empty(project)
+
+        fun testSpringRequestHeaderDefaultIsAppliedWithoutRules() = runTest {
+            assertRequiredMatchesSpringDeclaration(exportHeaders())
+        }
+    }
+
+    /**
+     * A user-authored `param.required` rule matching the issue report must be
+     * honoured for header parameters exactly like it is for query parameters.
+     */
+    class WithExplicitCustomRule : Base() {
+
+        override fun createConfigReader(): ConfigReader {
+            return TestConfigReader.fromRules(
+                project,
+                "param.required[@org.springframework.web.bind.annotation.RequestHeader]" to
+                    """groovy:it.ann("org.springframework.web.bind.annotation.RequestHeader", "required") != "false""""
+            )
+        }
+
+        fun testCustomParamRequiredRuleIsPropagatedToApiHeader() = runTest {
+            assertRequiredMatchesSpringDeclaration(exportHeaders())
+        }
+    }
+
+    /**
+     * An explicit rule overrides the Spring default: `param.required = false`
+     * must win over the annotation's implied `required = true`.
+     */
+    class CustomRuleTakesPrecedenceOverSpringDefault : Base() {
+
+        override fun createConfigReader(): ConfigReader {
+            return TestConfigReader.fromRules(
+                project,
+                "param.required[@org.springframework.web.bind.annotation.RequestHeader]" to "false"
+            )
+        }
+
+        fun testCustomRuleOverridesSpringDefault() = runTest {
+            val headers = exportHeaders()
+            headers.forEach { header ->
+                assertFalse(
+                    "param.required=false must win over the @RequestHeader default " +
+                        "(header=${header.name})",
+                    header.required
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1440: header parameters declared with `@RequestHeader` were exported through a
dedicated `extractParamHeaders` branch that built `ApiHeader` without consulting the
`param.required` rule. As a result headers always carried `required = false` and YApi
`req_headers[].required` was always `0`, even when the rule resolved to `true`.

## Changes

- **Spring MVC** (`SpringMvcClassExporter`): `param.required` now wins when configured;
  when no rule is set, the Spring default is applied in code — `@RequestHeader` is
  required unless `required = false` is declared explicitly.
- **JAX-RS** (`JaxRsClassExporter`) and **custom framework** (`CustomClassExporter`):
  `param.required` is now honoured for header-bound parameters (previously always
  emitted `required = false`).
- **Rule engine**: added `RuleEngine.evaluateOrNull` and
  `DocMetadataResolver.resolveParamRequired` so a framework-specific default can be
  applied only when no rule is configured.
- YApi (`req_headers[].required`) and OpenAPI (`header.required`) consumers now see the
  correct flag.

## Tests

- `SpringMvcRequestHeaderRequiredTest` — covers the Spring default (no rules), the
  exact custom rule from the report, and rule-overrides-default precedence.
- `JaxRsHeaderRequiredTest` — covers rule-driven required propagation for `@HeaderParam`.
- `YapiFormatterTest` — added a contract test for the `req_headers[].required` mapping.

All new tests pass and the `com.itangcent.easyapi.framework.*` package is green. The
full suite could not be completed on this machine because the test executor JVM runs
out of native memory (pre-existing environment limitation, unrelated to this change).

## Notes

- Without a `param.required` rule, `@RequestParam` (query params) keeps its current
  behaviour (optional). Aligning `@RequestParam` with the Spring default would be a
  separate, broader change.
- The header name for a parameter without a `param.name` rule still falls back to the
  Java parameter name rather than the `@RequestHeader` value — pre-existing behaviour,
  out of scope here.
