### PR TITLE
release v3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the EasyAPI plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.4] - 2026-09-05
+
+### Added
+- feat(ai): accept simple class names in PSI tools
+- feat(ai): self-describing rule keys with exported context catalogs
+-  add best-effort compatibility builds for older IDEA versions (#1438)
+
+### Fixed
+- fix(rules): surface rule failures during export
+- fix(ai): read rule files relative to project dir
+- fix(rules): garbled Chinese text in rule files
+-  stop dropping public fields from exported models (#1443)
+-  propagate required flag to @RequestHeader-derived headers (#1441)
+-  prevent read-access error in rule scripts (#1432) (#1433)
+
+### Improved
+- enhance(ai): teach the rule agent contextType()
+- docs: document isExtend FQN contract
+- test: cover read-access fix for rule scripts (#1437)
+- perf(rule): speed up field-model building (#1436)
+- test: add MyBatis-Plus IPage response coverage (#1435)
+
+---
+
 ## [3.2.3] - 2026-08-11
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.workers.max=2
 kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
 # Plugin base version (semver, e.g. 3.2.3) — bumped by script/release.sh.
 # Full version is <base>.<since>.<until|0>, e.g. 3.2.3.252.0.
-pluginBaseVersion=3.2.3
+pluginBaseVersion=3.2.4
 # Default IDEA compatibility lower bound (build number, e.g. 252 = 2025.2).
 # Override per invocation: ./gradlew buildPlugin -PpluginSinceBuild=243 [-PpluginUntilBuild=252]
 pluginSinceBuild=252


### PR DESCRIPTION
## Release Changes

* feat(ai): accept simple class names in PSI tools
* feat(ai): self-describing rule keys with exported context catalogs
* fix(rules): surface rule failures during export
* fix(ai): read rule files relative to project dir
* fix(rules): garbled Chinese text in rule files
* enhance(ai): teach the rule agent contextType()
* docs: document isExtend FQN contract
* fix: stop dropping public fields from exported models (#1443)
* fix: propagate required flag to @RequestHeader-derived headers (#1441)
* feat: add best-effort compatibility builds for older IDEA versions (#1438)
* test: cover read-access fix for rule scripts (#1437)
* perf(rule): speed up field-model building (#1436)
* test: add MyBatis-Plus IPage response coverage (#1435)
* fix: prevent read-access error in rule scripts (#1432) (#1433)