### PR TITLE
chore(ci): skip CI/CO/packaging for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
               return core.setOutput('should-skip', 'true');
             }
             
-            console.log('PR does not have type: doc label, continuing with CI');
+            const releaseLabel = labels.data.find(label => label.name === 'release');
+            if (releaseLabel) {
+              console.log('PR has release label, skipping CI');
+              return core.setOutput('should-skip', 'true');
+            }
+            
+            console.log('PR has no skip labels, continuing with CI');
             return core.setOutput('should-skip', 'false');
 
   build-test:

--- a/.github/workflows/co.yml
+++ b/.github/workflows/co.yml
@@ -29,7 +29,13 @@ jobs:
               return core.setOutput('should-skip', 'true');
             }
             
-            console.log('PR does not have type: doc label, continuing with CO');
+            const releaseLabel = labels.data.find(label => label.name === 'release');
+            if (releaseLabel) {
+              console.log('PR has release label, skipping CO');
+              return core.setOutput('should-skip', 'true');
+            }
+            
+            console.log('PR has no skip labels, continuing with CO');
             return core.setOutput('should-skip', 'false');
 
   coverage:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -17,7 +17,33 @@ env:
   COMPAT_UNTIL: '251'
 
 jobs:
+  check-skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should-skip: ${{ steps.check-labels.outputs.should-skip }}
+    steps:
+      - id: check-labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const releaseLabel = labels.data.find(label => label.name === 'release');
+            if (releaseLabel) {
+              console.log('PR has release label, skipping packaging');
+              return core.setOutput('should-skip', 'true');
+            }
+
+            console.log('PR has no release label, continuing with packaging');
+            return core.setOutput('should-skip', 'false');
+
   package-and-comment:
+    needs: check-skip
+    if: needs.check-skip.outputs.should-skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Release PRs (e.g. `release/v3.2.4`) only bump `pluginBaseVersion` and the changelog. The actual build/publish is handled by the **Create Release** workflow on `master` after merge. Right now those release PRs also trigger the full PR-scoped checks, which is wasteful and noisy:

- **CI** — full matrix (3 OS × 2 JDK), each running `test` + `buildPlugin`
- **CO** — `check` + `koverXmlReport` + Codecov upload (`fail_ci_if_error: true`)
- **PR Package and Comment** — builds both packages, uploads artifacts, posts "📦 Plugin has been packaged" comments on the PR

## Change

Add a `release` label skip guard to all three workflows, mirroring the existing `type: doc` mechanism. The `release` label is already applied automatically by `auto-label.yml`, so no manual step is required.

### File-level change matrix

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `check-labels` step now also skips when the `release` label is present |
| `.github/workflows/co.yml` | Same `release` label skip guard added |
| `.github/workflows/pr-package.yml` | New `check-skip` job gating `package-and-comment` on the `release` label |

After merge, the next release PR (e.g. `release/v3.2.5`) will skip CI/CO/packaging and only run `Update Release PR` + `Auto Label PR`, then the real `Create Release` on merge.

## Testing

- Label-based guard is identical in shape to the already-working `type: doc` skip.
- Non-release PRs are unaffected — the guard only short-circuits when the `release` label is present.