### PR TITLE
fix(dashboard): refresh pristine snapshot after Reset to Default

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanel.kt
@@ -1520,6 +1520,13 @@ class EndpointDetailsPanel(
         } finally {
             isLoading = false
         }
+
+        // Re-capture the pristine snapshot for the freshly reloaded model content.
+        // Without this, `pristineSnapshot` still holds the pre-reset merged content, so
+        // switching away would serialize the (now model-default) UI state, find it
+        // differs from the stale snapshot, and re-persist a cache row — defeating the
+        // reset's "leave no cached edit" intent.
+        pristineSnapshot = currentEndpoint?.let { currentEditCache(it) }?.let { GsonUtils.toJson(it) }
     }
 
     fun resetEndpoint(endpoint: ApiEndpoint) {


### PR DESCRIPTION
## Description

A follow-up to #1448. That PR introduced a `pristineSnapshot` dirty-check (P1-a) so merely opening an endpoint doesn't persist a cache row, but it did not refresh the snapshot inside `resetCurrentEndpoint`. As a result, after "Reset to Default" the snapshot still held the pre-reset merged content, and switching away re-persisted a cache row — undoing the reset's "leave no cached edit" intent.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues

Follow-up to #1448 / issue #1446

## Affected Area

- [ ] YApi export
- [ ] Postman export
- [ ] Markdown export
- [ ] Send HTTP request (Call)
- [x] API scanning / dashboard
- [ ] Rule engine / custom rules / config
- [ ] Settings / UI
- [ ] Other / not user-facing

## Changes Made

- In `EndpointDetailsPanel.resetCurrentEndpoint`, re-capture `pristineSnapshot` after deleting the cached edit and reloading the endpoint from the source model, mirroring the capture at the end of `showEndpoint`.

## How I Tested

- [x] `./gradlew test` passes (full suite)
- [ ] Manual verification in a sandbox IDE (`./gradlew runIde`)
- [ ] New tests added for new functionality (N/A — Swing/UI method not covered by the pure-logic test framework; the change is a one-line state sync)

## Architecture & Threading Checklist

- [x] New code lives in the right bucket (`core/dashboard/`, no `core.*` → concrete sibling imports)
- [x] PSI/VFS reads wrapped — `currentEditCache` only reads UI table models, no PSI access
- [x] Boundary classes self-protect — no new public members
- [x] PSI writes and UI updates go through `write {}` / `swing {}` — unchanged
- [x] No new `launch(Dispatchers.Default)` from EDT/startup contexts

## Logging Checklist

- [x] Exactly one channel per event — no logging added
- [x] No `LOG.error` / `LOG.debug` / `LOG.trace` / `println` / `printStackTrace()`
- [x] No silent `runCatching{}.getOrNull()` or empty `catch`

## General Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — no user-facing surface change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — see above)
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

N/A

## Additional Notes

Low severity (the re-persisted row contained model-default values, never stale data), but it defeated the reset's intent and left a residual row that "Clean Up Request Edits" would classify as live. The fix keeps the request-edit cache clean after a reset.