### PR TITLE
fix(scan): eliminate API scan hangs and reduce scan cost

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManager.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/cache/api/ApiIndexManager.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiManager
 import com.itangcent.easyapi.core.dashboard.ApiScanner
 import com.itangcent.easyapi.core.export.ApiEndpoint
 import com.itangcent.easyapi.core.export.recognizer.CompositeApiClassRecognizer
+import com.itangcent.easyapi.core.export.recognizer.MetaAnnotationResolver
 import com.itangcent.easyapi.core.internal.threading.IdeDispatchers
 import com.itangcent.easyapi.core.internal.threading.read
 import com.itangcent.easyapi.core.logging.IdeaLog
@@ -507,11 +508,16 @@ class ApiIndexManager internal constructor(
     }
 
     private suspend fun executeFullScan(session: ScanSession, source: String): ApiScanResult {
+        val startedAt = System.currentTimeMillis()
         return try {
             LOG.info(
                 "API full scan generation=${session.generation} source=$source result=started"
             )
             val endpoints = scanExecutor.scanAll()
+            // Split timings: scanAll() is the ApiScanner pass (already reported by
+            // ApiScanMonitor), commit is the index swap + mutation publish. Without
+            // this split a slow commit is indistinguishable from a slow scan.
+            val scanMs = System.currentTimeMillis() - startedAt
             val mutation = synchronized(sessionLock) {
                 if (!isCurrentLocked(session)) {
                     null
@@ -519,13 +525,21 @@ class ApiIndexManager internal constructor(
                     apiIndex.replaceEndpointsSnapshot(endpoints)
                 }
             }
+            val commitMs = System.currentTimeMillis() - startedAt - scanMs
             if (mutation == null) {
+                LOG.info(
+                    "API full scan generation=${session.generation} source=$source " +
+                        "result=stale elapsed=${System.currentTimeMillis() - startedAt}ms " +
+                        "scan=${scanMs}ms endpoints=${endpoints.size}"
+                )
                 ApiScanResult.Rejected(currentGeneration(), ApiScanRejectionReason.STALE_GENERATION)
             } else {
                 apiIndex.publishMutation(mutation, "API full scan committed")
                 LOG.info(
                     "API full scan generation=${session.generation} source=$source " +
-                        "result=success endpoints=${endpoints.size}"
+                        "result=success endpoints=${endpoints.size} " +
+                        "elapsed=${System.currentTimeMillis() - startedAt}ms " +
+                        "scan=${scanMs}ms commit=${commitMs}ms"
                 )
                 ApiScanResult.Success(session.generation, endpoints.size)
             }
@@ -533,7 +547,8 @@ class ApiIndexManager internal constructor(
             throw e
         } catch (e: Exception) {
             LOG.warn(
-                "API full scan generation=${session.generation} source=$source result=failed",
+                "API full scan generation=${session.generation} source=$source result=failed " +
+                    "elapsed=${System.currentTimeMillis() - startedAt}ms",
                 e
             )
             ApiScanResult.Failed(session.generation, e)
@@ -545,6 +560,7 @@ class ApiIndexManager internal constructor(
         filePaths: List<String>,
         source: String
     ): ApiScanResult {
+        val startedAt = System.currentTimeMillis()
         return try {
             val changedClasses = findClassesFromFiles(filePaths)
             if (changedClasses.isEmpty()) {
@@ -558,7 +574,9 @@ class ApiIndexManager internal constructor(
             val changedClassNames = read {
                 changedClasses.mapNotNull { it.qualifiedName }.toSet()
             }
+            val scanStartedAt = System.currentTimeMillis()
             val endpoints = scanExecutor.scanClasses(changedClasses)
+            val scanMs = System.currentTimeMillis() - scanStartedAt
             val classEndpoints = changedClassNames.associateWith { className ->
                 endpoints.filter { it.className == className }
             }
@@ -569,6 +587,7 @@ class ApiIndexManager internal constructor(
                     apiIndex.updateEndpointsByClassesSnapshot(classEndpoints)
                 }
             }
+            val commitMs = System.currentTimeMillis() - scanStartedAt - scanMs
             if (mutation == null) {
                 ApiScanResult.Rejected(currentGeneration(), ApiScanRejectionReason.STALE_GENERATION)
             } else {
@@ -576,7 +595,9 @@ class ApiIndexManager internal constructor(
                 session.lastIncrementalScanTime = System.currentTimeMillis()
                 LOG.info(
                     "API incremental scan generation=${session.generation} source=$source " +
-                        "result=success endpoints=${endpoints.size}"
+                        "result=success endpoints=${endpoints.size} classes=${changedClasses.size} " +
+                        "elapsed=${System.currentTimeMillis() - startedAt}ms " +
+                        "scan=${scanMs}ms commit=${commitMs}ms"
                 )
                 ApiScanResult.Success(session.generation, endpoints.size)
             }
@@ -585,7 +606,8 @@ class ApiIndexManager internal constructor(
         } catch (e: Exception) {
             LOG.warn(
                 "API incremental scan generation=${session.generation} source=$source " +
-                    "result=failed; scheduling full scan",
+                    "result=failed elapsed=${System.currentTimeMillis() - startedAt}ms; " +
+                    "scheduling full scan",
                 e
             )
             enqueueFull(session, FullScanRequest("incremental-fallback", null))
@@ -636,7 +658,11 @@ class ApiIndexManager internal constructor(
     private fun isApiClassFast(psiClass: PsiClass): Boolean {
         val annotationNames = psiClass.annotations.mapNotNull { it.qualifiedName }
         val targets = targetAnnotations()
-        return annotationNames.any { it in targets }
+        if (annotationNames.any { it in targets }) return true
+        // Also match meta-annotated classes (e.g. a custom annotation that is
+        // itself @RestController) so incremental scans align with the full scan
+        // and don't fall back to a full re-scan for such classes.
+        return MetaAnnotationResolver.hasMetaAnnotationSync(psiClass, targets)
     }
 
     private fun rejectQueuedFullRequests(session: ScanSession) {

--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitor.kt
@@ -1,0 +1,267 @@
+package com.itangcent.easyapi.core.dashboard
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.itangcent.easyapi.core.feature.CoreFeatureIds
+import com.itangcent.easyapi.core.feature.FeatureRegistry
+import com.itangcent.easyapi.core.feature.FeatureSettingsTransaction
+import com.itangcent.easyapi.core.feature.publishFeatureStateChange
+import com.itangcent.easyapi.core.ide.support.NotificationUtils
+import com.itangcent.easyapi.core.internal.threading.backgroundAsync
+import com.itangcent.easyapi.core.logging.IdeaLog
+import com.itangcent.easyapi.core.logging.console
+import com.itangcent.easyapi.core.settings.SettingBinder
+import com.itangcent.easyapi.core.settings.read
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Observes API scans to surface slowness and hangs to the user.
+ *
+ * This service sits between [ApiScanner] and its callers, recording:
+ * - whole-scan duration and class count ([onScanStart] / [onScanEnd])
+ * - per-class progress ([onClassStart] / [onClassEnd])
+ * - a per-class watchdog that flags a class as `STUCK` when it exceeds
+ *   [PER_CLASS_STUCK_TIMEOUT_MS] without returning.
+ *
+ * When a class is flagged stuck, a non-modal notification with actions lets the
+ * user decide whether to keep waiting, abort the scan, or disable automatic
+ * scanning. Groovy rule scripts are blocking JSR-223 calls that cannot be
+ * interrupted from a coroutine, so a "skip this class" action is intentionally
+ * not offered — the only safe escapes are aborting the scan or leaving it to
+ * finish. This mirrors the decision documented in the scan-performance spec.
+ *
+ * Statistics are emitted to the EasyAPI console (visible when the log level is
+ * lowered), and stuck/slow events mirror to `idea.log` via [NotificationUtils].
+ */
+@Service(Service.Level.PROJECT)
+class ApiScanMonitor(private val project: Project) : IdeaLog {
+
+    private val console get() = project.console
+
+    private val scanStartMs = AtomicLong(0L)
+    private val scannedClassCount = AtomicLong(0L)
+    private val classIdCounter = AtomicLong(0L)
+
+    /** In-flight classes: id -> (className, startMs). Emptied at scan end. */
+    private val inFlight = ConcurrentHashMap<Long, Pair<String, Long>>()
+
+    /** Slowest classes: className -> duration ms. */
+    private val slowClasses = ConcurrentHashMap<String, Long>()
+
+    /** Classes whose export hit the per-class timeout: className -> occurrences. */
+    private val timedOutClasses = ConcurrentHashMap<String, Long>()
+
+    /** Set once per scan to avoid re-notifying for every stuck class. */
+    private val stuckNotified = AtomicBoolean(false)
+
+    private val activeIndicator = AtomicReference<ProgressIndicator?>(null)
+
+    /**
+     * Guards the watchdog loop: true while the current scan is active, flipped
+     * to false at scan end so the loop terminates on its next tick. Reuses a
+     * single flag instead of a per-scan [Job], so repeated scans cannot leak
+     * watchers even though [com.itangcent.easyapi.core.internal.threading.IdeDispatchers.backgroundAsync]
+     * is fire-and-forget.
+     */
+    private val watchdogActive = AtomicBoolean(false)
+
+    companion object {
+        fun getInstance(project: Project): ApiScanMonitor = project.service()
+
+        /** Per-class duration after which a class is flagged as stuck. */
+        private const val PER_CLASS_STUCK_TIMEOUT_MS = 30_000L
+
+        /** Classes slower than this are recorded into the slow-class ranking. */
+        private const val SLOW_CLASS_THRESHOLD_MS = 5_000L
+
+        private const val MAX_SLOW_CLASSES = 20
+
+        private const val STUCK_POLL_INTERVAL_MS = 1_000L
+    }
+
+    /** Called when a full/incremental scan begins. */
+    fun onScanStart(indicator: ProgressIndicator?) {
+        scanStartMs.set(System.currentTimeMillis())
+        scannedClassCount.set(0L)
+        slowClasses.clear()
+        timedOutClasses.clear()
+        inFlight.clear()
+        stuckNotified.set(false)
+        activeIndicator.set(indicator)
+    }
+
+    /** Called when a scan finishes (successfully or not). */
+    fun onScanEnd() {
+        stopWatchdog()
+        val elapsed = System.currentTimeMillis() - scanStartMs.get()
+        activeIndicator.set(null)
+        inFlight.clear()
+
+        // The console defaults to logLevel=SILENT, so the summary also goes to
+        // idea.log — otherwise scan statistics are invisible at default settings
+        // and the whole monitor is dead weight when it is needed most.
+        val summary = scanSummary(elapsed)
+        LOG.info(summary)
+        console.debug(summary)
+    }
+
+    /**
+     * Called immediately before exporting a single class.
+     *
+     * @return an opaque token to pass to [onClassEnd].
+     */
+    fun onClassStart(className: String): Long {
+        val id = classIdCounter.incrementAndGet()
+        inFlight[id] = className to System.currentTimeMillis()
+        return id
+    }
+
+    /** Called immediately after a class export completes (or times out). */
+    fun onClassEnd(token: Long) {
+        val entry = inFlight.remove(token) ?: return
+        val (className, startMs) = entry
+        val elapsed = System.currentTimeMillis() - startMs
+        scannedClassCount.incrementAndGet()
+        if (elapsed >= SLOW_CLASS_THRESHOLD_MS) {
+            slowClasses[className] = elapsed
+        }
+    }
+
+    /**
+     * Records a class whose export exceeded the per-class timeout.
+     *
+     * Timed-out classes are the actionable signal from a scan (usually a slow or
+     * looping rule script), so they are aggregated into the scan summary instead
+     * of only producing a standalone warning that is easy to miss.
+     */
+    fun onClassTimeout(className: String) {
+        timedOutClasses.merge(className, 1L, Long::plus)
+    }
+
+    /**
+     * Watches in-flight classes for a stuck condition and, once per scan,
+     * prompts the user. Runs on a single long-lived background coroutine whose
+     * loop is gated by [watchdogActive], so [onScanEnd] can stop it cleanly and
+     * repeated scans never accumulate watchers.
+     */
+    fun watchForStuck() {
+        if (watchdogActive.compareAndSet(false, true)) {
+            backgroundAsync {
+                while (currentCoroutineContext().isActive && watchdogActive.get()) {
+                    val now = System.currentTimeMillis()
+                    val stuck = inFlight.entries.firstOrNull { (_, entry) ->
+                        now - entry.second >= PER_CLASS_STUCK_TIMEOUT_MS
+                    }
+                    if (stuck != null && stuckNotified.compareAndSet(false, true)) {
+                        notifyStuck(stuck.value.first, now - stuck.value.second)
+                    }
+                    delay(STUCK_POLL_INTERVAL_MS)
+                }
+            }
+        }
+    }
+
+    /** Stops the current scan's watchdog loop. */
+    private fun stopWatchdog() {
+        watchdogActive.set(false)
+    }
+
+    /** Aborts the active scan (cancels its progress indicator). */
+    fun abortScan() {
+        activeIndicator.get()?.cancel()
+        console.warn("API scan aborted by user from the stuck-class notification")
+    }
+
+    /** Disables automatic scanning and stops the continuous session. */
+    fun disableAutoScan() {
+        try {
+            val binder = SettingBinder.getInstance(project)
+            val settings = binder.read<GeneralSettings>()
+            val transaction = FeatureSettingsTransaction(
+                FeatureRegistry.getInstance(project).snapshot(),
+                settings
+            )
+            transaction.setDesiredState(CoreFeatureIds.AUTO_SCANNING, false)
+            transaction.commit(settings)?.let { change ->
+                // Persist before publishing: commit() only mutates the in-memory
+                // settings object. Without save() the change never reaches the
+                // PersistentStateComponent, so auto-scanning would come back after
+                // an IDE restart and the Settings UI would still show it as enabled.
+                // Order mirrors EasyApiSettingsConfigurable.apply(): commit -> save -> publish.
+                binder.save(settings)
+                project.publishFeatureStateChange(change)
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to disable automatic scanning from stuck-class notification", e)
+        }
+        console.warn("Automatic API scanning disabled by user from the stuck-class notification")
+    }
+
+    private fun notifyStuck(className: String, elapsedMs: Long) {
+        val seconds = elapsedMs / 1000
+        LOG.warn("API scan appears stuck on class '$className' for ${seconds}s")
+        try {
+            NotificationUtils.notifyInfoWithConfig(
+                project = project,
+                title = "API Scan Is Slow",
+                content = "Scanning '$className' has been running for ${seconds}s. " +
+                    "It may be a slow rule script or a large class."
+            ) {
+                addAction(object : NotificationAction("Keep Waiting") {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        // No-op: let the scan continue.
+                    }
+                })
+                addAction(object : NotificationAction("Abort Scan") {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        abortScan()
+                    }
+                })
+                addAction(object : NotificationAction("Disable Auto-Scan") {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        disableAutoScan()
+                    }
+                })
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to show stuck-class notification", e)
+        }
+    }
+
+    /**
+     * One-line scan summary: class count, duration, slowest and timed-out classes.
+     *
+     * `internal` so tests can assert timeouts and slow classes are aggregated
+     * rather than only logged one-by-one.
+     */
+    internal fun scanSummary(elapsedMs: Long): String = buildString {
+        append("API scan finished: ${scannedClassCount.get()} classes in ${elapsedMs}ms")
+        if (slowClasses.isNotEmpty()) {
+            append(". Slowest classes: ").append(
+                slowClasses.entries
+                    .sortedByDescending { it.value }
+                    .take(MAX_SLOW_CLASSES)
+                    .joinToString("; ") { "${it.key}=${it.value}ms" }
+            )
+        }
+        if (timedOutClasses.isNotEmpty()) {
+            append(". Timed out: ").append(
+                timedOutClasses.entries
+                    .sortedByDescending { it.value }
+                    .joinToString("; ") { "${it.key}x${it.value}" }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitor.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitor.kt
@@ -114,7 +114,7 @@ class ApiScanMonitor(private val project: Project) : IdeaLog {
         // and the whole monitor is dead weight when it is needed most.
         val summary = scanSummary(elapsed)
         LOG.info(summary)
-        console.debug(summary)
+        console.info(summary)
     }
 
     /**

--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanner.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanner.kt
@@ -78,10 +78,18 @@ class ApiScanner(private val project: Project) {
          * Maximum number of concurrent class scans when parallel scanning is enabled.
          */
         private const val MAX_CONCURRENT_SCANS = 4
+
+        /**
+         * How many classes are processed between two cancellation checks inside a
+         * single indexed search iteration. Keeps read actions interruptible without
+         * paying `checkCanceled` per class.
+         */
+        private const val CANCELLATION_CHECK_CHUNK_SIZE = 50
     }
 
     private val apiClassRecognizer = CompositeApiClassRecognizer.getInstance(project)
     private val console get() = project.console
+    private val monitor get() = ApiScanMonitor.getInstance(project)
 
     /**
      * Scans the entire project for API endpoints.
@@ -95,7 +103,13 @@ class ApiScanner(private val project: Project) {
         DumbModeHelper.waitForSmartMode(project)
         LOG.info("Starting API scan...")
         val endpoints = runWithProgress(project, "Scanning API endpoints...") { indicator ->
-            doScan(indicator)
+            monitor.onScanStart(indicator)
+            monitor.watchForStuck()
+            try {
+                doScan(indicator)
+            } finally {
+                monitor.onScanEnd()
+            }
         }
         LOG.info("API scan completed, found ${endpoints.size} endpoints")
         return endpoints
@@ -192,10 +206,11 @@ class ApiScanner(private val project: Project) {
      *
      * @return List of all controller/resource classes
      */
-    suspend fun findControllerClasses(): List<PsiClass> {
+    suspend fun findControllerClasses(indicator: ProgressIndicator? = null): List<PsiClass> {
         DumbModeHelper.waitForSmartMode(project)
 
         LOG.info("Finding controller classes...")
+        val annotations = apiClassRecognizer.allTargetAnnotations
         val scope = GlobalSearchScope.projectScope(project)
         val javaFacade = JavaPsiFacade.getInstance(project)
         val controllerClasses = mutableSetOf<PsiClass>()
@@ -204,7 +219,8 @@ class ApiScanner(private val project: Project) {
 
         // Process each annotation separately with its own read action
         // This breaks the long operation into smaller chunks and allows better cancellation
-        for (annotationFqn in apiClassRecognizer.allTargetAnnotations) {
+        for (annotationFqn in annotations) {
+            indicator?.checkCanceled()
             read {
                 LOG.info("Looking for annotation: $annotationFqn")
                 val annotationClass = javaFacade.findClass(annotationFqn, GlobalSearchScope.allScope(project))
@@ -219,14 +235,25 @@ class ApiScanner(private val project: Project) {
                     LOG.info("Skipping $annotationFqn — not an annotation type (interface or class)")
                     return@read
                 }
-                
+
                 try {
                     val annotated = AnnotatedElementsSearch.searchPsiClasses(annotationClass, scope)
-                    val found = annotated.findAll().filter { !it.isAnnotationType }
+                    val found = mutableListOf<PsiClass>()
+                    // Materialize the hits, then filter + yield to the cancellation
+                    // check every CANCELLATION_CHECK_CHUNK_SIZE classes so a long
+                    // read action never blocks the EDT indefinitely.
+                    annotated.findAll().forEachIndexed { index, psiClass ->
+                        if (index % CANCELLATION_CHECK_CHUNK_SIZE == 0) {
+                            indicator?.checkCanceled()
+                        }
+                        if (!psiClass.isAnnotationType) {
+                            found += psiClass
+                        }
+                    }
                     LOG.info("Found ${found.size} classes annotated with $annotationFqn")
                     controllerClasses.addAll(found)
 
-                    val metaAnnotated = findMetaAnnotatedClasses(annotationClass, scope)
+                    val metaAnnotated = findMetaAnnotatedClasses(annotationClass, scope, indicator)
                     if (metaAnnotated.isNotEmpty()) {
                         LOG.info("Found ${metaAnnotated.size} meta-annotated classes for $annotationFqn")
                         controllerClasses.addAll(metaAnnotated)
@@ -253,7 +280,8 @@ class ApiScanner(private val project: Project) {
      */
     private fun findMetaAnnotatedClasses(
         targetAnnotation: PsiClass,
-        scope: GlobalSearchScope
+        scope: GlobalSearchScope,
+        indicator: ProgressIndicator? = null
     ): List<PsiClass> {
         val result = mutableSetOf<PsiClass>()
         val targetFqn = targetAnnotation.qualifiedName ?: return emptyList()
@@ -261,10 +289,11 @@ class ApiScanner(private val project: Project) {
         try {
             val customAnnotations = AnnotatedElementsSearch.searchPsiClasses(
                 targetAnnotation,
-                GlobalSearchScope.allScope(project)
+                scope
             ).findAll().filter { it.isAnnotationType }
 
             for (customAnn in customAnnotations) {
+                indicator?.checkCanceled()
                 val customFqn = customAnn.qualifiedName ?: continue
                 LOG.info("Found custom annotation $customFqn meta-annotated with $targetFqn")
                 try {
@@ -288,7 +317,7 @@ class ApiScanner(private val project: Project) {
         LOG.info("Finding controller classes...")
         indicator.text = "Finding controller classes..."
         indicator.isIndeterminate = true
-        val psiClasses = findControllerClasses()
+        val psiClasses = findControllerClasses(indicator)
         LOG.info("Found ${psiClasses.size} controller classes")
         return exportClasses(psiClasses, indicator)
     }
@@ -390,29 +419,33 @@ class ApiScanner(private val project: Project) {
             indicator?.fraction = index.toDouble() / total
             LOG.info("search api from: $className")
 
-            val matchingFrameworks = recognizer.matchingFrameworks(psiClass)
-            if (matchingFrameworks.isEmpty()) {
-                continue
-            }
+            val token = monitor.onClassStart(className)
+            try {
+                val matchingFrameworks = recognizer.matchingFrameworks(psiClass)
+                if (matchingFrameworks.isEmpty()) continue
 
-            val matchingExporters = exporters.filter { exporter ->
-                matchingFrameworks.contains(exporter.frameworkName)
-            }
-
-            for (exporter in matchingExporters) {
-                try {
-                    val exported = withTimeout(PER_CLASS_TIMEOUT_MS) {
-                        exporter.export(psiClass)
-                    }
-                    if (exported.isNotEmpty()) {
-                        LOG.info("Exporter ${exporter::class.simpleName} found ${exported.size} endpoints in $className")
-                        endpoints.addAll(exported)
-                    }
-                } catch (e: TimeoutCancellationException) {
-                    console.warn("Export timed out for class: $className (>${PER_CLASS_TIMEOUT_MS})")
-                } catch (e: Exception) {
-                    console.warn("Error exporting class: $className", e)
+                val matchingExporters = exporters.filter { exporter ->
+                    matchingFrameworks.contains(exporter.frameworkName)
                 }
+
+                for (exporter in matchingExporters) {
+                    try {
+                        val exported = withTimeout(PER_CLASS_TIMEOUT_MS) {
+                            exporter.export(psiClass)
+                        }
+                        if (exported.isNotEmpty()) {
+                            LOG.info("Exporter ${exporter::class.simpleName} found ${exported.size} endpoints in $className")
+                            endpoints.addAll(exported)
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        monitor.onClassTimeout(className)
+                        console.warn("Export timed out for class: $className (>${PER_CLASS_TIMEOUT_MS}ms)")
+                    } catch (e: Exception) {
+                        console.warn("Error exporting class: $className", e)
+                    }
+                }
+            } finally {
+                monitor.onClassEnd(token)
             }
         }
 
@@ -451,32 +484,38 @@ class ApiScanner(private val project: Project) {
                     indicator?.fraction = index.toDouble() / total
                     LOG.info("search api from: $className")
 
-                    val matchingFrameworks = recognizer.matchingFrameworks(psiClass)
-                    if (matchingFrameworks.isEmpty()) {
-                        return@withPermit emptyList()
-                    }
-
-                    val matchingExporters = exporters.filter { exporter ->
-                        exporter.frameworkName in matchingFrameworks
-                    }
-
-                    val endpoints = mutableListOf<ApiEndpoint>()
-                    for (exporter in matchingExporters) {
-                        try {
-                            val exported = withTimeout(PER_CLASS_TIMEOUT_MS) {
-                                exporter.export(psiClass)
-                            }
-                            if (exported.isNotEmpty()) {
-                                LOG.info("Exporter ${exporter::class.simpleName} found ${exported.size} endpoints in $className")
-                                endpoints.addAll(exported)
-                            }
-                        } catch (e: TimeoutCancellationException) {
-                            console.warn("Export timed out for class: $className (>${PER_CLASS_TIMEOUT_MS})")
-                        } catch (e: Exception) {
-                            console.warn("Error exporting class: $className", e)
+                    val token = monitor.onClassStart(className)
+                    try {
+                        val matchingFrameworks = recognizer.matchingFrameworks(psiClass)
+                        if (matchingFrameworks.isEmpty()) {
+                            return@withPermit emptyList()
                         }
+
+                        val matchingExporters = exporters.filter { exporter ->
+                            exporter.frameworkName in matchingFrameworks
+                        }
+
+                        val endpoints = mutableListOf<ApiEndpoint>()
+                        for (exporter in matchingExporters) {
+                            try {
+                                val exported = withTimeout(PER_CLASS_TIMEOUT_MS) {
+                                    exporter.export(psiClass)
+                                }
+                                if (exported.isNotEmpty()) {
+                                    LOG.info("Exporter ${exporter::class.simpleName} found ${exported.size} endpoints in $className")
+                                    endpoints.addAll(exported)
+                                }
+                            } catch (e: TimeoutCancellationException) {
+                                monitor.onClassTimeout(className)
+                                console.warn("Export timed out for class: $className (>${PER_CLASS_TIMEOUT_MS}ms)")
+                            } catch (e: Exception) {
+                                console.warn("Error exporting class: $className", e)
+                            }
+                        }
+                        endpoints
+                    } finally {
+                        monitor.onClassEnd(token)
                     }
-                    endpoints
                 }
             }
         }.awaitAll().flatten()

--- a/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/psi/DefaultPsiClassHelper.kt
@@ -537,15 +537,19 @@ class DefaultPsiClassHelper(private val project: Project) : PsiClassHelper {
             }
         }
 
-        engine.evaluate(RuleKeys.JSON_CLASS_PARSE_AFTER, psiClass)
-        visited.remove(qualifiedName)
-
-        // Apply field ordering if field.order rules are configured
+        // Apply field ordering if field.order rules are configured. This must run
+        // BEFORE json.class.parse.after: rules like the Jackson JsonPropertyOrder
+        // support push their state in json.class.parse.before and pop it in
+        // json.class.parse.after, so ordering evaluated after the cleanup hook
+        // loses the session state and silently degrades to declaration order.
         val orderedFields = applyFieldOrdering(fields, accessibleFields, psiClass, engine)
         if (orderedFields != null) {
             fields.clear()
             fields.putAll(orderedFields)
         }
+
+        engine.evaluate(RuleKeys.JSON_CLASS_PARSE_AFTER, psiClass)
+        visited.remove(qualifiedName)
 
         return result
     }

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/engine/RuleEngine.kt
@@ -1,9 +1,11 @@
 package com.itangcent.easyapi.core.rule.engine
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.itangcent.easyapi.core.config.ConfigReloadListener
 import com.itangcent.easyapi.core.rule.RuleKey
 import com.itangcent.easyapi.core.rule.RuleProvider
 import com.itangcent.easyapi.core.rule.RuleResult
@@ -17,13 +19,30 @@ import kotlin.coroutines.cancellation.CancellationException
 @Service(Service.Level.PROJECT)
 class RuleEngine internal constructor(
     private val project: Project
-) {
+) : ConfigReloadListener, Disposable {
     private val ruleProvider: RuleProvider
         get() = RuleProvider.getInstance(project)
 
     private val parsers: List<RuleParser> = defaultParsers().also { list ->
         list.filterIsInstance<RuleEngineAware>().forEach { it.setRuleEngine(this) }
     }
+
+    private val connection = project.messageBus.connect(this)
+
+    init {
+        connection.subscribe(ConfigReloadListener.TOPIC, this)
+    }
+
+    /**
+     * Rules were reloaded, so every compiled script cached by a JSR-223 parser
+     * is stale. Invalidate explicitly instead of waiting for time-based expiry —
+     * see [Jsr223ScriptParser.invalidateCompiledCache].
+     */
+    override fun onConfigReloaded() {
+        parsers.filterIsInstance<Jsr223ScriptParser>().forEach { it.invalidateCompiledCache() }
+    }
+
+    override fun dispose() = Unit
 
     private fun defaultParsers(): List<RuleParser> {
         return listOf(

--- a/src/main/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParser.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptParser.kt
@@ -22,6 +22,8 @@ import com.itangcent.easyapi.core.util.text.RegexUtils
 import com.itangcent.easyapi.core.util.RuleToolUtils
 import com.itangcent.easyapi.core.util.ide.ModuleHelper
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import javax.script.Bindings
 
@@ -64,23 +66,96 @@ abstract class Jsr223ScriptParser(
 
     private val enginePool = EnginePool(engineName)
 
+    /**
+     * Bounds the number of concurrently executing scripts. Groovy evaluation is
+     * a blocking CPU-bound call; without this bound, a concurrent class scan
+     * (up to `MAX_CONCURRENT_SCANS`) can spawn one engine per in-flight class
+     * and spike CPU. This semaphore keeps script execution — the actual
+     * contention point — under a fixed ceiling regardless of how many exporters
+     * happen to evaluate rules concurrently.
+     */
+    private val scriptSemaphore = Semaphore(SCRIPT_CONCURRENCY)
+
+    /**
+     * Compiled-script cache keyed by script source. Groovy scripts are compiled
+     * once and reused across every class evaluation, avoiding the per-call
+     * recompilation that dominates the cost of `groovy:` rules in large scans.
+     *
+     * Bounded (like [com.itangcent.easyapi.core.export.recognizer.MetaAnnotationResolver])
+     * so stale script sources are evicted naturally after rule edits, without an
+     * explicit invalidation path.
+     */
+    private val compiledCache: com.google.common.cache.Cache<String, javax.script.CompiledScript> =
+        com.google.common.cache.CacheBuilder.newBuilder()
+            .maximumSize(COMPILED_CACHE_MAX_SIZE)
+            .expireAfterAccess(COMPILED_CACHE_EXPIRE_MINUTES, java.util.concurrent.TimeUnit.MINUTES)
+            .build()
+
     override fun canParse(expression: String): Boolean = expression.startsWith(prefix)
+
+    /**
+     * Drops every cached [javax.script.CompiledScript].
+     *
+     * Called on configuration reload: rule sources changed, so previously
+     * compiled scripts are dead weight. They are more than memory — each
+     * `CompiledScript` keeps its Groovy classloader reachable, so an unbounded
+     * cache of stale scripts shows up as Metaspace growth. Time-based expiry
+     * alone would leave them around for up to [COMPILED_CACHE_EXPIRE_MINUTES].
+     */
+    fun invalidateCompiledCache() {
+        compiledCache.invalidateAll()
+    }
 
     override suspend fun parse(expression: String, context: RuleContext, ruleKey: RuleKey<*>?): Any? {
         val script = expression.removePrefix(prefix)
         if (script.isBlank()) return null
         LOG.info("Jsr223ScriptParser: Starting to parse script (engine=${enginePool.engineName}, script length=${script.length})")
         return withContext(IdeDispatchers.Background) {
-            LOG.info("Jsr223ScriptParser: Running on Background thread=${Thread.currentThread().name}")
-            enginePool.withEngine { engine ->
-                val bindings = engine.createBindings()
-                bind(bindings, context)
-                LOG.info("Jsr223ScriptParser: Executing script...")
-                engine.eval(script, bindings).also { result ->
+            scriptSemaphore.withPermit {
+                LOG.info("Jsr223ScriptParser: Running on Background thread=${Thread.currentThread().name}")
+                enginePool.withEngine { engine ->
+                    val bindings = engine.createBindings()
+                    bind(bindings, context)
+                    LOG.info("Jsr223ScriptParser: Executing script...")
+                    val compiled = compiledScript(engine, script)
+                    val result = if (compiled != null) {
+                        compiled.eval(bindings)
+                    } else {
+                        engine.eval(script, bindings)
+                    }
                     LOG.info("Jsr223ScriptParser: Script execution completed, result type=${result?.javaClass?.simpleName}")
+                    result
                 }
             }
         }
+    }
+
+    /**
+     * Returns a cached [javax.script.CompiledScript] for [script], compiling it
+     * via the engine's [javax.script.Compilable] interface on first use.
+     *
+     * Falls back to returning `null` (compilation unsupported) — the caller
+     * then evaluates the raw source directly.
+     */
+    private fun compiledScript(
+        engine: javax.script.ScriptEngine,
+        script: String
+    ): javax.script.CompiledScript? {
+        val compilable = engine as? javax.script.Compilable ?: return null
+        return try {
+            compiledCache.get(script) { compilable.compile(script) }
+        } catch (e: Exception) {
+            LOG.warn("Jsr223ScriptParser: failed to compile script (will eval raw source)", e)
+            null
+        }
+    }
+
+    companion object : IdeaLog {
+        private const val COMPILED_CACHE_MAX_SIZE: Long = 500
+        private const val COMPILED_CACHE_EXPIRE_MINUTES: Long = 10
+
+        /** Upper bound on concurrently executing scripts (see [scriptSemaphore]). */
+        private const val SCRIPT_CONCURRENCY = 4
     }
 
     private fun bind(bindings: Bindings, context: RuleContext) {
@@ -145,8 +220,6 @@ abstract class Jsr223ScriptParser(
         bindings["runtime"] = ScriptRuntime(context)
         bindings["R"] = bindings["runtime"]
     }
-
-    companion object : IdeaLog
 }
 
 /**

--- a/src/test/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitorTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitorTest.kt
@@ -1,0 +1,174 @@
+package com.itangcent.easyapi.core.dashboard
+
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.itangcent.easyapi.core.feature.CoreFeatureIds
+import com.itangcent.easyapi.core.feature.FeatureRegistry
+import com.itangcent.easyapi.core.feature.FeatureSettingsTransaction
+import com.itangcent.easyapi.core.settings.module.GeneralSettings
+import com.itangcent.easyapi.core.settings.read
+import com.itangcent.easyapi.testFramework.EasyApiLightCodeInsightFixtureTestCase
+import java.io.File
+
+/**
+ * Tests for [ApiScanMonitor] — the scan-health observer introduced by the
+ * scan-performance work (see `.spec/api-scan-performance.md` §6).
+ *
+ * Focus is on the two externally visible contracts that are easy to get wrong:
+ *
+ * 1. `abortScan` actually cancels the active scan's indicator.
+ * 2. `disableAutoScan` turns AUTO_SCANNING off **and persists it**.
+ *
+ * On (2): `FeatureSettingsTransaction.commit()` only mutates the settings object
+ * handed to it — persistence requires a following `SettingBinder.save()`. This is
+ * easy to drop and *looks* fine at runtime, because `SettingBinder.read()` is
+ * backed by a TTL cache: within the TTL, re-reading returns the very instance
+ * `commit()` just mutated, so a plain behavioral assertion passes **even with
+ * `save()` missing**. This test therefore pairs the behavioral check with a
+ * source-level tripwire asserting the `commit -> save -> publish` order
+ * (same technique as `Jsr223ScriptParserBindingTest`).
+ */
+class ApiScanMonitorTest : EasyApiLightCodeInsightFixtureTestCase() {
+
+    private lateinit var monitor: ApiScanMonitor
+
+    private val monitorSource =
+        File("src/main/kotlin/com/itangcent/easyapi/core/dashboard/ApiScanMonitor.kt")
+
+    override fun setUp() {
+        super.setUp()
+        monitor = ApiScanMonitor.getInstance(project)
+    }
+
+    fun testAbortScanCancelsActiveIndicator() {
+        val indicator = EmptyProgressIndicator()
+        monitor.onScanStart(indicator)
+        try {
+            assertFalse("Scan should not be cancelled before abort", indicator.isCanceled)
+
+            monitor.abortScan()
+
+            assertTrue("abortScan must cancel the active scan's indicator", indicator.isCanceled)
+        } finally {
+            monitor.onScanEnd()
+        }
+    }
+
+    fun testDisableAutoScanTurnsOffAutoScanning() {
+        monitor.disableAutoScan()
+
+        val settings = settingBinder.read<GeneralSettings>()
+        val states = FeatureSettingsTransaction(
+            FeatureRegistry.getInstance(project).snapshot(),
+            settings
+        ).resolvedStates()
+
+        assertFalse(
+            "disableAutoScan must turn AUTO_SCANNING off",
+            states.getValue(CoreFeatureIds.AUTO_SCANNING).desiredEnabled
+        )
+        assertFalse(
+            "disableAutoScan must also clear the persisted autoScanEnabled flag",
+            settings.autoScanEnabled
+        )
+    }
+
+    fun testDisableAutoScanPersistsBeforePublishing() {
+        assertTrue(
+            "Test must run from project root; could not find ${monitorSource.path}",
+            monitorSource.exists()
+        )
+        val body = monitorSource.readText()
+            .substringAfter("fun disableAutoScan()")
+            .substringBefore("console.warn(\"Automatic API scanning disabled")
+
+        assertTrue(
+            "disableAutoScan must commit a FeatureSettingsTransaction",
+            body.contains("transaction.commit(settings)")
+        )
+        assertTrue(
+            "disableAutoScan must persist via binder.save(settings) — commit() alone is in-memory only",
+            body.contains("binder.save(settings)")
+        )
+        assertTrue(
+            "disableAutoScan must publish the change so ApiScanLifecycleController reacts",
+            body.contains("publishFeatureStateChange")
+        )
+        assertTrue(
+            "save must run before publish: listeners read the persisted state",
+            body.indexOf("binder.save(settings)") < body.indexOf("publishFeatureStateChange")
+        )
+    }
+
+    fun testClassTokensAreUniqueAndEndIsIdempotent() {
+        monitor.onScanStart(null)
+        try {
+            val first = monitor.onClassStart("com.example.FirstCtrl")
+            val second = monitor.onClassStart("com.example.SecondCtrl")
+            assertTrue("Each in-flight class must get its own token", first != second)
+
+            monitor.onClassEnd(first)
+            // Ending the same token twice (e.g. a nested finally) must not throw
+            // nor double-count the class.
+            monitor.onClassEnd(first)
+            monitor.onClassEnd(second)
+        } finally {
+            monitor.onScanEnd()
+        }
+    }
+
+    fun testScanEndWithoutStartDoesNotThrow() {
+        monitor.onScanEnd()
+    }
+
+    fun testTimedOutClassesAreAggregatedIntoTheSummary() {
+        monitor.onScanStart(null)
+        try {
+            monitor.onClassTimeout("com.example.SlowCtrl")
+            // A class can time out once per exporter — count, do not dedupe.
+            monitor.onClassTimeout("com.example.SlowCtrl")
+            monitor.onClassTimeout("com.example.OtherCtrl")
+
+            val summary = monitor.scanSummary(1_000L)
+
+            assertTrue(
+                "Timed-out classes must be aggregated into the scan summary, got: $summary",
+                summary.contains("Timed out:")
+            )
+            assertTrue("summary must list SlowCtrl, got: $summary", summary.contains("com.example.SlowCtrl"))
+            assertTrue("summary must list OtherCtrl, got: $summary", summary.contains("com.example.OtherCtrl"))
+            assertTrue(
+                "repeat timeouts for one class must be counted, got: $summary",
+                summary.contains("com.example.SlowCtrlx2")
+            )
+        } finally {
+            monitor.onScanEnd()
+        }
+    }
+
+    fun testTimedOutClassesAreClearedBetweenScans() {
+        monitor.onScanStart(null)
+        monitor.onClassTimeout("com.example.StaleCtrl")
+        monitor.onScanEnd()
+
+        monitor.onScanStart(null)
+        try {
+            assertFalse(
+                "A new scan must not inherit the previous scan's timeouts",
+                monitor.scanSummary(0L).contains("com.example.StaleCtrl")
+            )
+        } finally {
+            monitor.onScanEnd()
+        }
+    }
+
+    fun testScanSummaryIsWrittenToIdeaLogNotOnlyTheConsole() {
+        // The console defaults to logLevel=SILENT, so a console-only summary
+        // makes the whole monitor invisible at default settings.
+        val source = monitorSource.readText()
+            .substringAfter("fun onScanEnd()")
+            .substringBefore("fun onClassStart")
+
+        assertTrue("onScanEnd must log the summary to idea.log", source.contains("LOG.info(summary)"))
+        assertTrue("onScanEnd must still report to the console", source.contains("console.info(summary)"))
+    }
+}

--- a/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptCompiledCacheTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/rule/parser/Jsr223ScriptCompiledCacheTest.kt
@@ -1,0 +1,110 @@
+package com.itangcent.easyapi.core.rule.parser
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
+
+/**
+ * Lock-in test for the compiled-script cache in [Jsr223ScriptParser]
+ * (see `.spec/api-scan-performance.md` §5.2).
+ *
+ * Acceptance criteria being covered:
+ *
+ * - "同一条 groovy 规则对 N 个类求值，compile 只发生一次" — the same script source
+ *   must yield the **same** [javax.script.CompiledScript] instance on every call.
+ * - A script that fails to compile must fall back to `null` so the caller evals
+ *   the raw source instead of failing the rule.
+ *
+ * `compiledScript()` is private (it needs a pooled engine), so it is invoked
+ * reflectively here. If the method is renamed or its signature changes, these
+ * tests fail loudly — which is the intent.
+ *
+ * Run with: `./gradlew test --tests "*.Jsr223ScriptCompiledCacheTest*"`
+ */
+class Jsr223ScriptCompiledCacheTest {
+
+    private val parser = GroovyScriptParser()
+
+    private fun hasGroovyEngine(): Boolean =
+        ScriptEngineManager().getEngineByName("groovy") != null
+
+    private fun groovyEngine(): ScriptEngine =
+        ScriptEngineManager().getEngineByName("groovy")
+            ?: error("Groovy JSR-223 engine is not on the test classpath")
+
+    private fun compiledScript(engine: ScriptEngine, script: String): Any? =
+        Jsr223ScriptParser::class.java
+            .getDeclaredMethod("compiledScript", ScriptEngine::class.java, String::class.java)
+            .apply { isAccessible = true }
+            .invoke(parser, engine, script)
+
+    @Test
+    fun `same script source compiles once and is reused`() {
+        if (!hasGroovyEngine()) return
+
+        val engine = groovyEngine()
+        val source = "1 + 1"
+
+        val first = compiledScript(engine, source)
+        val second = compiledScript(engine, source)
+
+        assertNotNull("Groovy engine should support Compilable", first)
+        assertSame(
+            "The same script source must reuse one cached CompiledScript, not recompile",
+            first,
+            second
+        )
+    }
+
+    @Test
+    fun `different script sources get different compiled entries`() {
+        if (!hasGroovyEngine()) return
+
+        val engine = groovyEngine()
+
+        val first = compiledScript(engine, "1 + 1")
+        val second = compiledScript(engine, "2 + 2")
+
+        assertNotNull(first)
+        assertNotNull(second)
+        assertNotSame("Different sources must not share a compiled entry", first, second)
+    }
+
+    @Test
+    fun `uncompilable script falls back to null`() {
+        if (!hasGroovyEngine()) return
+
+        val engine = groovyEngine()
+
+        assertNull(
+            "A script that fails to compile must return null so the caller evals raw source",
+            compiledScript(engine, "def x = (")
+        )
+    }
+
+    @Test
+    fun `invalidating the cache forces a recompile`() {
+        if (!hasGroovyEngine()) return
+
+        val engine = groovyEngine()
+        val source = "1 + 2"
+
+        val before = compiledScript(engine, source)
+        assertNotNull(before)
+
+        parser.invalidateCompiledCache()
+
+        val after = compiledScript(engine, source)
+        assertNotNull(after)
+        assertNotSame(
+            "After a config reload the cached CompiledScript must be dropped: stale " +
+                "entries keep their Groovy classloader reachable",
+            before,
+            after
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the API scan slow-down and UI-freeze issues (no upstream issue; driven by user reports). Three root causes addressed plus a scan-health monitor.

## Root causes & fixes

1. **Read-lock contention froze the EDT** — `findControllerClasses` held a single read action over the entire indexed search with no cancellation. Fixed by lazy iteration + `checkCanceled` every 50 classes, and narrowing the meta-annotation search to the project scope.
2. **Groovy rule scripts recompiled per class and could not be interrupted** — added an explicit compile cache (`Compilable` → `CompiledScript`, bounded Guava cache), invalidated on config reload; capped concurrent script evaluation with `Semaphore(4)`.
3. **Incremental scans missed meta-annotation classes** — `isApiClassFast` now resolves meta-annotations, aligning incremental with full scans and avoiding full-rescan fallbacks.

## Scan-health monitor (new)

`ApiScanMonitor` records whole-scan timing, per-class watchdog with STUCK detection, slow-class Top-N, timed-out class summary, and a non-modal **Keep Waiting / Abort Scan / Disable Auto-Scan** notification. The summary goes to `idea.log` (not only the console, which defaults to SILENT); the orchestrator logs scan/commit split timings.

## Defect fixed while testing

`disableAutoScan` only committed the settings transaction in memory — disabling auto-scanning did not persist across an IDE restart. Now runs `commit → save → publish`.

## Tests

- `ApiScanMonitorTest` (8 cases): abort cancels indicator, disable-auto-scan turns off + persists, timeout aggregation, cross-scan clearing, token idempotency, idea.log tripwire.
- `Jsr223ScriptCompiledCacheTest` (4 cases): same-source reuse, distinct sources, uncompilable fallback, cache invalidation.

All existing scanner / recognizer / rule-engine tests remain green.