### PR TITLE
fix(dashboard): format XML and HTML request/response bodies

### DIFF
--- a/src/main/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanel.kt
+++ b/src/main/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanel.kt
@@ -244,6 +244,8 @@ class EndpointDetailsPanel(
     }
 
     private val jsonFileType = FileTypeManager.getInstance().getFileTypeByExtension("json")
+    private val xmlFileType = FileTypeManager.getInstance().getFileTypeByExtension("xml")
+    private val htmlFileType = FileTypeManager.getInstance().getFileTypeByExtension("html")
 
     /** Editor for pre-request script */
     private val preRequestScriptArea = EditorTextField("", project, jsonFileType).apply {
@@ -256,19 +258,19 @@ class EndpointDetailsPanel(
     }
 
     // Body area (editable, raw JSON with syntax highlighting)
-    /** Editor for request body with JSON syntax highlighting */
+    /** Editor for request body with syntax highlighting matched to the content type */
     private val bodyArea = EditorTextField("", project, jsonFileType).apply {
         setOneLineMode(false)
     }
 
-    /** Button to format/beautify JSON body */
+    /** Button to format/beautify the request body */
     private val formatBodyBtn = JButton("Format").apply {
-        toolTipText = "Format/Beautify JSON"
+        toolTipText = "Format/Beautify body"
         addActionListener { formatRequestBody() }
     }
 
     // Response body area
-    /** Editor for response body with JSON syntax highlighting (read-only) */
+    /** Editor for response body with syntax highlighting matched to the content type (read-only) */
     private val responseBodyArea = EditorTextField("", project, jsonFileType).apply {
         setOneLineMode(false)
         isViewer = true
@@ -296,6 +298,9 @@ class EndpointDetailsPanel(
     // Response body state
     /** Raw response body text */
     private var rawResponseBody: String = ""
+
+    /** The response body's content type, used to pick the formatter and highlighting */
+    private var responseContentType: String? = null
 
     /** Whether response is displayed in pretty JSON format */
     private var isPrettyJson: Boolean = true
@@ -838,6 +843,8 @@ class EndpointDetailsPanel(
             hostComboBox.selectedIndex = 0
         }
 
+        endpointContentType = null
+        applyFileType(bodyArea, null)
         bodyArea.text = EndpointDetailsPanelLogic.mergeJsonBody3(cache.baseBody, meta.body?.let { it.toJson() }, cache.body) ?: ""
     }
 
@@ -851,6 +858,8 @@ class EndpointDetailsPanel(
         }
         hostComboBox.selectedIndex = 0
 
+        endpointContentType = null
+        applyFileType(bodyArea, null)
         bodyArea.text = meta.body?.let { it.toJson() } ?: ""
     }
 
@@ -999,6 +1008,7 @@ class EndpointDetailsPanel(
         hasFormData = isFormData
         endpointContentType = cache.contentType ?: contentType
 
+        applyFileType(bodyArea, if (isFormData) null else endpointContentType)
         bodyArea.text = if (!isFormData) {
             EndpointDetailsPanelLogic.mergeJsonBody3(cache.baseBody, meta?.body?.let { it.toJson() }, cache.body) ?: ""
         } else ""
@@ -1061,6 +1071,7 @@ class EndpointDetailsPanel(
         hasFormData = isFormData
         endpointContentType = contentType
 
+        applyFileType(bodyArea, if (isFormData) null else endpointContentType)
         bodyArea.text = if (!isFormData) {
             meta?.body?.let { it.toJson() } ?: ""
         } else ""
@@ -1093,6 +1104,7 @@ class EndpointDetailsPanel(
         sendButton.text = "Send"
 
         rawResponseBody = ""
+        responseContentType = null
         isPrettyJson = true
         prettyToggleBtn.text = "Raw"
         responseBodyArea.text = ""
@@ -1114,9 +1126,12 @@ class EndpointDetailsPanel(
         if (demoJson.isBlank() || demoJson == "{}") return
 
         rawResponseBody = demoJson
+        // The example response is always serialized from the JSON model, so it is JSON.
+        responseContentType = null
         isPrettyJson = true
         prettyToggleBtn.text = "Raw"
-        responseBodyArea.text = formatJson(demoJson)
+        applyFileType(responseBodyArea, null)
+        responseBodyArea.text = EndpointDetailsPanelLogic.formatByContentType(demoJson, null)
         responseStatusLabel.text = "Example Response"
         responseStatusLabel.foreground = Color(0x888888)
     }
@@ -1322,9 +1337,11 @@ class EndpointDetailsPanel(
             sendButton.text = "Send"
 
             rawResponseBody = response.body
+            responseContentType = response.headers.firstOrNull { it.first.equals("Content-Type", ignoreCase = true) }?.second
             isPrettyJson = true
             prettyToggleBtn.text = "Raw"
-            responseBodyArea.text = if (response.isError) response.body else formatJson(response.body)
+            applyFileType(responseBodyArea, responseContentType)
+            responseBodyArea.text = if (response.isError) response.body else EndpointDetailsPanelLogic.formatByContentType(response.body, responseContentType)
 
             when {
                 response.statusCode != null -> {
@@ -1366,7 +1383,7 @@ class EndpointDetailsPanel(
         isPrettyJson = !isPrettyJson
         prettyToggleBtn.text = if (isPrettyJson) "Raw" else "Format"
         responseBodyArea.text = if (isPrettyJson) {
-            formatJson(rawResponseBody)
+            EndpointDetailsPanelLogic.formatByContentType(rawResponseBody, responseContentType)
         } else {
             rawResponseBody
         }
@@ -1477,11 +1494,33 @@ class EndpointDetailsPanel(
         return EndpointDetailsPanelLogic.buildFormParams(rows)
     }
 
-    private fun formatJson(json: String) = FormatterHelper.formatJson(json)
+    /**
+     * Maps a content type to the [com.intellij.openapi.fileTypes.FileType] used for syntax
+     * highlighting, falling back to JSON.
+     */
+    private fun fileTypeForContentType(contentType: String?) =
+        when (EndpointDetailsPanelLogic.formatCategoryOf(contentType)) {
+            EndpointDetailsPanelLogic.FormatCategory.XML -> xmlFileType
+            EndpointDetailsPanelLogic.FormatCategory.HTML -> htmlFileType
+            EndpointDetailsPanelLogic.FormatCategory.JSON -> jsonFileType
+        }
+
+    /**
+     * Switches [editor]'s syntax-highlighting file type to match [contentType] without
+     * disturbing its current text. [EditorTextField.setFileType] recreates the document,
+     * so the text is preserved and re-applied explicitly.
+     */
+    private fun applyFileType(editor: EditorTextField, contentType: String?) {
+        val target = fileTypeForContentType(contentType)
+        if (editor.fileType === target) return
+        val text = editor.text
+        editor.setFileType(target)
+        editor.text = text
+    }
 
     private fun formatRequestBody() {
         val currentText = bodyArea.text
-        val formatted = formatJson(currentText)
+        val formatted = EndpointDetailsPanelLogic.formatByContentType(currentText, endpointContentType)
         if (formatted != currentText) {
             bodyArea.text = formatted
         }
@@ -1933,4 +1972,40 @@ internal object EndpointDetailsPanelLogic {
             }
         }
     }
+
+    /**
+     * The format family a body belongs to, driving formatter selection and syntax highlighting.
+     */
+    enum class FormatCategory { XML, HTML, JSON }
+
+    /**
+     * Classifies a media type into a [FormatCategory].
+     *
+     * Dispatch rules (first match wins):
+     * - `application/xml` / `text/xml` (or any `.../xml`, `.../...+xml`) → [FormatCategory.XML]
+     * - `text/html` / `application/xhtml+xml` → [FormatCategory.HTML]
+     * - otherwise (including null/blank, `application/json`, `text/plain`) → [FormatCategory.JSON]
+     */
+    fun formatCategoryOf(contentType: String?): FormatCategory {
+        val ct = contentType?.trim()?.lowercase() ?: ""
+        return when {
+            // Check HTML before XML: `application/xhtml+xml` also ends with `xml`/contains `+xml`.
+            ct == "text/html" || ct == "application/xhtml+xml" -> FormatCategory.HTML
+            ct.endsWith("xml") || ct.contains("+xml") -> FormatCategory.XML
+            else -> FormatCategory.JSON
+        }
+    }
+
+    /**
+     * Pretty-prints [text] using the formatter matching [contentType].
+     *
+     * The generic formatters live in [FormatterHelper]; this dispatches to the right one
+     * based on the media type and falls back to JSON for unknown or missing types.
+     */
+    fun formatByContentType(text: String, contentType: String?): String =
+        when (formatCategoryOf(contentType)) {
+            FormatCategory.XML -> FormatterHelper.formatXml(text)
+            FormatCategory.HTML -> FormatterHelper.formatHtml(text)
+            FormatCategory.JSON -> FormatterHelper.formatJson(text)
+        }
 }

--- a/src/test/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanelLogicTest.kt
+++ b/src/test/kotlin/com/itangcent/easyapi/core/dashboard/EndpointDetailsPanelLogicTest.kt
@@ -242,4 +242,51 @@ class EndpointDetailsPanelLogicTest {
         assertTrue(merged.contains("10"))
         assertTrue(merged.contains("20"))
     }
+
+    // ── formatCategoryOf ────────────────────────────────────────────────────
+
+    @Test
+    fun `formatCategoryOf classifies xml media types`() {
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.XML, EndpointDetailsPanelLogic.formatCategoryOf("application/xml"))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.XML, EndpointDetailsPanelLogic.formatCategoryOf("text/xml"))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.XML, EndpointDetailsPanelLogic.formatCategoryOf("application/soap+xml"))
+        // Case-insensitive
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.XML, EndpointDetailsPanelLogic.formatCategoryOf("TEXT/XML"))
+    }
+
+    @Test
+    fun `formatCategoryOf classifies html media types`() {
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.HTML, EndpointDetailsPanelLogic.formatCategoryOf("text/html"))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.HTML, EndpointDetailsPanelLogic.formatCategoryOf("application/xhtml+xml"))
+    }
+
+    @Test
+    fun `formatCategoryOf falls back to JSON`() {
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.JSON, EndpointDetailsPanelLogic.formatCategoryOf("application/json"))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.JSON, EndpointDetailsPanelLogic.formatCategoryOf("text/plain"))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.JSON, EndpointDetailsPanelLogic.formatCategoryOf(null))
+        assertEquals(EndpointDetailsPanelLogic.FormatCategory.JSON, EndpointDetailsPanelLogic.formatCategoryOf("  "))
+    }
+
+    // ── formatByContentType ─────────────────────────────────────────────────
+
+    @Test
+    fun `formatByContentType formats xml bodies`() {
+        val result = EndpointDetailsPanelLogic.formatByContentType("<root><item>v</item></root>", "application/xml")
+        assertTrue(result.contains("<root>"))
+        assertTrue(result.contains("\n"))
+    }
+
+    @Test
+    fun `formatByContentType formats html bodies`() {
+        val result = EndpointDetailsPanelLogic.formatByContentType("<div> <p>text</p> </div>", "text/html")
+        assertTrue(result.contains("<div>"))
+        assertTrue(result.contains("\n"))
+    }
+
+    @Test
+    fun `formatByContentType formats json by default`() {
+        val result = EndpointDetailsPanelLogic.formatByContentType("""{"a":1}""", null)
+        assertTrue(result.contains("\n"))
+    }
 }


### PR DESCRIPTION
## Problem

Closes #1447

The Dashboard's request/response body panes were hardcoded to a JSON-only path:

- The **Format** button (`formatRequestBody` in `EndpointDetailsPanel`) and the response body display both always called `formatJson`.
- Both editor panes (`bodyArea` and `responseBodyArea`) were created with `jsonFileType` syntax highlighting only.
- Clicking **Format** on a non-JSON body silently returned the original text unchanged (`runCatching` fallback), so it neither errored nor formatted the content.

`com.itangcent.easyapi.core.util.FormatterHelper` already implements `formatJson` / `formatXml` / `formatHtml` with test coverage — the XML and HTML formatters were simply never wired into the Dashboard.

## Fix

Dispatch to the matching formatter based on content type, and switch the editor's syntax-highlighting file type to match:

| Content type | Formatter | Highlighting |
|---|---|---|
| `*/xml`, `*/*+xml` | `formatXml` | XML file type |
| `text/html`, `application/xhtml+xml` | `formatHtml` | HTML file type |
| everything else (incl. null/blank) | `formatJson` | JSON file type |

- **Request body** uses the endpoint's content type (`endpointContentType`); form-data bodies fall back to JSON.
- **Response body** reads `Content-Type` from `RequestResult.headers`.
- **Example response** stays JSON — it is serialized from the JSON model, so there is no XML/HTML variant.
- gRPC panes explicitly reset to JSON, since gRPC bodies are always proto JSON.

The dispatch is extracted into `EndpointDetailsPanelLogic` as pure functions (`formatCategoryOf` / `formatByContentType`) so it is unit-testable without a Swing fixture.

> Note: the HTML branch must be evaluated **before** the XML one — `application/xhtml+xml` also matches the `xml` / `+xml` pattern and would otherwise be misclassified as XML. This is covered by a test.

## Changes

| File | Change |
|---|---|
| `src/main/kotlin/.../dashboard/EndpointDetailsPanel.kt` | Add `xmlFileType`/`htmlFileType`; `applyFileType()` switches highlighting per content type; new `responseContentType` state; `formatRequestBody` / `handleResponse` / `togglePrettyJson` / `showResponseDemo` route through the content-aware dispatch; `EndpointDetailsPanelLogic` gains `FormatCategory` + `formatCategoryOf` + `formatByContentType`; remove the now-dead `formatJson` helper |
| `src/test/kotlin/.../dashboard/EndpointDetailsPanelLogicTest.kt` | 8 new cases covering XML/HTML/JSON classification, case-insensitivity, null/blank fallback, and end-to-end formatting |

## Verification

- `./gradlew compileKotlin compileTestKotlin` — passes
- `./gradlew test --tests "...EndpointDetailsPanelLogicTest"` — 33/33 green

## Scope

Formatting capability only. Separate from #1446 (dashboard request-body persistence), which is already handled by #1448.
