### PR TITLE
chore(scripts): stop daemons on memory pressure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,12 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
-org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+# -Xmx3g hosts the in-process Kotlin compiler; daemons exit after 10 min idle
+# so no JVM stays resident after test/build runs.
+org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+org.gradle.daemon.idletimeout=600000
 org.gradle.workers.max=2
-kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+# Run the Kotlin compiler inside the Gradle daemon — no second resident JVM.
+kotlin.compiler.execution.strategy=in-process
 # Plugin base version (semver, e.g. 3.2.3) — bumped by script/release.sh.
 # Full version is <base>.<since>.<until|0>, e.g. 3.2.3.252.0.
 pluginBaseVersion=3.2.4

--- a/script/_common.sh
+++ b/script/_common.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Shared helper for script/*.sh: stop the Gradle daemons when the machine
+# is under memory pressure. Source it, then register the EXIT trap:
+#   source "$(dirname "$0")/_common.sh"
+#   trap maybe_stop_daemon_on_memory_pressure EXIT
+#
+# Thresholds (percent of physical memory in use): Windows 90, macOS 95;
+# override both with EASYAPI_MEM_PRESSURE_PCT. Linux/CI is left untouched.
+# Best effort — never fails the calling script.
+maybe_stop_daemon_on_memory_pressure() {
+    local os threshold used_pct="" free_pct total free
+    os="$(uname -s 2>/dev/null || true)"
+    case "$os" in
+        MINGW*|MSYS*|CYGWIN*)
+            threshold="${EASYAPI_MEM_PRESSURE_PCT:-90}"
+            if [[ -r /proc/meminfo ]]; then
+                total="$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)"
+                free="$(awk '/^MemFree:/{print $2}' /proc/meminfo 2>/dev/null)"
+                if [[ -n "$total" && -n "$free" && "$total" -gt 0 ]]; then
+                    used_pct=$(( (total - free) * 100 / total ))
+                fi
+            fi
+            if [[ -z "$used_pct" ]]; then
+                used_pct="$(powershell.exe -NoProfile -Command '$os = Get-CimInstance Win32_OperatingSystem; [int](($os.TotalVisibleMemorySize - $os.FreePhysicalMemory) * 100 / $os.TotalVisibleMemorySize)' 2>/dev/null | tr -d '[:space:]' || true)"
+            fi
+            ;;
+        Darwin)
+            threshold="${EASYAPI_MEM_PRESSURE_PCT:-95}"
+            # memory_pressure reports "System-wide memory free percentage: N%"
+            free_pct="$(memory_pressure 2>/dev/null | awk -F': ' '/memory free percentage/ {gsub(/%/, "", $2); print $2}' | tail -1 || true)"
+            [[ -n "$free_pct" ]] && used_pct=$(( 100 - free_pct ))
+            ;;
+        *)
+            return 0 ;;
+    esac
+
+    if [[ -z "$used_pct" || ! "$used_pct" =~ ^[0-9]+$ ]]; then
+        return 0  # probe unavailable — leave the daemon alone
+    fi
+
+    if (( used_pct > threshold )); then
+        echo "Memory pressure: ${used_pct}% in use (threshold ${threshold}%) — stopping Gradle daemons"
+        ./gradlew --stop >/dev/null 2>&1 || true
+    fi
+    return 0
+}

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/_common.sh"
+trap maybe_stop_daemon_on_memory_pressure EXIT
 
-SOURCE="$0"
-while [[ -h "$SOURCE"  ]]; do
-    scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ ${SOURCE} != /*  ]] && SOURCE="$scriptDir/$SOURCE"
-done
-scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-basedir=${scriptDir%/*}
-cd "${basedir}"
+cd "$(dirname "$0")/.." || exit 1
 
 ./gradlew clean build -x test "$@"
 

--- a/script/package.sh
+++ b/script/package.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/_common.sh"
+trap maybe_stop_daemon_on_memory_pressure EXIT
 
-SOURCE="$0"
-while [[ -h "$SOURCE"  ]]; do
-    scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ ${SOURCE} != /*  ]] && SOURCE="$scriptDir/$SOURCE"
-done
-scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-basedir=${scriptDir%/*}
-cd "${basedir}"
+cd "$(dirname "$0")/.." || exit 1
+basedir="$(pwd)"
 
 # Optional first positional argument selects the IDEA compatibility range:
 #   ./script/package.sh              # default: sinceBuild from gradle.properties (252), unbounded

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/_common.sh"
+trap maybe_stop_daemon_on_memory_pressure EXIT
 
 set -e
 
-SCRIPT_SOURCE="$0"
-while [[ -h "$SCRIPT_SOURCE" ]]; do
-    scriptDir="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
-    SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
-    [[ ${SCRIPT_SOURCE} != /* ]] && SCRIPT_SOURCE="$scriptDir/$SCRIPT_SOURCE"
-done
-scriptDir="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
-basedir=${scriptDir%/*}
-cd "${basedir}"
+cd "$(dirname "$0")/.." || exit 1
 
 last_version=$(sed -n 's/^pluginBaseVersion=//p' gradle.properties | head -1 | tr -d '[:space:]')
 echo "Last version: ${last_version}"

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/_common.sh"
+trap maybe_stop_daemon_on_memory_pressure EXIT
 
-SOURCE="$0"
-while [[ -h "$SOURCE"  ]]; do
-    scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ ${SOURCE} != /*  ]] && SOURCE="$scriptDir/$SOURCE"
-done
-scriptDir="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-basedir=${scriptDir%/*}
-cd "${basedir}"
+cd "$(dirname "$0")/.." || exit 1
 
 ./gradlew clean test --stacktrace "$@"
 


### PR DESCRIPTION
## Description

After running `./gradlew test` / `build.sh`, two JVM daemons (Gradle Daemon + Kotlin Compile Daemon, up to ~4 GB combined heap) stayed resident for hours, pinning memory on dev machines. This PR removes the second resident JVM entirely, shortens daemon idle time, and adds a best-effort memory-pressure guard to the shell scripts; the per-script boilerplate is deduplicated into `script/_common.sh`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Test coverage improvement

## Related Issues

<!-- Link to related issues using #issue_number -->

None.

## Affected Area

<!-- Which entry points / capability does this change touch? -->

- [ ] YApi export
- [ ] Postman export
- [ ] Markdown export
- [ ] Send HTTP request (Call)
- [ ] API scanning / dashboard
- [ ] Rule engine / custom rules / config
- [ ] Settings / UI
- [x] Other / not user-facing

## Changes Made

<!-- List the main changes made in this PR -->

- `gradle.properties`: run the Kotlin compiler in-process inside the Gradle daemon (`kotlin.compiler.execution.strategy=in-process`) — no second resident JVM; raise Gradle daemon heap to `-Xmx3g` to host the compiler; daemon exits after 10 min idle (`org.gradle.daemon.idletimeout=600000`)

- `script/_common.sh` (new): shared helper — `maybe_stop_daemon_on_memory_pressure` runs `./gradlew --stop` when physical memory use exceeds a threshold (Windows 90% via `/proc/meminfo` with a PowerShell fallback, macOS 95% via `memory_pressure`; Linux/CI untouched; override with `EASYAPI_MEM_PRESSURE_PCT`); never fails the calling script

- `script/{build,package,release,test}.sh`: source `_common.sh` and register the EXIT trap; the duplicated symlink-resolution `cd` boilerplate collapsed to `cd "$(dirname "$0")/.."`

## How I Tested

<!-- Describe the tests you ran to verify your changes -->

- [ ] `./gradlew test` passes
- [ ] Manual verification in a sandbox IDE (`./gradlew runIde`) — describe the entry action exercised
      (e.g. "Right-click a Spring controller → EasyYapi → ExportMarkdown, checked the generated markdown")
- [ ] New tests added for new functionality

Shell-only change: exercised the scripts locally (`test.sh` / `build.sh`) and observed the daemons stop under memory pressure; no plugin code touched. CI building with the new `gradle.properties` validates the in-process compiler setup.

## Architecture & Threading Checklist

<!-- Mirrors the rules in AGENTS.md — if an item doesn't apply, note why instead of deleting it -->

- [ ] New code lives in the right bucket — N/A: no Kotlin code; change is `script/*.sh` + `gradle.properties`
- [x] PSI/VFS reads wrapped in `read {}` / `readSync {}` — N/A: no PSI/VFS access
- [x] Boundary classes (script contexts handed to Groovy, EP implementations) self-protect every public member — N/A: no boundary classes touched
- [x] PSI writes and UI updates go through `write {}` / `swing {}` — N/A: no PSI/UI code
- [x] No new `launch(Dispatchers.Default)` from EDT / startup contexts — N/A: no coroutines touched

## Logging Checklist

<!-- Mirrors the Logging rules in AGENTS.md -->

- [x] Exactly one channel per event — N/A: shell scripts echo to the terminal; no IDEA logging channels involved
- [x] No `LOG.error`, `LOG.debug`, `LOG.trace`, `println`, or `printStackTrace()` in production code — N/A: no Kotlin/Java code touched
- [x] Throwables passed as the last argument, never stringified into the message; no silent `runCatching{}.getOrNull()` or empty `catch` on meaningful operations — N/A; the memory-pressure probe is explicitly best-effort and documented as never failing the calling script

## General Checklist

- [x] My code follows the project's architecture principles
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — thresholds/env override documented in `_common.sh` header and `gradle.properties` comments
- [x] I have made corresponding changes to the documentation — N/A: no user-facing docs affected
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A: shell scripts; verified manually
- [ ] New and existing unit tests pass locally with my changes — no plugin code touched; CI runs the suite

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

None.

## Additional Notes

<!-- Add any additional notes or context about the PR -->

Intent: after a normal `./gradlew test` run nothing stays resident — the Kotlin compiler lives inside the Gradle daemon and the daemon exits after 10 minutes idle; the scripts' EXIT trap additionally stops daemons when the machine is under memory pressure.
